### PR TITLE
Problem: benchmarks don't always yield good statistics for the first run

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -53,7 +53,7 @@ tasks:
     desc: Runs benchmarks using hyperfine.
     dir: 'docs/examples/ft-illinois'
     cmds:
-      - hyperfine '{{.ERIN}} run exft-illinois.toml' --export-markdown ../../../benchmark-{{.ISO_DATE}}-{{.GIT_COMMIT}}.md --export-json ../../../benchmark-{{.ISO_DATE}}-{{.GIT_COMMIT}}.json --export-csv ../../../benchmark-{{.ISO_DATE}}-{{.GIT_COMMIT}}.csv
+      - hyperfine --warmup 2 '{{.ERIN}} run exft-illinois.toml' --export-markdown ../../../benchmark-{{.ISO_DATE}}-{{.GIT_COMMIT}}.md --export-json ../../../benchmark-{{.ISO_DATE}}-{{.GIT_COMMIT}}.json --export-csv ../../../benchmark-{{.ISO_DATE}}-{{.GIT_COMMIT}}.csv
     vars:
       ERIN: "../../../build/bin/erin"
       GIT_COMMIT:
@@ -64,7 +64,7 @@ tasks:
     desc: Runs benchmarks using hyperfine on Windows.
     dir: 'docs/examples/ft-illinois'
     cmds:
-      - hyperfine '{{.ERIN}} run exft-illinois.toml' --export-markdown ..\\..\\..\\benchmark-{{.ISO_DATE}}-{{.GIT_COMMIT}}.md --export-json ..\\..\\..\\benchmark-{{.ISO_DATE}}-{{.GIT_COMMIT}}.json --export-csv ..\\..\\..\\benchmark-{{.ISO_DATE}}-{{.GIT_COMMIT}}.csv
+      - hyperfine --warmup 2 '{{.ERIN}} run exft-illinois.toml' --export-markdown ..\\..\\..\\benchmark-{{.ISO_DATE}}-{{.GIT_COMMIT}}.md --export-json ..\\..\\..\\benchmark-{{.ISO_DATE}}-{{.GIT_COMMIT}}.json --export-csv ..\\..\\..\\benchmark-{{.ISO_DATE}}-{{.GIT_COMMIT}}.csv
     vars:
       ERIN: "..\\..\\..\\build\\bin\\Release\\erin.exe"
       GIT_COMMIT:


### PR DESCRIPTION
## Solution

The [hyperfine](https://github.com/sharkdp/hyperfine) tool we are using comes with a "warmup" option:

> For programs that perform a lot of disk I/O, the benchmarking results can be heavily influenced by disk caches and whether they are cold or warm.

Using the warmup option, helps us to have consistent times that use warm disk caches.