### PR TITLE
Problem: Regression testing is not running on CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -44,3 +44,4 @@ jobs:
       - name: Run Regression Testing
         run: python regress.py
         working-directory: docs/examples
+        if: ${{ matrix.os }} == "windows-latest"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -42,9 +42,6 @@ jobs:
       - name: Configure CMake (Ubuntu)
         run: cmake -S . -B build -DCMAKE_BUILD_TYPE="${{ matrix.config }}" -DERIN_TESTING="ON"
         if: ${{ matrix.os == 'ubuntu-latest' }}
-        env:
-          CC: clang
-          CXX: clang++
       - name: Build
         run: cmake --build build --config ${{ matrix.config }}
       - name: Test

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -37,7 +37,7 @@ jobs:
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
           sudo apt-get update
-          sudo apt-get -y install clang-14
+          sudo apt-get -y install clang-17
       - name: Echo clang versions on Ubuntu
         run: |
           clang --version
@@ -45,10 +45,10 @@ jobs:
         if: ${{ matrix.os == 'ubuntu-latest' }}
       - name: Configure CMake (Ubuntu)
         if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: cmake -S . -B build -DCMAKE_BUILD_TYPE="${{ matrix.config }}"
+        run: cmake -S . -B build -DCMAKE_BUILD_TYPE="${{ matrix.config }}" -DERIN_TESTING="ON"
         env:
-          CC: clang-14
-          CXX: clang++-14
+          CC: clang-17
+          CXX: clang++-17
       - name: Build
         run: cmake --build build --config ${{ matrix.config }}
       - name: Test

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -43,9 +43,9 @@ jobs:
         run: |
           clang --version
           clang++ --version
-        if: ${{ matrix.is == 'ubuntu-latest' }}
+        if: ${{ matrix.os == 'ubuntu-latest' }}
       - name: Configure CMake (Ubuntu)
