### PR TITLE
Problem: program cannot report out on how it was compiled

### DIFF
--- a/apps/.gitignore
+++ b/apps/.gitignore
@@ -1,0 +1,1 @@
+compilation_settings.h

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -1,12 +1,16 @@
 # Copyright (c) 2024 Big Ladder Software LLC. All rights reserved.
 # See the LICENSE.txt file for additional terms and conditions.
+configure_file(
+	${PROJECT_SOURCE_DIR}/apps/compilation_settings.h.in
+	${PROJECT_SOURCE_DIR}/apps/compilation_settings.h)
+
 add_executable(erin_next_stress_test
 	erin_next_stress_test.cpp)
 target_include_directories(erin_next_stress_test
 	PUBLIC ${PROJECT_SOURCE_DIR}/include)
 target_link_libraries(erin_next_stress_test erin_next)
 
-add_executable(erin erin.cpp)
+add_executable(erin erin.cpp compilation_settings.h.in)
 target_include_directories(erin
 	PUBLIC "${PROJECT_SOURCE_DIR}/include"
 	PRIVATE "${PROJECT_SOURCE_DIR}/vendor/toml11"

--- a/apps/compilation_settings.h.in
+++ b/apps/compilation_settings.h.in
@@ -1,0 +1,10 @@
+/* Copyright (c) 2020-2024 Big Ladder Software LLC. All rights reserved.
+ * See the LICENSE.txt file for additional terms and conditions. */
+
+#ifndef APPS_COMPILATION_SETTINGS_H
+#define APPS_COMPILATION_SETTINGS_H
+
+std::string const build_type =
+	std::string{"@CMAKE_BUILD_TYPE@"};
+
+#endif

--- a/apps/erin.cpp
+++ b/apps/erin.cpp
@@ -20,11 +20,13 @@
 #include "../vendor/CLI11/include/CLI/CLI.hpp"
 #include "toml/exception.hpp"
 #include "toml/get.hpp"
+#include "compilation_settings.h"
 
 int
 versionCommand()
 {
-    std::cout << "Version: " << erin::version::version_string;
+    std::cout << "Version: " << erin::version::version_string << "\n";
+    std::cout << "Build Type: " << build_type << "\n"; 
     return EXIT_SUCCESS;
 }
 

--- a/apps/erin.cpp
+++ b/apps/erin.cpp
@@ -26,7 +26,7 @@ int
 versionCommand()
 {
     std::cout << "Version: " << erin::version::version_string << "\n";
-    std::cout << "Build Type: " << build_type << "\n"; 
+    std::cout << "Build Type: " << build_type << "\n";
     return EXIT_SUCCESS;
 }
 

--- a/include/erin/version.h.in
+++ b/include/erin/version.h.in
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 Big Ladder Software LLC. All rights reserved.
+/* Copyright (c) 2020-2024 Big Ladder Software LLC. All rights reserved.
  * See the LICENSE.txt file for additional terms and conditions. */
 
 #ifndef ERIN_VERSION_H
@@ -10,7 +10,7 @@ namespace erin::version
   constexpr int major_version{@ERIN_VERSION_MAJOR@};
   constexpr int minor_version{@ERIN_VERSION_MINOR@};
   constexpr int release_number{@ERIN_VERSION_PATCH@};
-  const std::string version_string{"@ERIN_VERSION@"};
+  std::string const version_string{"@ERIN_VERSION@"};
 }
 
 #endif

--- a/src/erin_next.cpp
+++ b/src/erin_next.cpp
@@ -110,6 +110,8 @@ namespace erin
             ComponentType compType = m.ComponentMap.CompType[compId];
             size_t idx = m.ComponentMap.Idx[compId];
             std::string const& tag = m.ComponentMap.Tag[compId];
+            size_t nConns = m.Connections.size();
+            ignore(nConns);
             switch (compType)
             {
                 case ComponentType::ConstantEfficiencyConverterType:

--- a/src/erin_next.cpp
+++ b/src/erin_next.cpp
@@ -110,7 +110,6 @@ namespace erin
             ComponentType compType = m.ComponentMap.CompType[compId];
             size_t idx = m.ComponentMap.Idx[compId];
             std::string const& tag = m.ComponentMap.Tag[compId];
-            size_t nConns = m.Connections.size();
             switch (compType)
             {
                 case ComponentType::ConstantEfficiencyConverterType:


### PR DESCRIPTION
# Solution

Add a report out under the `version` subcommand as to the BUILD_TYPE setting that was used during compilation/building.