### PR TITLE
Stop echoing the TOML input file.

### DIFF
--- a/apps/erin.cpp
+++ b/apps/erin.cpp
@@ -74,7 +74,6 @@ runCommand(
     auto nameOnly = std::filesystem::path(tomlFilename).filename();
     auto data = toml::parse(ifs, nameOnly.string());
     ifs.close();
-    std::cout << data << std::endl;
     auto validationInfo = SetupGlobalValidationInfo();
     auto maybeSim = Simulation_ReadFromToml(data, validationInfo);
     if (!maybeSim.has_value())


### PR DESCRIPTION
This is no longer needed. It was originally added as a help for debugging to ensure TOML was parsing correctly but now it is mostly a hindrance to reading ERIN's output.
