### PR TITLE
Problem: no user feedback when components declared but do not appear in network

### DIFF
--- a/apps/erin.cpp
+++ b/apps/erin.cpp
@@ -7,6 +7,7 @@
 #include "erin_next/erin_next.h"
 #include "erin_next/erin_next_distribution.h"
 #include "erin_next/erin_next_scenario.h"
+#include "erin_next/erin_next_toml.h"
 #include "erin_next/erin_next_units.h"
 #include "erin_next/erin_next_result.h"
 #include "erin_next/erin_next_validation.h"
@@ -17,6 +18,7 @@
 #include <string>
 #include <filesystem>
 #include <unordered_map>
+#include <unordered_set>
 #include "../vendor/CLI11/include/CLI/CLI.hpp"
 #include "toml/exception.hpp"
 #include "toml/get.hpp"
@@ -81,8 +83,10 @@ runCommand(
 
     using namespace erin;
     auto nameOnly = std::filesystem::path(tomlFilename).filename();
-    auto data = toml::parse(ifs, nameOnly.string());
+    toml::value data = toml::parse(ifs, nameOnly.string());
     ifs.close();
+    std::unordered_set<std::string> componentTagsInUse =
+        TOMLTable_ParseComponentTagsInUse(data);
     auto validationInfo = SetupGlobalValidationInfo();
     auto maybeSim = Simulation_ReadFromToml(data, validationInfo);
     if (!maybeSim.has_value())

--- a/apps/erin.cpp
+++ b/apps/erin.cpp
@@ -88,7 +88,8 @@ runCommand(
     std::unordered_set<std::string> componentTagsInUse =
         TOMLTable_ParseComponentTagsInUse(data);
     auto validationInfo = SetupGlobalValidationInfo();
-    auto maybeSim = Simulation_ReadFromToml(data, validationInfo);
+    auto maybeSim =
+        Simulation_ReadFromToml(data, validationInfo, componentTagsInUse);
     if (!maybeSim.has_value())
     {
         return EXIT_FAILURE;
@@ -123,8 +124,11 @@ graphCommand(
     auto name_only = std::filesystem::path(inputFilename).filename();
     auto data = toml::parse(ifs, name_only.string());
     ifs.close();
+    std::unordered_set<std::string> componentTagsInUse =
+        TOMLTable_ParseComponentTagsInUse(data);
     auto validation_info = SetupGlobalValidationInfo();
-    auto maybe_sim = Simulation_ReadFromToml(data, validation_info);
+    auto maybe_sim =
+        Simulation_ReadFromToml(data, validation_info, componentTagsInUse);
     if (!maybe_sim.has_value())
     {
         return EXIT_FAILURE;
@@ -161,8 +165,11 @@ checkNetworkCommand(std::string tomlFilename)
     auto nameOnly = std::filesystem::path(tomlFilename).filename();
     auto data = toml::parse(ifs, nameOnly.string());
     ifs.close();
+    std::unordered_set<std::string> componentTagsInUse =
+        TOMLTable_ParseComponentTagsInUse(data);
     auto validationInfo = SetupGlobalValidationInfo();
-    auto maybeSim = Simulation_ReadFromToml(data, validationInfo);
+    auto maybeSim =
+        Simulation_ReadFromToml(data, validationInfo, componentTagsInUse);
     if (!maybeSim.has_value())
     {
         return EXIT_FAILURE;

--- a/include/erin_next/erin_next_component.h
+++ b/include/erin_next/erin_next_component.h
@@ -7,6 +7,7 @@
 #include "erin_next/erin_next_result.h"
 #include "../vendor/toml11/toml.hpp"
 #include "erin_next/erin_next_validation.h"
+#include <unordered_set>
 
 namespace erin
 {
@@ -23,7 +24,8 @@ namespace erin
     ParseComponents(
         Simulation& s,
         toml::table const& table,
-        ComponentValidationMap const& compValids
+        ComponentValidationMap const& compValids,
+        std::unordered_set<std::string> const& componentTagsInUse
     );
 
 } // namespace erin

--- a/include/erin_next/erin_next_simulation.h
+++ b/include/erin_next/erin_next_simulation.h
@@ -13,6 +13,7 @@
 #include <vector>
 #include <optional>
 #include <cstdlib>
+#include <unordered_set>
 
 namespace erin
 {
@@ -146,7 +147,8 @@ namespace erin
     Simulation_ParseComponents(
         Simulation& s,
         toml::value const& v,
-        ComponentValidationMap const& compValidations
+        ComponentValidationMap const& compValidations,
+        std::unordered_set<std::string> const& componentTagsInUse
     );
 
     Result
@@ -161,7 +163,8 @@ namespace erin
     std::optional<Simulation>
     Simulation_ReadFromToml(
         toml::value const& v,
-        InputValidationMap const& validationInfo
+        InputValidationMap const& validationInfo,
+        std::unordered_set<std::string> const& componentTagsInUse
     );
 
     void

--- a/include/erin_next/erin_next_toml.h
+++ b/include/erin_next/erin_next_toml.h
@@ -98,6 +98,10 @@ namespace erin
         std::string const& fieldName,
         std::string const& tableName
     );
+
+    std::unordered_set<std::string>
+    TOMLTable_ParseComponentTagsInUse(toml::value const& data);
+
 } // namespace erin
 
 #endif

--- a/src/erin_next_simulation.cpp
+++ b/src/erin_next_simulation.cpp
@@ -16,6 +16,7 @@
 #include <limits>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 #include <map>
 #include <iomanip>
@@ -1120,13 +1121,17 @@ namespace erin
     Simulation_ParseComponents(
         Simulation& s,
         toml::value const& v,
-        ComponentValidationMap const& compValidations
+        ComponentValidationMap const& compValidations,
+        std::unordered_set<std::string> const& componentTagsInUse
     )
     {
         if (v.contains("components") && v.at("components").is_table())
         {
             return ParseComponents(
-                s, v.at("components").as_table(), compValidations
+                s,
+                v.at("components").as_table(),
+                compValidations,
+                componentTagsInUse
             );
         }
         WriteErrorMessage("<top>", "required field 'components' not found");
@@ -1246,7 +1251,8 @@ namespace erin
     std::optional<Simulation>
     Simulation_ReadFromToml(
         toml::value const& v,
-        InputValidationMap const& validationInfo
+        InputValidationMap const& validationInfo,
+        std::unordered_set<std::string> const& componentTagsInUse
     )
     {
         Simulation s = {};
@@ -1269,7 +1275,9 @@ namespace erin
             WriteErrorMessage("loads", "problem parsing...");
             return {};
         }
-        auto compResult = Simulation_ParseComponents(s, v, validationInfo.Comp);
+        auto compResult = Simulation_ParseComponents(
+            s, v, validationInfo.Comp, componentTagsInUse
+        );
         if (compResult == Result::Failure)
         {
             WriteErrorMessage("components", "problem parsing...");

--- a/src/erin_next_toml.cpp
+++ b/src/erin_next_toml.cpp
@@ -896,4 +896,60 @@ namespace erin
         return result;
     }
 
+    std::unordered_set<std::string>
+    TOMLTable_ParseComponentTagsInUse(toml::value const& data)
+    {
+        std::unordered_set<std::string> tagsInUse;
+        if (!data.is_table())
+        {
+            return tagsInUse;
+        }
+        toml::table const& table = data.as_table();
+        if (!table.contains("network"))
+        {
+            return tagsInUse;
+        }
+        toml::value const& network = table.at("network");
+        if (!network.is_table())
+        {
+            return tagsInUse;
+        }
+        toml::table const& networkTable = network.as_table();
+        if (!networkTable.contains("connections"))
+        {
+            return tagsInUse;
+        }
+        toml::value const& conns = networkTable.at("connections");
+        if (!conns.is_array())
+        {
+            return tagsInUse;
+        }
+        std::vector<toml::value> const& connsArray = conns.as_array();
+        for (toml::value const& item : connsArray)
+        {
+            if (!item.is_array())
+            {
+                return tagsInUse;
+            }
+            std::vector<toml::value> const& itemArray = item.as_array();
+            // NOTE: array should be 3+ in size but we'll only access
+            // the first two items.
+            if (itemArray.size() < 2)
+            {
+                return tagsInUse;
+            }
+            if (!itemArray[0].is_string() || !itemArray[1].is_string())
+            {
+                return tagsInUse;
+            }
+            std::string const& first = itemArray[0].as_string();
+            std::string const& second = itemArray[1].as_string();
+            std::string tag1 = first.substr(0, first.find(":"));
+            std::string tag2 = second.substr(0, second.find(":"));
+            tagsInUse.emplace(tag1);
+            tagsInUse.emplace(tag2);
+        }
+        return tagsInUse;
+    }
+
 } // namespace erin

--- a/test/erin_tests.cpp
+++ b/test/erin_tests.cpp
@@ -1876,9 +1876,7 @@ TEST(Erin, TestParsingComponentsInUse)
             connTable,
         },
     };
-    std::unordered_set<std::string> expected{
-        "a", "b", "c", "d"
-    };
+    std::unordered_set<std::string> expected{"a", "b", "c", "d"};
     std::unordered_set<std::string> actual =
         erin::TOMLTable_ParseComponentTagsInUse(exampleInput);
     EXPECT_EQ(expected.size(), actual.size());


### PR DESCRIPTION
## Problem (cont)

Furthermore, issues can occur in the way ERIN is currently architected if a component is read in but doesn't appear in the network.

## Solution

Read in a set of all tags (i.e., component names) that appear in the network.connections array and use that to determine whether or not to load a component declaration. If a component is declared but doesn't appear in the network, its loading is still skipped but we now also issue a warning message.