-        run: cmake -S . -B build -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILIER=clang++ -DCMAKE_BUILD_TYPE="${{ matrix.config }}" -DERIN_TESTING="ON"
+        run: CC=clang CXX=clang++ cmake -S . -B build -DCMAKE_BUILD_TYPE="${{ matrix.config }}" -DERIN_TESTING="ON"
         if: ${{ matrix.os == 'ubuntu-latest' }}
       - name: Build
         run: cmake --build build --config ${{ matrix.config }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -37,3 +37,10 @@ jobs:
       - name: Test
         run: ctest -C ${{ matrix.config }} --output-on-failure
         working-directory: build
+      - name: Install Python 3
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+      - name: Run Regression Testing
+        run: python regress.py
+        working-directory: docs/examples

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -38,12 +38,13 @@ jobs:
         uses: KyleMayes/install-llvm-action@v2
         with:
           version: "14"
+          env: true
       - name: Configure CMake (Ubuntu)
         run: cmake -S . -B build -DCMAKE_BUILD_TYPE="${{ matrix.config }}" -DERIN_TESTING="ON"
         if: ${{ matrix.os == 'ubuntu-latest' }}
         env:
-          CC: clang-14
-          CXX: clang++-14
+          CC: clang
+          CXX: clang++
       - name: Build
         run: cmake --build build --config ${{ matrix.config }}
       - name: Test

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -39,8 +39,13 @@ jobs:
         with:
           version: 14
           env: 1
+      - name: Echo clang versions on Ubuntu
+        run: |
+          clang --version
+          clang++ --version
+        if: ${{ matrix.is == 'ubuntu-latest' }}
       - name: Configure CMake (Ubuntu)
-        run: cmake -S . -B build -DCMAKE_BUILD_TYPE="${{ matrix.config }}" -DERIN_TESTING="ON"
+        run: cmake -S . -B build -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILIER=clang++ -DCMAKE_BUILD_TYPE="${{ matrix.config }}" -DERIN_TESTING="ON"
         if: ${{ matrix.os == 'ubuntu-latest' }}
       - name: Build
         run: cmake --build build --config ${{ matrix.config }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -37,8 +37,8 @@ jobs:
         if: ${{ matrix.os == 'ubuntu-latest' }}
         uses: KyleMayes/install-llvm-action@v2
         with:
-          version: "14"
-          env: true
+          version: 14
+          env: 1
       - name: Configure CMake (Ubuntu)
         run: cmake -S . -B build -DCMAKE_BUILD_TYPE="${{ matrix.config }}" -DERIN_TESTING="ON"
         if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -44,4 +44,4 @@ jobs:
       - name: Run Regression Testing
         run: python regress.py
         working-directory: docs/examples
-        if: ${{ matrix.os }} == "windows-latest"
+        if: ${{ matrix.os == 'windows-latest' }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -32,23 +32,6 @@ jobs:
         run: cmake -E make_directory ${{github.workspace}}/build
       - name: Configure CMake (non-Ubuntu)
         run: cmake -S . -B build -DCMAKE_BUILD_TYPE="${{ matrix.config }}" -DERIN_TESTING="ON"
-        if: ${{ matrix.os != 'ubuntu-latest' }}
-      - name: Install LLVM and Clang
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: |
-          sudo apt-get update
-          sudo apt-get -y install clang-17
-      - name: Echo clang versions on Ubuntu
-        run: |
-          clang --version
-          clang++ --version
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-      - name: Configure CMake (Ubuntu)
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: cmake -S . -B build -DCMAKE_BUILD_TYPE="${{ matrix.config }}" -DERIN_TESTING="ON"
-        env:
-          CC: clang-17
-          CXX: clang++-17
       - name: Build
         run: cmake --build build --config ${{ matrix.config }}
       - name: Test

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -35,18 +35,20 @@ jobs:
         if: ${{ matrix.os != 'ubuntu-latest' }}
       - name: Install LLVM and Clang
         if: ${{ matrix.os == 'ubuntu-latest' }}
-        uses: KyleMayes/install-llvm-action@v2
-        with:
-          version: 14
-          env: 1
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install clang-14
       - name: Echo clang versions on Ubuntu
         run: |
           clang --version
           clang++ --version
         if: ${{ matrix.os == 'ubuntu-latest' }}
       - name: Configure CMake (Ubuntu)
-        run: CC=clang CXX=clang++ cmake -S . -B build -DCMAKE_BUILD_TYPE="${{ matrix.config }}" -DERIN_TESTING="ON"
         if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: cmake -S . -B build -DCMAKE_BUILD_TYPE="${{ matrix.config }}"
+        env:
+          CC: clang-14
+          CXX: clang++-14
       - name: Build
         run: cmake --build build --config ${{ matrix.config }}
       - name: Test

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -37,8 +37,8 @@ jobs:
         run: cmake -S . -B build -DCMAKE_BUILD_TYPE="${{ matrix.config }}" -DERIN_TESTING="ON"
         if: ${{ matrix.os == 'ubuntu-latest' }}
         env:
-          CC: which clang
-          CXX: which clang++
+          CC: clang
+          CXX: clang++
       - name: Build
         run: cmake --build build --config ${{ matrix.config }}
       - name: Test

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -30,8 +30,15 @@ jobs:
         run: echo "REPOSITORY_NAME=$(echo '${{ github.repository }}' | awk -F '/' '{print $2}')" >> $GITHUB_ENV
       - name: Create Build Directory
         run: cmake -E make_directory ${{github.workspace}}/build
-      - name: Configure CMake
+      - name: Configure CMake (non-Ubuntu)
         run: cmake -S . -B build -DCMAKE_BUILD_TYPE="${{ matrix.config }}" -DERIN_TESTING="ON"
+        if: ${{ matrix.os != 'ubuntu-latest' }}
+      - name: Configure CMake (Ubuntu)
+        run: cmake -S . -B build -DCMAKE_BUILD_TYPE="${{ matrix.config }}" -DERIN_TESTING="ON"
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        env:
+          CC: which clang
+          CXX: which clang++
       - name: Build
         run: cmake --build build --config ${{ matrix.config }}
       - name: Test

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -33,12 +33,17 @@ jobs:
       - name: Configure CMake (non-Ubuntu)
         run: cmake -S . -B build -DCMAKE_BUILD_TYPE="${{ matrix.config }}" -DERIN_TESTING="ON"
         if: ${{ matrix.os != 'ubuntu-latest' }}
+      - name: Install LLVM and Clang
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        uses: KyleMayes/install-llvm-action@v2
+        with:
+          version: "14"
       - name: Configure CMake (Ubuntu)
         run: cmake -S . -B build -DCMAKE_BUILD_TYPE="${{ matrix.config }}" -DERIN_TESTING="ON"
         if: ${{ matrix.os == 'ubuntu-latest' }}
         env:
-          CC: clang
-          CXX: clang++
+          CC: clang-14
+          CXX: clang++-14
       - name: Build
         run: cmake --build build --config ${{ matrix.config }}
       - name: Test

--- a/README.md
+++ b/README.md
@@ -36,6 +36,23 @@ This project uses [Clang Format](https://clang.llvm.org/docs/ClangFormat.html).
 Once installed, formatting is facilitated by using task: `task format`.
 This makes the formatting step explicit.
 
+Note: we have added a Dockerfile to enable developers to run clang format within Docker.
+
+To run clang-format from Docker, do the following:
+
+
+0. Install Taskfile if you haven't already
+1. Install Docker Desktop
+2. Start Docker Desktop
+3. Run task docker-format
+
+NOTE: if you prefer to not use taskfile, you can run the commands manually.
+First, start Docker Desktop.
+Next, open the Taskfile which is a plain text file written in YAML format.
+Copy and run the docker-build task's command in your shell at the repo top directory.
+When those commands have completed, run docker-format tasks's command.
+
+
 ## Running Tests
 
 Task contains a convenient test task.

--- a/apps/erin.cpp
+++ b/apps/erin.cpp
@@ -36,6 +36,12 @@ int
 limitsCommand()
 {
     std::cout << "Limits: " << std::endl;
+    std::cout << "- value of max_flow_W: " << erin::max_flow_W << std::endl;
+    std::cout << "- max_flow_W ==     9223372036854776: "
+              << (erin::max_flow_W == 9'223'372'036'854'776ULL) << std::endl;
+    std::cout << "- max_flow_W == 18446744073709551615: "
+              << (erin::max_flow_W == 18'446'744'073'709'551'615ULL)
+              << std::endl;
     std::cout << "- sizeof(uint64_t): " << (sizeof(uint64_t)) << std::endl;
     std::cout << "- std::numeric_limits<uint64_t>::max(): "
               << std::numeric_limits<uint64_t>::max() << std::endl;

--- a/docs/examples/regress.py
+++ b/docs/examples/regress.py
@@ -106,11 +106,14 @@ def smoke_test(example_name, dir=None, timeit=False, print_it=False):
     
     in_name = f"ex{example_name}.toml"
     start_time = time.perf_counter_ns()
-    result = subprocess.run([CLI_EXE, "run", f"{in_name}", "-e", f"{out_name}", "-s", f"{stats_name}"], capture_output=True, cwd=cwd)
+    cmd = [CLI_EXE, "run", in_name, "-e", out_name, "-s", stats_name]
+    result = subprocess.run(cmd, capture_output=True, cwd=cwd)
     end_time = time.perf_counter_ns()
     time_ns = end_time - start_time
     if result.returncode != 0:
         print(f"Error running CLI for example {example_name}")
+        print("Command: " + " ".join(cmd))
+        print(f"CLI_EXE.exist(): {Path(CLI_EXE).exists()}")
         print("stdout:\n")
         print(result.stdout.decode())
         print("stderr:\n")

--- a/docs/examples/regress.py
+++ b/docs/examples/regress.py
@@ -112,7 +112,7 @@ def smoke_test(example_name, dir=None, timeit=False, print_it=False):
     time_ns = end_time - start_time
     if result.returncode != 0:
         print(f"Error running CLI for example {example_name}")
-        print("Command: " + " ".join(cmd))
+        print("Command: " + (" ".join(cmd)))
         print(f"CLI_EXE.exist(): {Path(CLI_EXE).exists()}")
         print("stdout:\n")
         print(result.stdout.decode())

--- a/docs/examples/regress.py
+++ b/docs/examples/regress.py
@@ -114,6 +114,7 @@ def smoke_test(example_name, dir=None, timeit=False, print_it=False):
         print(f"Error running CLI for example {example_name}")
         print("Command: " + (" ".join(cmd)))
         print(f"CLI_EXE.exist(): {Path(CLI_EXE).exists()}")
+        print(f"{in_name}.exists(): {Path(in_name).exists()}")
         print("stdout:\n")
         print(result.stdout.decode())
         print("stderr:\n")

--- a/docs/examples/regress.py
+++ b/docs/examples/regress.py
@@ -112,7 +112,7 @@ def smoke_test(example_name, dir=None, timeit=False, print_it=False):
     time_ns = end_time - start_time
     if result.returncode != 0:
         print(f"Error running CLI for example {example_name}")
-        print("Command: " + (" ".join(cmd)))
+        print("Command: " + (" ".join([str(c) for c in cmd])))
         print(f"CLI_EXE.exist(): {Path(CLI_EXE).exists()}")
         print(f"{in_name}.exists(): {Path(in_name).exists()}")
         print("stdout:\n")

--- a/docs/examples/regress.py
+++ b/docs/examples/regress.py
@@ -60,6 +60,18 @@ if not CLI_EXE.exists():
     sys.exit(1)
 
 
+def run_limits():
+    """
+    Calls ERIN limits   
+    """
+    result = subprocess.run([CLI_EXE, "limits"], capture_output=True)
+    if result.returncode != 0:
+        print("ERIN limits did not return a non-zero exit code")
+        sys.exit(1)
+    else:
+        print(result.stdout.decode(), flush=True)
+
+
 def run_tests():
     """
     Run the test suite
@@ -70,7 +82,7 @@ def run_tests():
             stem = Path(test).stem
             print(f"Test '{stem}' did not pass!")
             print("stdout:\n")
-            print(result.stderr.decode())
+            print(result.stdout.decode())
             print("stdout:\n")
             print(result.stderr.decode())
             sys.exit(1)
@@ -261,6 +273,7 @@ def run_perf():
 
 
 if __name__ == "__main__":
+    run_limits()
     run_tests()
     print("Passed all unit tests!")
     run_cli("01")

--- a/docs/examples/regress.py
+++ b/docs/examples/regress.py
@@ -23,6 +23,7 @@ if platform.system() == 'Windows':
     if not BIN_DIR.exists():
         print("Could not find build directory!")
         sys.exit(1)
+    BIN_DIR = BIN_DIR.resolve()
     TEST_EXE = BIN_DIR / 'erin_tests.exe'
     RAND_TEST_EXE = BIN_DIR / 'erin_next_random_tests.exe'
     LOOKUP_TABLE_TEST_EXE = BIN_DIR / 'erin_lookup_table_tests.exe'
@@ -31,6 +32,7 @@ if platform.system() == 'Windows':
 elif platform.system() == 'Darwin' or platform.system() == 'Linux':
     DIFF_PROG = 'diff'
     BIN_DIR = (Path('.') / '..' / '..' / 'build' / 'bin').absolute()
+    BIN_DIR = BIN_DIR.resolve()
     TEST_EXE = BIN_DIR / 'erin_tests'
     RAND_TEST_EXE = BIN_DIR / 'erin_next_random_tests'
     LOOKUP_TABLE_TEST_EXE = BIN_DIR / 'erin_lookup_table_tests'

--- a/src/erin_next.cpp
+++ b/src/erin_next.cpp
@@ -3284,7 +3284,7 @@ namespace erin
                         sumOfFlowsByCompId[fromId] -= flow;
                         sumOfFlowsByCompId[toId] += flow;
                     }
-                    for (auto const item : sumOfFlowsByCompId)
+                    for (auto const& item : sumOfFlowsByCompId)
                     {
                         size_t const& compId = item.first;
                         ComponentType ctype =

--- a/src/erin_next.cpp
+++ b/src/erin_next.cpp
@@ -4053,6 +4053,12 @@ namespace erin
         size_t idx = m.ConstEffConvs.size();
         ConstantEfficiencyConverter cec{
             .Efficiency = efficiency,
+            .InflowConn = 0,
+            .OutflowConn = 0,
+            .LossflowConn = {},
+            .WasteflowConn = 0,
+            .MaxOutflow_W = max_flow_W,
+            .MaxLossflow_W = max_flow_W,
         };
         m.ConstEffConvs.push_back(std::move(cec));
         size_t wasteId = Component_AddComponentReturningId(

--- a/src/erin_next_simulation.cpp
+++ b/src/erin_next_simulation.cpp
@@ -1668,8 +1668,10 @@ namespace erin
         if (value_W == max_flow_W)
         {
             std::cout << "Found infinity:" << std::endl;
-            std::cout << "- value_W   : " << fmt::format("{}", value_W) << std::endl;
-            std::cout << "- max_flow_W: " << fmt::format("{}", max_flow_W) << std::endl;
+            std::cout << "- value_W   : " << fmt::format("{}", value_W)
+                      << std::endl;
+            std::cout << "- max_flow_W: " << fmt::format("{}", max_flow_W)
+                      << std::endl;
             return "inf";
         }
         double value_kW = value_W / W_per_kW;

--- a/src/erin_next_simulation.cpp
+++ b/src/erin_next_simulation.cpp
@@ -1667,6 +1667,9 @@ namespace erin
     {
         if (value_W == max_flow_W)
         {
+            std::cout << "Found infinity:" << std::endl;
+            std::cout << "- value_W   : " << fmt::format("{}", value_W) << std::endl;
+            std::cout << "- max_flow_W: " << fmt::format("{}", max_flow_W) << std::endl;
             return "inf";
         }
         double value_kW = value_W / W_per_kW;


### PR DESCRIPTION
## Description of the Problem this PR will Solve

Fixes #7 and fixes #5 .

We haven't had the regression tests running in our CI which makes it easier for regressions to get through on PRs. This fix enables `docs/examples/regress.py` to run to exercise the tests, run regressions, and also to run simple benchmarking.
