### PR TITLE
Redefine edge cases for EA and ER

### DIFF
--- a/src/erin_next_simulation.cpp
+++ b/src/erin_next_simulation.cpp
@@ -2260,9 +2260,9 @@ namespace erin
                 : 0.0;
             double ER = os.OutflowRequest_kJ > 0.0
                 ? (os.OutflowAchieved_kJ / os.OutflowRequest_kJ)
-                : 0.0;
+                : 1.0;
             double EA =
-                os.Duration_s > 0.0 ? (os.Uptime_s / os.Duration_s) : 0.0;
+                os.Duration_s > 0.0 ? (os.Uptime_s / os.Duration_s) : 1.0;
             stats << s.ScenarioMap.Tags[os.Id];
             stats << "," << os.OccurrenceNumber;
             stats << "," << (os.Duration_s / seconds_per_hour);


### PR DESCRIPTION
When there is no flow request, we now
redefine ER to be 1.0 (as the limit
approaching 0.0/0.0). Similarly, EA
is set to 1.0 if duration is 0 s.