### PR TITLE
Problem: benchmarking files were dumping into the top-level directory

### DIFF
--- a/src/erin_next_simulation.cpp
+++ b/src/erin_next_simulation.cpp
@@ -2260,9 +2260,9 @@ namespace erin
                 : 0.0;
             double ER = os.OutflowRequest_kJ > 0.0
                 ? (os.OutflowAchieved_kJ / os.OutflowRequest_kJ)
-                : 0.0;
+                : 1.0;
             double EA =
-                os.Duration_s > 0.0 ? (os.Uptime_s / os.Duration_s) : 0.0;
+                os.Duration_s > 0.0 ? (os.Uptime_s / os.Duration_s) : 1.0;
             stats << s.ScenarioMap.Tags[os.Id];
             stats << "," << os.OccurrenceNumber;
             stats << "," << (os.Duration_s / seconds_per_hour);


### PR DESCRIPTION
## Further Issues

Also, the data written was free-form and difficult to parse.

## Solution

Write to an ignored `benchmark/` directory and write data in a pseudo-JSON format. That is, each line is a valid JSON object but we ignore writing a starting `[` and ending `]` so we can always append to the file. (A reader would merely need to read and split by lines and parse each JSON object -- OR just append the `[` and `]` to the string and call JSON.parse).