### PR TITLE
Update taskfile to run benchmark on Windows

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -53,8 +53,20 @@ tasks:
     desc: Runs benchmarks using hyperfine.
     dir: 'docs/examples/ft-illinois'
     cmds:
-      - hyperfine '../../../build/bin/erin run exft-illinois.toml' --export-markdown ../../../benchmark-{{.ISO_DATE}}-{{.GIT_COMMIT}}.md --export-json ../../../benchmark-{{.ISO_DATE}}-{{.GIT_COMMIT}}.json --export-csv ../../../benchmark-{{.ISO_DATE}}-{{.GIT_COMMIT}}.csv
+      - hyperfine '{{.ERIN}} run exft-illinois.toml' --export-markdown ../../../benchmark-{{.ISO_DATE}}-{{.GIT_COMMIT}}.md --export-json ../../../benchmark-{{.ISO_DATE}}-{{.GIT_COMMIT}}.json --export-csv ../../../benchmark-{{.ISO_DATE}}-{{.GIT_COMMIT}}.csv
     vars:
+      ERIN: "../../../build/bin/erin"
+      GIT_COMMIT:
+        sh: git rev-parse --short HEAD
+      ISO_DATE:
+        sh: date +"%Y-%m-%dT%H%M%S%z"
+  bench-win:
+    desc: Runs benchmarks using hyperfine on Windows.
+    dir: 'docs/examples/ft-illinois'
+    cmds:
+      - hyperfine '{{.ERIN}} run exft-illinois.toml' --export-markdown ..\\..\\..\\benchmark-{{.ISO_DATE}}-{{.GIT_COMMIT}}.md --export-json ..\\..\\..\\benchmark-{{.ISO_DATE}}-{{.GIT_COMMIT}}.json --export-csv ..\\..\\..\\benchmark-{{.ISO_DATE}}-{{.GIT_COMMIT}}.csv
+    vars:
+      ERIN: "..\\..\\..\\build\\bin\\Release\\erin.exe"
       GIT_COMMIT:
         sh: git rev-parse --short HEAD
       ISO_DATE:


### PR DESCRIPTION
## Description

Enable benchmarking on Windows.

There was an issue in the Taskfile syntax that prevented hyperfine from running benchmarks on Windows. This corrects that.