### PR TITLE
Allow reporting with uniform time step

### DIFF
--- a/apps/erin.cpp
+++ b/apps/erin.cpp
@@ -68,10 +68,14 @@ runCommand(
     std::string const& tomlFilename,
     std::string const& eventsFilename,
     std::string const& statsFilename,
-    std::pair<bool, double> const& custom_cadence,
+    double cadence,
     bool verbose
 )
 {
+
+    std::pair<bool, double> custom_cadence = {false, cadence};
+    custom_cadence.first = (custom_cadence.second > 0.);
+
     if (verbose)
     {
         std::cout << "input file: " << tomlFilename << std::endl;
@@ -472,9 +476,8 @@ main(int argc, char** argv)
             "Statistics csv filename; default:stats.csv"
         );
 
-        std::pair<bool, double> custom_cadence = {false, -1.};
-        run->add_option("time_step_h", custom_cadence.second, "Report with uniform time step");
-        custom_cadence.first = (custom_cadence.second > 0.);
+        double cadence = -1.;
+        run->add_option("-t,--time_step_h", cadence, "Report with uniform time step");
 
         bool verbose = false;
         run->add_flag("-v,--verbose", verbose, "Verbose output");
@@ -482,7 +485,7 @@ main(int argc, char** argv)
         run->callback(
             [&]() {
                 result = runCommand(
-                    tomlFilename, eventsFilename, statsFilename, custom_cadence, verbose
+                    tomlFilename, eventsFilename, statsFilename, cadence, verbose
                 );
             }
         );

--- a/apps/erin.cpp
+++ b/apps/erin.cpp
@@ -109,7 +109,7 @@ runCommand(
         Simulation_Print(s);
         std::cout << "-----------------" << std::endl;
     }
-    Simulation_Run(s, eventsFilename, statsFilename, verbose);
+    Simulation_Run(s, eventsFilename, statsFilename, custom_cadence, verbose);
 
     return EXIT_SUCCESS;
 }

--- a/apps/erin.cpp
+++ b/apps/erin.cpp
@@ -25,14 +25,16 @@
 #include "compilation_settings.h"
 
 int
-versionCommand() {
+versionCommand()
+{
     std::cout << "Version: " << erin::version::version_string << "\n";
     std::cout << "Build Type: " << build_type << "\n";
     return EXIT_SUCCESS;
 }
 
 int
-limitsCommand() {
+limitsCommand()
+{
     std::cout << "Limits: " << std::endl;
     std::cout << "- value of max_flow_W: " << erin::max_flow_W << std::endl;
     std::cout << "- max_flow_W ==     9223372036854776: "
@@ -63,14 +65,16 @@ limitsCommand() {
 
 int
 runCommand(
-        std::string const &tomlFilename,
-        std::string const &eventsFilename,
-        std::string const &statsFilename,
-        double time_step_h,
-        bool verbose
-) {
+    std::string const& tomlFilename,
+    std::string const& eventsFilename,
+    std::string const& statsFilename,
+    double time_step_h,
+    bool verbose
+)
+{
 
-    if (verbose) {
+    if (verbose)
+    {
         std::cout << "input file: " << tomlFilename << std::endl;
         std::cout << "events file: " << eventsFilename << std::endl;
         std::cout << "statistics file: " << statsFilename << std::endl;
@@ -80,7 +84,8 @@ runCommand(
     }
 
     std::ifstream ifs(tomlFilename, std::ios_base::binary);
-    if (!ifs.good()) {
+    if (!ifs.good())
+    {
         std::cout << "Could not open input file stream on input file"
                   << std::endl;
         return EXIT_FAILURE;
@@ -90,16 +95,18 @@ runCommand(
     auto nameOnly = std::filesystem::path(tomlFilename).filename();
     toml::value data = toml::parse(ifs, nameOnly.string());
     ifs.close();
-    std::unordered_set < std::string > componentTagsInUse =
-            TOMLTable_ParseComponentTagsInUse(data);
+    std::unordered_set<std::string> componentTagsInUse =
+        TOMLTable_ParseComponentTagsInUse(data);
     auto validationInfo = SetupGlobalValidationInfo();
     auto maybeSim =
-            Simulation_ReadFromToml(data, validationInfo, componentTagsInUse);
-    if (!maybeSim.has_value()) {
+        Simulation_ReadFromToml(data, validationInfo, componentTagsInUse);
+    if (!maybeSim.has_value())
+    {
         return EXIT_FAILURE;
     }
     Simulation s = std::move(maybeSim.value());
-    if (verbose) {
+    if (verbose)
+    {
         Simulation_Print(s);
         std::cout << "-----------------" << std::endl;
     }
@@ -110,12 +117,14 @@ runCommand(
 
 int
 graphCommand(
-        std::string const &inputFilename,
-        std::string const &outputFilename,
-        bool const useHtml
-) {
+    std::string const& inputFilename,
+    std::string const& outputFilename,
+    bool const useHtml
+)
+{
     std::ifstream ifs(inputFilename, std::ios_base::binary);
-    if (!ifs.good()) {
+    if (!ifs.good())
+    {
         std::cout << "Could not open input file stream on input file"
                   << std::endl;
         return EXIT_FAILURE;
@@ -125,21 +134,23 @@ graphCommand(
     auto name_only = std::filesystem::path(inputFilename).filename();
     auto data = toml::parse(ifs, name_only.string());
     ifs.close();
-    std::unordered_set < std::string > componentTagsInUse =
-            TOMLTable_ParseComponentTagsInUse(data);
+    std::unordered_set<std::string> componentTagsInUse =
+        TOMLTable_ParseComponentTagsInUse(data);
     auto validation_info = SetupGlobalValidationInfo();
     auto maybe_sim =
-            Simulation_ReadFromToml(data, validation_info, componentTagsInUse);
-    if (!maybe_sim.has_value()) {
+        Simulation_ReadFromToml(data, validation_info, componentTagsInUse);
+    if (!maybe_sim.has_value())
+    {
         return EXIT_FAILURE;
     }
     Simulation s = std::move(maybe_sim.value());
     std::string dot_data = network_to_dot(
-            s.TheModel.Connections, s.TheModel.ComponentMap.Tag, "", useHtml
+        s.TheModel.Connections, s.TheModel.ComponentMap.Tag, "", useHtml
     );
     // save string from network_to_dot
     std::ofstream ofs(outputFilename, std::ios_base::binary);
-    if (!ofs.good()) {
+    if (!ofs.good())
+    {
         std::cout << "Could not open output file stream on output file"
                   << std::endl;
         return EXIT_FAILURE;
@@ -150,9 +161,11 @@ graphCommand(
 }
 
 int
-checkNetworkCommand(std::string tomlFilename) {
+checkNetworkCommand(std::string tomlFilename)
+{
     std::ifstream ifs(tomlFilename, std::ios_base::binary);
-    if (!ifs.good()) {
+    if (!ifs.good())
+    {
         std::cout << "Could not open input file stream on input file"
                   << std::endl;
         return EXIT_FAILURE;
@@ -162,19 +175,22 @@ checkNetworkCommand(std::string tomlFilename) {
     auto nameOnly = std::filesystem::path(tomlFilename).filename();
     auto data = toml::parse(ifs, nameOnly.string());
     ifs.close();
-    std::unordered_set < std::string > componentTagsInUse =
-            TOMLTable_ParseComponentTagsInUse(data);
+    std::unordered_set<std::string> componentTagsInUse =
+        TOMLTable_ParseComponentTagsInUse(data);
     auto validationInfo = SetupGlobalValidationInfo();
     auto maybeSim =
-            Simulation_ReadFromToml(data, validationInfo, componentTagsInUse);
-    if (!maybeSim.has_value()) {
+        Simulation_ReadFromToml(data, validationInfo, componentTagsInUse);
+    if (!maybeSim.has_value())
+    {
         return EXIT_FAILURE;
     }
     Simulation s = std::move(maybeSim.value());
     std::vector<std::string> issues = erin::Model_CheckNetwork(s.TheModel);
-    if (issues.size() > 0) {
+    if (issues.size() > 0)
+    {
         std::cout << "ISSUES FOUND:" << std::endl;
-        for (std::string const &issue: issues) {
+        for (std::string const& issue : issues)
+        {
             std::cout << issue << std::endl;
         }
         return EXIT_FAILURE;
@@ -185,12 +201,14 @@ checkNetworkCommand(std::string tomlFilename) {
 
 int
 updateTomlInputCommand(
-        std::string inputTomlFilename,
-        std::string outputTomlFilename,
-        bool removeIds
-) {
+    std::string inputTomlFilename,
+    std::string outputTomlFilename,
+    bool removeIds
+)
+{
     std::ifstream ifs(inputTomlFilename, std::ios_base::binary);
-    if (!ifs.good()) {
+    if (!ifs.good())
+    {
         std::cout << "Could not open input file stream on input file"
                   << std::endl;
         return EXIT_FAILURE;
@@ -201,11 +219,13 @@ updateTomlInputCommand(
     ifs.close();
 
     // rename networks.* to network
-    if (data.contains("networks")) {
-        auto new_node = std::unordered_map < std::string, toml::value>{};
+    if (data.contains("networks"))
+    {
+        auto new_node = std::unordered_map<std::string, toml::value>{};
         auto nw = data["networks"].as_table();
-        for (auto it = nw.begin(); it != nw.end(); ++it) {
-            std::string const &nwName = it->first;
+        for (auto it = nw.begin(); it != nw.end(); ++it)
+        {
+            std::string const& nwName = it->first;
             std::cout << "CHANGE .networks." << nwName << " to .network"
                       << std::endl;
             auto nwTable = it->second.as_table();
@@ -216,60 +236,72 @@ updateTomlInputCommand(
         data.as_table().erase("networks");
     }
     // add input_format_version = current_input_version
-    if (data.contains("simulation_info")) {
-        auto &sim_info_table = data.at("simulation_info").as_table();
-        if (sim_info_table.contains("input_format_version")) {
+    if (data.contains("simulation_info"))
+    {
+        auto& sim_info_table = data.at("simulation_info").as_table();
+        if (sim_info_table.contains("input_format_version"))
+        {
             std::cout << "UPDATE simulation_info.input_format_version from "
                       << sim_info_table["input_format_version"] << " to "
                       << current_input_version << std::endl;
-        } else {
+        }
+        else
+        {
             std::cout << "ADD simulation_info.input_format_version = "
                       << current_input_version << std::endl;
         }
         sim_info_table["input_format_version"] = current_input_version;
     }
     // add missing fields to components
-    if (data.contains("components")) {
-        auto &components = data["components"].as_table();
-        for (auto it = components.begin(); it != components.end(); ++it) {
-            std::string const &compName = it->first;
-            auto &comp = it->second.as_table();
+    if (data.contains("components"))
+    {
+        auto& components = data["components"].as_table();
+        for (auto it = components.begin(); it != components.end(); ++it)
+        {
+            std::string const& compName = it->first;
+            auto& comp = it->second.as_table();
             std::string compType = comp["type"].as_string();
-            if (compType == "store" && !comp.contains("max_discharge")) {
+            if (compType == "store" && !comp.contains("max_discharge"))
+            {
                 double maxDischarge = comp["max_inflow"].is_floating()
-                                      ? comp["max_inflow"].as_floating()
-                                      : static_cast<double>(comp["max_inflow"].as_integer());
+                    ? comp["max_inflow"].as_floating()
+                    : static_cast<double>(comp["max_inflow"].as_integer());
                 comp["max_discharge"] = toml::value(maxDischarge);
                 std::cout << "ADD components." << compName
                           << ".max_discharge = " << maxDischarge << std::endl;
             }
-            if (compType == "store" && comp.contains("max_inflow")) {
+            if (compType == "store" && comp.contains("max_inflow"))
+            {
                 double maxInflow = comp["max_inflow"].is_floating()
-                                   ? comp["max_inflow"].as_floating()
-                                   : static_cast<double>(comp["max_inflow"].as_integer());
+                    ? comp["max_inflow"].as_floating()
+                    : static_cast<double>(comp["max_inflow"].as_integer());
                 comp.erase("max_inflow");
                 comp["max_charge"] = toml::value(maxInflow);
                 std::cout << "RENAME components." << compName
                           << ".max_inflow to components" << compName
                           << ".max_charge" << std::endl;
             }
-            if (compType == "muxer" && comp.contains("dispatch_strategy")) {
+            if (compType == "muxer" && comp.contains("dispatch_strategy"))
+            {
                 comp.erase("dispatch_strategy");
                 std::cout << "REMOVE components." << compName
                           << ".dispatch_strategy" << std::endl;
             }
-            if (removeIds && comp.contains("id")) {
+            if (removeIds && comp.contains("id"))
+            {
                 comp.erase("id");
                 std::cout << "REMOVE components." << compName << ".id"
                           << std::endl;
             }
-            if (compType == "converter" && comp.contains("constant_efficiency")) {
+            if (compType == "converter" && comp.contains("constant_efficiency"))
+            {
                 double eff = comp["constant_efficiency"].is_floating()
-                             ? comp["constant_efficiency"].as_floating()
-                             : static_cast<double>(
-                                     comp["constant_efficiency"].as_integer()
-                             );
-                if (eff > 1.0) {
+                    ? comp["constant_efficiency"].as_floating()
+                    : static_cast<double>(
+                          comp["constant_efficiency"].as_integer()
+                      );
+                if (eff > 1.0)
+                {
                     comp["type"] = toml::value("mover");
                     comp["cop"] = toml::value(eff);
                     comp.erase("constant_efficiency");
@@ -279,56 +311,71 @@ updateTomlInputCommand(
             }
         }
     }
-    if (removeIds) {
-        if (data.contains("simulation_info")) {
-            auto &simInfoTable = data["simulation_info"].as_table();
-            if (simInfoTable.contains("id")) {
+    if (removeIds)
+    {
+        if (data.contains("simulation_info"))
+        {
+            auto& simInfoTable = data["simulation_info"].as_table();
+            if (simInfoTable.contains("id"))
+            {
                 simInfoTable.erase("id");
                 std::cout << "REMOVE simulation_info.id" << std::endl;
             }
         }
-        if (data.contains("fragility_mode")) {
-            auto &fms = data["fragility_mode"].as_table();
-            for (auto it = fms.begin(); it != fms.end(); ++it) {
-                std::string const &fmName = it->first;
-                auto &fm = it->second.as_table();
-                if (fm.contains("id")) {
+        if (data.contains("fragility_mode"))
+        {
+            auto& fms = data["fragility_mode"].as_table();
+            for (auto it = fms.begin(); it != fms.end(); ++it)
+            {
+                std::string const& fmName = it->first;
+                auto& fm = it->second.as_table();
+                if (fm.contains("id"))
+                {
                     fm.erase("id");
                     std::cout << "REMOVE fragility_mode." << fmName << ".id"
                               << std::endl;
                 }
             }
         }
-        if (data.contains("failure_mode")) {
-            auto &fms = data["failure_mode"].as_table();
-            for (auto it = fms.begin(); it != fms.end(); ++it) {
-                std::string const &fmName = it->first;
-                auto &fm = it->second.as_table();
-                if (fm.contains("id")) {
+        if (data.contains("failure_mode"))
+        {
+            auto& fms = data["failure_mode"].as_table();
+            for (auto it = fms.begin(); it != fms.end(); ++it)
+            {
+                std::string const& fmName = it->first;
+                auto& fm = it->second.as_table();
+                if (fm.contains("id"))
+                {
                     fm.erase("id");
                     std::cout << "REMOVE failure_mode." << fmName << ".id"
                               << std::endl;
                 }
             }
         }
-        if (data.contains("fragility_curve")) {
-            auto &fcs = data["fragility_curve"].as_table();
-            for (auto it = fcs.begin(); it != fcs.end(); ++it) {
-                std::string const &fcName = it->first;
-                auto &fc = it->second.as_table();
-                if (fc.contains("id")) {
+        if (data.contains("fragility_curve"))
+        {
+            auto& fcs = data["fragility_curve"].as_table();
+            for (auto it = fcs.begin(); it != fcs.end(); ++it)
+            {
+                std::string const& fcName = it->first;
+                auto& fc = it->second.as_table();
+                if (fc.contains("id"))
+                {
                     fc.erase("id");
                     std::cout << "REMOVE fragility_curve." << fcName << ".id"
                               << std::endl;
                 }
             }
         }
-        if (data.contains("dist")) {
-            auto &dists = data["dist"].as_table();
-            for (auto it = dists.begin(); it != dists.end(); ++it) {
-                std::string const &distName = it->first;
-                auto &distTable = it->second.as_table();
-                if (distTable.contains("id")) {
+        if (data.contains("dist"))
+        {
+            auto& dists = data["dist"].as_table();
+            for (auto it = dists.begin(); it != dists.end(); ++it)
+            {
+                std::string const& distName = it->first;
+                auto& distTable = it->second.as_table();
+                if (distTable.contains("id"))
+                {
                     distTable.erase("id");
                     std::cout << "REMOVE dist." << distName << ".id"
                               << std::endl;
@@ -338,7 +385,8 @@ updateTomlInputCommand(
     }
 
     std::ofstream ofs(outputTomlFilename, std::ios_base::binary);
-    if (!ofs.good()) {
+    if (!ofs.good())
+    {
         std::cout << "Could not open ouptut file stream for output file"
                   << std::endl;
         return EXIT_FAILURE;
@@ -351,17 +399,20 @@ updateTomlInputCommand(
 
 int
 packLoadsCommand(
-        std::string const &tomlFilename,
-        std::string const &loadsFilename,
-        bool verbose
-) {
-    if (verbose) {
+    std::string const& tomlFilename,
+    std::string const& loadsFilename,
+    bool verbose
+)
+{
+    if (verbose)
+    {
         std::cout << "input file: " << tomlFilename << std::endl;
         std::cout << "verbose: " << (verbose ? "true" : "false") << std::endl;
     }
 
     std::ifstream ifs(tomlFilename, std::ios_base::binary);
-    if (!ifs.good()) {
+    if (!ifs.good())
+    {
         std::cout << "Could not open input file stream on input file"
                   << std::endl;
         return EXIT_FAILURE;
@@ -371,13 +422,14 @@ packLoadsCommand(
     auto data = toml::parse(ifs, tomlFilenameOnly.string());
     ifs.close();
 
-    auto const &loadTable = data.at("loads").as_table();
+    auto const& loadTable = data.at("loads").as_table();
 
     auto validationInfo = erin::SetupGlobalValidationInfo();
     erin::ValidationInfo explicitValidation = validationInfo.Load_01Explicit;
     erin::ValidationInfo fileValidation = validationInfo.Load_02FileBased;
     auto maybeLoads = ParseLoads(loadTable, explicitValidation, fileValidation);
-    if (!maybeLoads.has_value()) {
+    if (!maybeLoads.has_value())
+    {
         return EXIT_FAILURE;
     }
     std::vector<erin::Load> loads = std::move(maybeLoads.value());
@@ -386,7 +438,8 @@ packLoadsCommand(
 }
 
 int
-main(int argc, char **argv) {
+main(int argc, char** argv)
+{
     int result = EXIT_SUCCESS;
 
     CLI::App app{"erin"};
@@ -408,39 +461,40 @@ main(int argc, char **argv) {
 
         std::string eventsFilename = "out.csv";
         run->add_option(
-                "-e,--events",
-                eventsFilename,
-                "Events csv filename; default:out.csv"
+            "-e,--events",
+            eventsFilename,
+            "Events csv filename; default:out.csv"
         );
-
 
         std::string statsFilename = "stats.csv";
         run->add_option(
-                "-s,--statistics",
-                statsFilename,
-                "Statistics csv filename; default:stats.csv"
+            "-s,--statistics",
+            statsFilename,
+            "Statistics csv filename; default:stats.csv"
         );
 
         double time_step_h = -1.;
         run->add_option(
-                "-t,--time_step_h",
-                time_step_h,
-                "Report with uniform time step (hours)"
-        )->check(CLI::PositiveNumber);
+               "-t,--time_step_h",
+               time_step_h,
+               "Report with uniform time step (hours)"
+        )
+            ->check(CLI::PositiveNumber);
 
         bool verbose = false;
         run->add_flag("-v,--verbose", verbose, "Verbose output");
 
         run->callback(
-                [&]() {
-                    result = runCommand(
-                            tomlFilename,
-                            eventsFilename,
-                            statsFilename,
-                            time_step_h,
-                            verbose
-                    );
-                }
+            [&]()
+            {
+                result = runCommand(
+                    tomlFilename,
+                    eventsFilename,
+                    statsFilename,
+                    time_step_h,
+                    verbose
+                );
+            }
         );
     }
 
@@ -448,7 +502,7 @@ main(int argc, char **argv) {
         std::string tomlFilename;
         auto graph = app.add_subcommand("graph", "Graph a simulation");
         graph->add_option("toml_file", tomlFilename, "TOML filename")
-                ->required();
+            ->required();
 
         std::string outputFilename = "graph.dot";
         bool useHtml = true;
@@ -456,17 +510,19 @@ main(int argc, char **argv) {
         graph->add_flag("-s,--simple", useHtml, "Create a simpler graph view");
 
         graph->callback(
-                [&]() { result = graphCommand(tomlFilename, outputFilename, !useHtml); }
+            [&]()
+            { result = graphCommand(tomlFilename, outputFilename, !useHtml); }
         );
 
         auto checkNetwork =
-                app.add_subcommand("check", "Check network for issues");
+            app.add_subcommand("check", "Check network for issues");
         checkNetwork
-                ->add_option(
-                        "toml_input_file", tomlFilename, "TOML input file name"
-                )
-                ->required();
-        checkNetwork->callback([&]() { result = checkNetworkCommand(tomlFilename); });
+            ->add_option(
+                "toml_input_file", tomlFilename, "TOML input file name"
+            )
+            ->required();
+        checkNetwork->callback([&]()
+                               { result = checkNetworkCommand(tomlFilename); });
     }
 
     {
@@ -474,55 +530,57 @@ main(int argc, char **argv) {
         std::string tomlOutputFilename = "out.toml";
         bool stripIds = false;
         auto update =
-                app.add_subcommand("update", "Update an ERIN 0.55 file to current");
+            app.add_subcommand("update", "Update an ERIN 0.55 file to current");
         update
-                ->add_option(
-                        "toml_input_file", tomlFilename, "TOML input file name"
-                )
-                ->required();
+            ->add_option(
+                "toml_input_file", tomlFilename, "TOML input file name"
+            )
+            ->required();
         update->add_option(
-                "toml_output_file", tomlOutputFilename, "TOML output file name"
+            "toml_output_file", tomlOutputFilename, "TOML output file name"
         );
         update->add_flag(
-                "-s,--strip-ids",
-                stripIds,
-                "If specified, strips ids from the input file"
+            "-s,--strip-ids",
+            stripIds,
+            "If specified, strips ids from the input file"
         );
         update->callback(
-                [&]() {
-                    result = updateTomlInputCommand(
-                            tomlFilename, tomlOutputFilename, stripIds
-                    );
-                }
+            [&]() {
+                result = updateTomlInputCommand(
+                    tomlFilename, tomlOutputFilename, stripIds
+                );
+            }
         );
     }
 
     {
         std::string tomlFilename;
         auto packLoads = app.add_subcommand(
-                "pack-loads", "Pack loads into a single csv file"
+            "pack-loads", "Pack loads into a single csv file"
         );
         packLoads->add_option("toml_file", tomlFilename, "TOML filename")
-                ->required();
+            ->required();
 
         std::string loadsFilename = "packed-loads.csv";
         packLoads->add_option(
-                "-o,--outcsv",
-                loadsFilename,
-                "Packed-loads csv filename; default:packed-loads.csv"
+            "-o,--outcsv",
+            loadsFilename,
+            "Packed-loads csv filename; default:packed-loads.csv"
         );
 
         bool verbose = false;
         packLoads->add_flag("-v,--verbose", verbose, "Verbose output");
 
         packLoads->callback(
-                [&]() { result = packLoadsCommand(tomlFilename, loadsFilename, verbose); }
+            [&]()
+            { result = packLoadsCommand(tomlFilename, loadsFilename, verbose); }
         );
     }
     CLI11_PARSE(app, argc, argv);
 
     // call with no subcommands is equivalent to subcommand "help"
-    if (argc == 1) {
+    if (argc == 1)
+    {
         std::cout << "ERIN - Energy Resilience of Interacting Networks\n"
                   << "Version " << erin::version::version_string << "\n"
                   << std::endl;

--- a/apps/erin.cpp
+++ b/apps/erin.cpp
@@ -78,8 +78,10 @@ runCommand(
         std::cout << "input file: " << tomlFilename << std::endl;
         std::cout << "events file: " << eventsFilename << std::endl;
         std::cout << "statistics file: " << statsFilename << std::endl;
-        if (time_step_h > 0.)
+        if (time_step_h > 0.0)
+        {
             std::cout << "time step (h): " << time_step_h << std::endl;
+        }
         std::cout << "verbose: " << (verbose ? "true" : "false") << std::endl;
     }
 
@@ -473,7 +475,7 @@ main(int argc, char** argv)
             "Statistics csv filename; default:stats.csv"
         );
 
-        double time_step_h = -1.;
+        double time_step_h = -1.0;
         run->add_option(
                "-t,--time_step_h",
                time_step_h,

--- a/apps/erin.cpp
+++ b/apps/erin.cpp
@@ -25,16 +25,14 @@
 #include "compilation_settings.h"
 
 int
-versionCommand()
-{
+versionCommand() {
     std::cout << "Version: " << erin::version::version_string << "\n";
     std::cout << "Build Type: " << build_type << "\n";
     return EXIT_SUCCESS;
 }
 
 int
-limitsCommand()
-{
+limitsCommand() {
     std::cout << "Limits: " << std::endl;
     std::cout << "- value of max_flow_W: " << erin::max_flow_W << std::endl;
     std::cout << "- max_flow_W ==     9223372036854776: "
@@ -65,19 +63,17 @@ limitsCommand()
 
 int
 runCommand(
-    std::string const& tomlFilename,
-    std::string const& eventsFilename,
-    std::string const& statsFilename,
-    double cadence,
-    bool verbose
-)
-{
+        std::string const &tomlFilename,
+        std::string const &eventsFilename,
+        std::string const &statsFilename,
+        double cadence,
+        bool verbose
+) {
 
     std::pair<bool, double> custom_cadence = {false, cadence};
     custom_cadence.first = (custom_cadence.second > 0.);
 
-    if (verbose)
-    {
+    if (verbose) {
         std::cout << "input file: " << tomlFilename << std::endl;
         std::cout << "events file: " << eventsFilename << std::endl;
         std::cout << "statistics file: " << statsFilename << std::endl;
@@ -87,8 +83,7 @@ runCommand(
     }
 
     std::ifstream ifs(tomlFilename, std::ios_base::binary);
-    if (!ifs.good())
-    {
+    if (!ifs.good()) {
         std::cout << "Could not open input file stream on input file"
                   << std::endl;
         return EXIT_FAILURE;
@@ -98,18 +93,16 @@ runCommand(
     auto nameOnly = std::filesystem::path(tomlFilename).filename();
     toml::value data = toml::parse(ifs, nameOnly.string());
     ifs.close();
-    std::unordered_set<std::string> componentTagsInUse =
-        TOMLTable_ParseComponentTagsInUse(data);
+    std::unordered_set < std::string > componentTagsInUse =
+            TOMLTable_ParseComponentTagsInUse(data);
     auto validationInfo = SetupGlobalValidationInfo();
     auto maybeSim =
-        Simulation_ReadFromToml(data, validationInfo, componentTagsInUse);
-    if (!maybeSim.has_value())
-    {
+            Simulation_ReadFromToml(data, validationInfo, componentTagsInUse);
+    if (!maybeSim.has_value()) {
         return EXIT_FAILURE;
     }
     Simulation s = std::move(maybeSim.value());
-    if (verbose)
-    {
+    if (verbose) {
         Simulation_Print(s);
         std::cout << "-----------------" << std::endl;
     }
@@ -120,14 +113,12 @@ runCommand(
 
 int
 graphCommand(
-    std::string const& inputFilename,
-    std::string const& outputFilename,
-    bool const useHtml
-)
-{
+        std::string const &inputFilename,
+        std::string const &outputFilename,
+        bool const useHtml
+) {
     std::ifstream ifs(inputFilename, std::ios_base::binary);
-    if (!ifs.good())
-    {
+    if (!ifs.good()) {
         std::cout << "Could not open input file stream on input file"
                   << std::endl;
         return EXIT_FAILURE;
@@ -137,23 +128,21 @@ graphCommand(
     auto name_only = std::filesystem::path(inputFilename).filename();
     auto data = toml::parse(ifs, name_only.string());
     ifs.close();
-    std::unordered_set<std::string> componentTagsInUse =
-        TOMLTable_ParseComponentTagsInUse(data);
+    std::unordered_set < std::string > componentTagsInUse =
+            TOMLTable_ParseComponentTagsInUse(data);
     auto validation_info = SetupGlobalValidationInfo();
     auto maybe_sim =
-        Simulation_ReadFromToml(data, validation_info, componentTagsInUse);
-    if (!maybe_sim.has_value())
-    {
+            Simulation_ReadFromToml(data, validation_info, componentTagsInUse);
+    if (!maybe_sim.has_value()) {
         return EXIT_FAILURE;
     }
     Simulation s = std::move(maybe_sim.value());
     std::string dot_data = network_to_dot(
-        s.TheModel.Connections, s.TheModel.ComponentMap.Tag, "", useHtml
+            s.TheModel.Connections, s.TheModel.ComponentMap.Tag, "", useHtml
     );
     // save string from network_to_dot
     std::ofstream ofs(outputFilename, std::ios_base::binary);
-    if (!ofs.good())
-    {
+    if (!ofs.good()) {
         std::cout << "Could not open output file stream on output file"
                   << std::endl;
         return EXIT_FAILURE;
@@ -164,11 +153,9 @@ graphCommand(
 }
 
 int
-checkNetworkCommand(std::string tomlFilename)
-{
+checkNetworkCommand(std::string tomlFilename) {
     std::ifstream ifs(tomlFilename, std::ios_base::binary);
-    if (!ifs.good())
-    {
+    if (!ifs.good()) {
         std::cout << "Could not open input file stream on input file"
                   << std::endl;
         return EXIT_FAILURE;
@@ -178,22 +165,19 @@ checkNetworkCommand(std::string tomlFilename)
     auto nameOnly = std::filesystem::path(tomlFilename).filename();
     auto data = toml::parse(ifs, nameOnly.string());
     ifs.close();
-    std::unordered_set<std::string> componentTagsInUse =
-        TOMLTable_ParseComponentTagsInUse(data);
+    std::unordered_set < std::string > componentTagsInUse =
+            TOMLTable_ParseComponentTagsInUse(data);
     auto validationInfo = SetupGlobalValidationInfo();
     auto maybeSim =
-        Simulation_ReadFromToml(data, validationInfo, componentTagsInUse);
-    if (!maybeSim.has_value())
-    {
+            Simulation_ReadFromToml(data, validationInfo, componentTagsInUse);
+    if (!maybeSim.has_value()) {
         return EXIT_FAILURE;
     }
     Simulation s = std::move(maybeSim.value());
     std::vector<std::string> issues = erin::Model_CheckNetwork(s.TheModel);
-    if (issues.size() > 0)
-    {
+    if (issues.size() > 0) {
         std::cout << "ISSUES FOUND:" << std::endl;
-        for (std::string const& issue : issues)
-        {
+        for (std::string const &issue: issues) {
             std::cout << issue << std::endl;
         }
         return EXIT_FAILURE;
@@ -204,14 +188,12 @@ checkNetworkCommand(std::string tomlFilename)
 
 int
 updateTomlInputCommand(
-    std::string inputTomlFilename,
-    std::string outputTomlFilename,
-    bool removeIds
-)
-{
+        std::string inputTomlFilename,
+        std::string outputTomlFilename,
+        bool removeIds
+) {
     std::ifstream ifs(inputTomlFilename, std::ios_base::binary);
-    if (!ifs.good())
-    {
+    if (!ifs.good()) {
         std::cout << "Could not open input file stream on input file"
                   << std::endl;
         return EXIT_FAILURE;
@@ -222,13 +204,11 @@ updateTomlInputCommand(
     ifs.close();
 
     // rename networks.* to network
-    if (data.contains("networks"))
-    {
-        auto new_node = std::unordered_map<std::string, toml::value>{};
+    if (data.contains("networks")) {
+        auto new_node = std::unordered_map < std::string, toml::value>{};
         auto nw = data["networks"].as_table();
-        for (auto it = nw.begin(); it != nw.end(); ++it)
-        {
-            std::string const& nwName = it->first;
+        for (auto it = nw.begin(); it != nw.end(); ++it) {
+            std::string const &nwName = it->first;
             std::cout << "CHANGE .networks." << nwName << " to .network"
                       << std::endl;
             auto nwTable = it->second.as_table();
@@ -239,72 +219,60 @@ updateTomlInputCommand(
         data.as_table().erase("networks");
     }
     // add input_format_version = current_input_version
-    if (data.contains("simulation_info"))
-    {
-        auto& sim_info_table = data.at("simulation_info").as_table();
-        if (sim_info_table.contains("input_format_version"))
-        {
+    if (data.contains("simulation_info")) {
+        auto &sim_info_table = data.at("simulation_info").as_table();
+        if (sim_info_table.contains("input_format_version")) {
             std::cout << "UPDATE simulation_info.input_format_version from "
                       << sim_info_table["input_format_version"] << " to "
                       << current_input_version << std::endl;
-        }
-        else
-        {
+        } else {
             std::cout << "ADD simulation_info.input_format_version = "
                       << current_input_version << std::endl;
         }
         sim_info_table["input_format_version"] = current_input_version;
     }
     // add missing fields to components
-    if (data.contains("components"))
-    {
-        auto& components = data["components"].as_table();
-        for (auto it = components.begin(); it != components.end(); ++it)
-        {
-            std::string const& compName = it->first;
-            auto& comp = it->second.as_table();
+    if (data.contains("components")) {
+        auto &components = data["components"].as_table();
+        for (auto it = components.begin(); it != components.end(); ++it) {
+            std::string const &compName = it->first;
+            auto &comp = it->second.as_table();
             std::string compType = comp["type"].as_string();
-            if (compType == "store" && !comp.contains("max_discharge"))
-            {
+            if (compType == "store" && !comp.contains("max_discharge")) {
                 double maxDischarge = comp["max_inflow"].is_floating()
-                    ? comp["max_inflow"].as_floating()
-                    : static_cast<double>(comp["max_inflow"].as_integer());
+                                      ? comp["max_inflow"].as_floating()
+                                      : static_cast<double>(comp["max_inflow"].as_integer());
                 comp["max_discharge"] = toml::value(maxDischarge);
                 std::cout << "ADD components." << compName
                           << ".max_discharge = " << maxDischarge << std::endl;
             }
-            if (compType == "store" && comp.contains("max_inflow"))
-            {
+            if (compType == "store" && comp.contains("max_inflow")) {
                 double maxInflow = comp["max_inflow"].is_floating()
-                    ? comp["max_inflow"].as_floating()
-                    : static_cast<double>(comp["max_inflow"].as_integer());
+                                   ? comp["max_inflow"].as_floating()
+                                   : static_cast<double>(comp["max_inflow"].as_integer());
                 comp.erase("max_inflow");
                 comp["max_charge"] = toml::value(maxInflow);
                 std::cout << "RENAME components." << compName
                           << ".max_inflow to components" << compName
                           << ".max_charge" << std::endl;
             }
-            if (compType == "muxer" && comp.contains("dispatch_strategy"))
-            {
+            if (compType == "muxer" && comp.contains("dispatch_strategy")) {
                 comp.erase("dispatch_strategy");
                 std::cout << "REMOVE components." << compName
                           << ".dispatch_strategy" << std::endl;
             }
-            if (removeIds && comp.contains("id"))
-            {
+            if (removeIds && comp.contains("id")) {
                 comp.erase("id");
                 std::cout << "REMOVE components." << compName << ".id"
                           << std::endl;
             }
-            if (compType == "converter" && comp.contains("constant_efficiency"))
-            {
+            if (compType == "converter" && comp.contains("constant_efficiency")) {
                 double eff = comp["constant_efficiency"].is_floating()
-                    ? comp["constant_efficiency"].as_floating()
-                    : static_cast<double>(
-                          comp["constant_efficiency"].as_integer()
-                      );
-                if (eff > 1.0)
-                {
+                             ? comp["constant_efficiency"].as_floating()
+                             : static_cast<double>(
+                                     comp["constant_efficiency"].as_integer()
+                             );
+                if (eff > 1.0) {
                     comp["type"] = toml::value("mover");
                     comp["cop"] = toml::value(eff);
                     comp.erase("constant_efficiency");
@@ -314,71 +282,56 @@ updateTomlInputCommand(
             }
         }
     }
-    if (removeIds)
-    {
-        if (data.contains("simulation_info"))
-        {
-            auto& simInfoTable = data["simulation_info"].as_table();
-            if (simInfoTable.contains("id"))
-            {
+    if (removeIds) {
+        if (data.contains("simulation_info")) {
+            auto &simInfoTable = data["simulation_info"].as_table();
+            if (simInfoTable.contains("id")) {
                 simInfoTable.erase("id");
                 std::cout << "REMOVE simulation_info.id" << std::endl;
             }
         }
-        if (data.contains("fragility_mode"))
-        {
-            auto& fms = data["fragility_mode"].as_table();
-            for (auto it = fms.begin(); it != fms.end(); ++it)
-            {
-                std::string const& fmName = it->first;
-                auto& fm = it->second.as_table();
-                if (fm.contains("id"))
-                {
+        if (data.contains("fragility_mode")) {
+            auto &fms = data["fragility_mode"].as_table();
+            for (auto it = fms.begin(); it != fms.end(); ++it) {
+                std::string const &fmName = it->first;
+                auto &fm = it->second.as_table();
+                if (fm.contains("id")) {
                     fm.erase("id");
                     std::cout << "REMOVE fragility_mode." << fmName << ".id"
                               << std::endl;
                 }
             }
         }
-        if (data.contains("failure_mode"))
-        {
-            auto& fms = data["failure_mode"].as_table();
-            for (auto it = fms.begin(); it != fms.end(); ++it)
-            {
-                std::string const& fmName = it->first;
-                auto& fm = it->second.as_table();
-                if (fm.contains("id"))
-                {
+        if (data.contains("failure_mode")) {
+            auto &fms = data["failure_mode"].as_table();
+            for (auto it = fms.begin(); it != fms.end(); ++it) {
+                std::string const &fmName = it->first;
+                auto &fm = it->second.as_table();
+                if (fm.contains("id")) {
                     fm.erase("id");
                     std::cout << "REMOVE failure_mode." << fmName << ".id"
                               << std::endl;
                 }
             }
         }
-        if (data.contains("fragility_curve"))
-        {
-            auto& fcs = data["fragility_curve"].as_table();
-            for (auto it = fcs.begin(); it != fcs.end(); ++it)
-            {
-                std::string const& fcName = it->first;
-                auto& fc = it->second.as_table();
-                if (fc.contains("id"))
-                {
+        if (data.contains("fragility_curve")) {
+            auto &fcs = data["fragility_curve"].as_table();
+            for (auto it = fcs.begin(); it != fcs.end(); ++it) {
+                std::string const &fcName = it->first;
+                auto &fc = it->second.as_table();
+                if (fc.contains("id")) {
                     fc.erase("id");
                     std::cout << "REMOVE fragility_curve." << fcName << ".id"
                               << std::endl;
                 }
             }
         }
-        if (data.contains("dist"))
-        {
-            auto& dists = data["dist"].as_table();
-            for (auto it = dists.begin(); it != dists.end(); ++it)
-            {
-                std::string const& distName = it->first;
-                auto& distTable = it->second.as_table();
-                if (distTable.contains("id"))
-                {
+        if (data.contains("dist")) {
+            auto &dists = data["dist"].as_table();
+            for (auto it = dists.begin(); it != dists.end(); ++it) {
+                std::string const &distName = it->first;
+                auto &distTable = it->second.as_table();
+                if (distTable.contains("id")) {
                     distTable.erase("id");
                     std::cout << "REMOVE dist." << distName << ".id"
                               << std::endl;
@@ -388,8 +341,7 @@ updateTomlInputCommand(
     }
 
     std::ofstream ofs(outputTomlFilename, std::ios_base::binary);
-    if (!ofs.good())
-    {
+    if (!ofs.good()) {
         std::cout << "Could not open ouptut file stream for output file"
                   << std::endl;
         return EXIT_FAILURE;
@@ -402,20 +354,17 @@ updateTomlInputCommand(
 
 int
 packLoadsCommand(
-    std::string const& tomlFilename,
-    std::string const& loadsFilename,
-    bool verbose
-)
-{
-    if (verbose)
-    {
+        std::string const &tomlFilename,
+        std::string const &loadsFilename,
+        bool verbose
+) {
+    if (verbose) {
         std::cout << "input file: " << tomlFilename << std::endl;
         std::cout << "verbose: " << (verbose ? "true" : "false") << std::endl;
     }
 
     std::ifstream ifs(tomlFilename, std::ios_base::binary);
-    if (!ifs.good())
-    {
+    if (!ifs.good()) {
         std::cout << "Could not open input file stream on input file"
                   << std::endl;
         return EXIT_FAILURE;
@@ -425,14 +374,13 @@ packLoadsCommand(
     auto data = toml::parse(ifs, tomlFilenameOnly.string());
     ifs.close();
 
-    auto const& loadTable = data.at("loads").as_table();
+    auto const &loadTable = data.at("loads").as_table();
 
     auto validationInfo = erin::SetupGlobalValidationInfo();
     erin::ValidationInfo explicitValidation = validationInfo.Load_01Explicit;
     erin::ValidationInfo fileValidation = validationInfo.Load_02FileBased;
     auto maybeLoads = ParseLoads(loadTable, explicitValidation, fileValidation);
-    if (!maybeLoads.has_value())
-    {
+    if (!maybeLoads.has_value()) {
         return EXIT_FAILURE;
     }
     std::vector<erin::Load> loads = std::move(maybeLoads.value());
@@ -441,8 +389,7 @@ packLoadsCommand(
 }
 
 int
-main(int argc, char** argv)
-{
+main(int argc, char **argv) {
     int result = EXIT_SUCCESS;
 
     CLI::App app{"erin"};
@@ -464,16 +411,16 @@ main(int argc, char** argv)
 
         std::string eventsFilename = "out.csv";
         run->add_option(
-            "-e,--events",
-            eventsFilename,
-            "Events csv filename; default:out.csv"
+                "-e,--events",
+                eventsFilename,
+                "Events csv filename; default:out.csv"
         );
 
         std::string statsFilename = "stats.csv";
         run->add_option(
-            "-s,--statistics",
-            statsFilename,
-            "Statistics csv filename; default:stats.csv"
+                "-s,--statistics",
+                statsFilename,
+                "Statistics csv filename; default:stats.csv"
         );
 
         double cadence = -1.;
@@ -483,11 +430,11 @@ main(int argc, char** argv)
         run->add_flag("-v,--verbose", verbose, "Verbose output");
 
         run->callback(
-            [&]() {
-                result = runCommand(
-                    tomlFilename, eventsFilename, statsFilename, cadence, verbose
-                );
-            }
+                [&]() {
+                    result = runCommand(
+                            tomlFilename, eventsFilename, statsFilename, cadence, verbose
+                    );
+                }
         );
     }
 
@@ -495,7 +442,7 @@ main(int argc, char** argv)
         std::string tomlFilename;
         auto graph = app.add_subcommand("graph", "Graph a simulation");
         graph->add_option("toml_file", tomlFilename, "TOML filename")
-            ->required();
+                ->required();
 
         std::string outputFilename = "graph.dot";
         bool useHtml = true;
@@ -503,19 +450,17 @@ main(int argc, char** argv)
         graph->add_flag("-s,--simple", useHtml, "Create a simpler graph view");
 
         graph->callback(
-            [&]()
-            { result = graphCommand(tomlFilename, outputFilename, !useHtml); }
+                [&]() { result = graphCommand(tomlFilename, outputFilename, !useHtml); }
         );
 
         auto checkNetwork =
-            app.add_subcommand("check", "Check network for issues");
+                app.add_subcommand("check", "Check network for issues");
         checkNetwork
-            ->add_option(
-                "toml_input_file", tomlFilename, "TOML input file name"
-            )
-            ->required();
-        checkNetwork->callback([&]()
-                               { result = checkNetworkCommand(tomlFilename); });
+                ->add_option(
+                        "toml_input_file", tomlFilename, "TOML input file name"
+                )
+                ->required();
+        checkNetwork->callback([&]() { result = checkNetworkCommand(tomlFilename); });
     }
 
     {
@@ -523,57 +468,55 @@ main(int argc, char** argv)
         std::string tomlOutputFilename = "out.toml";
         bool stripIds = false;
         auto update =
-            app.add_subcommand("update", "Update an ERIN 0.55 file to current");
+                app.add_subcommand("update", "Update an ERIN 0.55 file to current");
         update
-            ->add_option(
-                "toml_input_file", tomlFilename, "TOML input file name"
-            )
-            ->required();
+                ->add_option(
+                        "toml_input_file", tomlFilename, "TOML input file name"
+                )
+                ->required();
         update->add_option(
-            "toml_output_file", tomlOutputFilename, "TOML output file name"
+                "toml_output_file", tomlOutputFilename, "TOML output file name"
         );
         update->add_flag(
-            "-s,--strip-ids",
-            stripIds,
-            "If specified, strips ids from the input file"
+                "-s,--strip-ids",
+                stripIds,
+                "If specified, strips ids from the input file"
         );
         update->callback(
-            [&]() {
-                result = updateTomlInputCommand(
-                    tomlFilename, tomlOutputFilename, stripIds
-                );
-            }
+                [&]() {
+                    result = updateTomlInputCommand(
+                            tomlFilename, tomlOutputFilename, stripIds
+                    );
+                }
         );
     }
 
     {
         std::string tomlFilename;
         auto packLoads = app.add_subcommand(
-            "pack-loads", "Pack loads into a single csv file"
+                "pack-loads", "Pack loads into a single csv file"
         );
         packLoads->add_option("toml_file", tomlFilename, "TOML filename")
-            ->required();
+                ->required();
 
         std::string loadsFilename = "packed-loads.csv";
         packLoads->add_option(
-            "-o,--outcsv",
-            loadsFilename,
-            "Packed-loads csv filename; default:packed-loads.csv"
+                "-o,--outcsv",
+                loadsFilename,
+                "Packed-loads csv filename; default:packed-loads.csv"
         );
 
         bool verbose = false;
         packLoads->add_flag("-v,--verbose", verbose, "Verbose output");
 
         packLoads->callback(
-            [&]()
-            { result = packLoadsCommand(tomlFilename, loadsFilename, verbose); }
+                [&]() { result = packLoadsCommand(tomlFilename, loadsFilename, verbose); }
         );
     }
     CLI11_PARSE(app, argc, argv);
 
     // call with no subcommands is equivalent to subcommand "help"
-    if (argc == 1)
-    {
+    if (argc == 1) {
         std::cout << "ERIN - Energy Resilience of Interacting Networks\n"
                   << "Version " << erin::version::version_string << "\n"
                   << std::endl;

--- a/apps/erin.cpp
+++ b/apps/erin.cpp
@@ -413,6 +413,7 @@ main(int argc, char **argv) {
                 "Events csv filename; default:out.csv"
         );
 
+
         std::string statsFilename = "stats.csv";
         run->add_option(
                 "-s,--statistics",
@@ -421,7 +422,11 @@ main(int argc, char **argv) {
         );
 
         double time_step_h = -1.;
-        run->add_option("-t,--time_step_h", time_step_h, "Report with uniform time step (hours)");
+        run->add_option(
+                "-t,--time_step_h",
+                time_step_h,
+                "Report with uniform time step (hours)"
+        )->check(CLI::PositiveNumber);
 
         bool verbose = false;
         run->add_flag("-v,--verbose", verbose, "Verbose output");
@@ -429,7 +434,11 @@ main(int argc, char **argv) {
         run->callback(
                 [&]() {
                     result = runCommand(
-                            tomlFilename, eventsFilename, statsFilename, time_step_h, verbose
+                            tomlFilename,
+                            eventsFilename,
+                            statsFilename,
+                            time_step_h,
+                            verbose
                     );
                 }
         );

--- a/apps/erin.cpp
+++ b/apps/erin.cpp
@@ -68,6 +68,7 @@ runCommand(
     std::string const& tomlFilename,
     std::string const& eventsFilename,
     std::string const& statsFilename,
+    std::pair<bool, double> const& custom_cadence,
     bool verbose
 )
 {
@@ -76,6 +77,8 @@ runCommand(
         std::cout << "input file: " << tomlFilename << std::endl;
         std::cout << "events file: " << eventsFilename << std::endl;
         std::cout << "statistics file: " << statsFilename << std::endl;
+        if (custom_cadence.first)
+            std::cout << "custom cadence (h): " << custom_cadence.second << std::endl;
         std::cout << "verbose: " << (verbose ? "true" : "false") << std::endl;
     }
 
@@ -469,13 +472,17 @@ main(int argc, char** argv)
             "Statistics csv filename; default:stats.csv"
         );
 
+        std::pair<bool, double> custom_cadence = {false, -1.};
+        run->add_option("time_step_h", custom_cadence.second, "Report with uniform time step");
+        custom_cadence.first = (custom_cadence.second > 0.);
+
         bool verbose = false;
         run->add_flag("-v,--verbose", verbose, "Verbose output");
 
         run->callback(
             [&]() {
                 result = runCommand(
-                    tomlFilename, eventsFilename, statsFilename, verbose
+                    tomlFilename, eventsFilename, statsFilename, custom_cadence, verbose
                 );
             }
         );

--- a/apps/erin.cpp
+++ b/apps/erin.cpp
@@ -66,19 +66,16 @@ runCommand(
         std::string const &tomlFilename,
         std::string const &eventsFilename,
         std::string const &statsFilename,
-        double cadence,
+        double time_step_h,
         bool verbose
 ) {
-
-    std::pair<bool, double> custom_cadence = {false, cadence};
-    custom_cadence.first = (custom_cadence.second > 0.);
 
     if (verbose) {
         std::cout << "input file: " << tomlFilename << std::endl;
         std::cout << "events file: " << eventsFilename << std::endl;
         std::cout << "statistics file: " << statsFilename << std::endl;
-        if (custom_cadence.first)
-            std::cout << "custom cadence (h): " << custom_cadence.second << std::endl;
+        if (time_step_h > 0.)
+            std::cout << "time step (h): " << time_step_h << std::endl;
         std::cout << "verbose: " << (verbose ? "true" : "false") << std::endl;
     }
 
@@ -106,7 +103,7 @@ runCommand(
         Simulation_Print(s);
         std::cout << "-----------------" << std::endl;
     }
-    Simulation_Run(s, eventsFilename, statsFilename, custom_cadence, verbose);
+    Simulation_Run(s, eventsFilename, statsFilename, time_step_h, verbose);
 
     return EXIT_SUCCESS;
 }
@@ -423,8 +420,8 @@ main(int argc, char **argv) {
                 "Statistics csv filename; default:stats.csv"
         );
 
-        double cadence = -1.;
-        run->add_option("-t,--time_step_h", cadence, "Report with uniform time step");
+        double time_step_h = -1.;
+        run->add_option("-t,--time_step_h", time_step_h, "Report with uniform time step (hours)");
 
         bool verbose = false;
         run->add_flag("-v,--verbose", verbose, "Verbose output");
@@ -432,7 +429,7 @@ main(int argc, char **argv) {
         run->callback(
                 [&]() {
                     result = runCommand(
-                            tomlFilename, eventsFilename, statsFilename, cadence, verbose
+                            tomlFilename, eventsFilename, statsFilename, time_step_h, verbose
                     );
                 }
         );

--- a/include/erin_next/erin_next.h
+++ b/include/erin_next/erin_next.h
@@ -677,7 +677,7 @@ namespace erin
     CopyStorageStates(SimulationState& ss);
 
     std::vector<TimeAndFlows>
-    Simulate(Model& m, bool print);
+    Simulate(Model& m, std::pair<bool, bool print);
 
     void
     Model_SetComponentToRepaired(

--- a/include/erin_next/erin_next.h
+++ b/include/erin_next/erin_next.h
@@ -677,7 +677,7 @@ namespace erin
     CopyStorageStates(SimulationState& ss);
 
     std::vector<TimeAndFlows>
-    Simulate(Model& m, std::pair<bool, bool print);
+    Simulate(Model& m, bool print);
 
     void
     Model_SetComponentToRepaired(

--- a/include/erin_next/erin_next_simulation.h
+++ b/include/erin_next/erin_next_simulation.h
@@ -16,8 +16,10 @@
 #include <cstdlib>
 #include <unordered_set>
 
-namespace erin {
-    struct Simulation {
+namespace erin
+{
+    struct Simulation
+    {
         FlowDict FlowTypeMap;
         ScenarioDict ScenarioMap;
         LoadDict LoadMap;
@@ -41,265 +43,265 @@ namespace erin {
     FlowToString(flow_t value_W, unsigned int precision);
 
     void
-    Simulation_Init(Simulation &s);
+    Simulation_Init(Simulation& s);
 
     size_t
-    Simulation_RegisterFlow(Simulation &s, std::string const &flowTag);
+    Simulation_RegisterFlow(Simulation& s, std::string const& flowTag);
 
     size_t
-    Simulation_RegisterScenario(Simulation &s, std::string const &scenarioTag);
+    Simulation_RegisterScenario(Simulation& s, std::string const& scenarioTag);
 
     size_t
-    Simulation_RegisterIntensity(Simulation &s, std::string const &tag);
+    Simulation_RegisterIntensity(Simulation& s, std::string const& tag);
 
     size_t
     Simulation_RegisterIntensityLevelForScenario(
-            Simulation &s,
-            size_t scenarioId,
-            size_t intensityId,
-            double intensityLevel
+        Simulation& s,
+        size_t scenarioId,
+        size_t intensityId,
+        double intensityLevel
     );
 
     size_t
     Simulation_RegisterLoadSchedule(
-            Simulation &s,
-            std::string const &tag,
-            std::vector<TimeAndAmount> const &loadSchedule
+        Simulation& s,
+        std::string const& tag,
+        std::vector<TimeAndAmount> const& loadSchedule
     );
 
     std::optional<size_t>
-    Simulation_GetLoadIdByTag(Simulation const &s, std::string const &tag);
+    Simulation_GetLoadIdByTag(Simulation const& s, std::string const& tag);
 
     void
-    Simulation_RegisterAllLoads(Simulation &s, std::vector<Load> const &loads);
+    Simulation_RegisterAllLoads(Simulation& s, std::vector<Load> const& loads);
 
     void
-    Simulation_PrintComponents(Simulation const &s);
+    Simulation_PrintComponents(Simulation const& s);
 
     void
-    Simulation_PrintFragilityCurves(Simulation const &s);
+    Simulation_PrintFragilityCurves(Simulation const& s);
 
     void
-    Simulation_PrintFailureModes(Simulation const &s);
+    Simulation_PrintFailureModes(Simulation const& s);
 
     void
-    Simulation_PrintFragilityModes(Simulation const &s);
+    Simulation_PrintFragilityModes(Simulation const& s);
 
     void
-    Simulation_PrintScenarios(Simulation const &s);
+    Simulation_PrintScenarios(Simulation const& s);
 
     void
-    Simulation_PrintLoads(Simulation const &s);
+    Simulation_PrintLoads(Simulation const& s);
 
     size_t
-    Simulation_ScenarioCount(Simulation const &s);
+    Simulation_ScenarioCount(Simulation const& s);
 
     Result
     Simulation_ParseSimulationInfo(
-            Simulation &s,
-            toml::value const &v,
-            ValidationInfo const &validationInfo
+        Simulation& s,
+        toml::value const& v,
+        ValidationInfo const& validationInfo
     );
 
     Result
     Simulation_ParseLoads(
-            Simulation &s,
-            toml::value const &v,
-            ValidationInfo const &explicitValidation,
-            ValidationInfo const &fileBasedValidation
+        Simulation& s,
+        toml::value const& v,
+        ValidationInfo const& explicitValidation,
+        ValidationInfo const& fileBasedValidation
     );
 
     size_t
-    Simulation_RegisterFragilityCurve(Simulation &s, std::string const &tag);
+    Simulation_RegisterFragilityCurve(Simulation& s, std::string const& tag);
 
     size_t
     Simulation_RegisterFragilityCurve(
-            Simulation &s,
-            std::string const &tag,
-            FragilityCurveType curveType,
-            size_t curveIdx
+        Simulation& s,
+        std::string const& tag,
+        FragilityCurveType curveType,
+        size_t curveIdx
     );
 
     size_t
     Simulation_RegisterFailureMode(
-            Simulation &s,
-            std::string const &tag,
-            size_t failureId,
-            size_t repairId
+        Simulation& s,
+        std::string const& tag,
+        size_t failureId,
+        size_t repairId
     );
 
     size_t
     Simulation_RegisterFragilityMode(
-            Simulation &s,
-            std::string const &tag,
-            size_t fragilityCurveId,
-            std::optional<size_t> maybeRepairDistId
+        Simulation& s,
+        std::string const& tag,
+        size_t fragilityCurveId,
+        std::optional<size_t> maybeRepairDistId
     );
 
     Result
-    Simulation_ParseFragilityCurves(Simulation &s, std::string const &v);
+    Simulation_ParseFragilityCurves(Simulation& s, std::string const& v);
 
     Result
-    Simulation_ParseFragilityModes(Simulation &s, toml::value const &v);
+    Simulation_ParseFragilityModes(Simulation& s, toml::value const& v);
 
     Result
     Simulation_ParseComponents(
-            Simulation &s,
-            toml::value const &v,
-            ComponentValidationMap const &compValidations,
-            std::unordered_set<std::string> const &componentTagsInUse
+        Simulation& s,
+        toml::value const& v,
+        ComponentValidationMap const& compValidations,
+        std::unordered_set<std::string> const& componentTagsInUse
     );
 
     Result
-    Simulation_ParseDistributions(Simulation &s, toml::value const &v);
+    Simulation_ParseDistributions(Simulation& s, toml::value const& v);
 
     Result
-    Simulation_ParseNetwork(Simulation &s, toml::value const &v);
+    Simulation_ParseNetwork(Simulation& s, toml::value const& v);
 
     Result
-    Simulation_ParseScenarios(Simulation &s, toml::value const &v);
+    Simulation_ParseScenarios(Simulation& s, toml::value const& v);
 
     std::optional<Simulation>
     Simulation_ReadFromToml(
-            toml::value const &v,
-            InputValidationMap const &validationInfo,
-            std::unordered_set<std::string> const &componentTagsInUse
+        toml::value const& v,
+        InputValidationMap const& validationInfo,
+        std::unordered_set<std::string> const& componentTagsInUse
     );
 
     void
-    Simulation_Print(Simulation const &s);
+    Simulation_Print(Simulation const& s);
 
     void
-    Simulation_PrintIntensities(Simulation const &s);
+    Simulation_PrintIntensities(Simulation const& s);
 
     Result
     SetLoadsForScenario(
-            std::vector<ScheduleBasedLoad> &loads,
-            LoadDict loadMap,
-            size_t scenarioIdx
+        std::vector<ScheduleBasedLoad>& loads,
+        LoadDict loadMap,
+        size_t scenarioIdx
     );
 
     Result
     SetSupplyForScenario(
-            std::vector<ScheduleBasedSource> &loads,
-            LoadDict loadMap,
-            size_t scenarioIdx
+        std::vector<ScheduleBasedSource>& loads,
+        LoadDict loadMap,
+        size_t scenarioIdx
     );
 
     std::vector<double>
     DetermineScenarioOccurrenceTimes(
-            Simulation &s,
-            size_t scenIdx,
-            bool isVerbose
+        Simulation& s,
+        size_t scenIdx,
+        bool isVerbose
     );
 
     std::map<size_t, double>
-    GetIntensitiesForScenario(Simulation &s, size_t scenIdx);
+    GetIntensitiesForScenario(Simulation& s, size_t scenIdx);
 
     std::vector<ScheduleBasedReliability>
-    CopyReliabilities(Simulation const &s);
+    CopyReliabilities(Simulation const& s);
 
     std::vector<ScheduleBasedReliability>
     ApplyReliabilitiesAndFragilities(
-            Simulation &s,
-            double startTime_s,
-            double endTime_s,
-            std::map<size_t, double> const &intensityIdToAmount,
-            std::map<size_t, std::vector<TimeState>> const &relSchByCompId,
-            bool verbose
+        Simulation& s,
+        double startTime_s,
+        double endTime_s,
+        std::map<size_t, double> const& intensityIdToAmount,
+        std::map<size_t, std::vector<TimeState>> const& relSchByCompId,
+        bool verbose
     );
 
     std::vector<TimeAndFlows>
     applyUniformTimeStep(
-            std::vector<TimeAndFlows> const &results,
-            double const time_step_h
+        std::vector<TimeAndFlows> const& results,
+        double const time_step_h
     );
 
     void
     Simulation_Run(
-            Simulation &s,
-            const std::string &eventsFilename,
-            const std::string &statsFilename = "stats.csv",
-            double time_step_h = -1.,
-            const bool verbose = false
+        Simulation& s,
+        const std::string& eventsFilename,
+        const std::string& statsFilename = "stats.csv",
+        double time_step_h = -1.,
+        const bool verbose = false
     );
 
     bool
-    Simulation_IsFailureNameUnique(Simulation &s, std::string const &name);
+    Simulation_IsFailureNameUnique(Simulation& s, std::string const& name);
 
     bool
-    Simulation_IsFailureModeNameUnique(Simulation &s, std::string const &name);
+    Simulation_IsFailureModeNameUnique(Simulation& s, std::string const& name);
 
     bool
     Simulation_IsFragilityModeNameUnique(
-            Simulation &s,
-            std::string const &name
+        Simulation& s,
+        std::string const& name
     );
 
     Result
-    Simulation_ParseFailureModes(Simulation &s, toml::value const &v);
+    Simulation_ParseFailureModes(Simulation& s, toml::value const& v);
 
     Result
     Simulation_ParseLinearFragilityCurve(
-            Simulation &s,
-            std::string const &fcName,
-            std::string const &tableFullName,
-            toml::table const &fcData
+        Simulation& s,
+        std::string const& fcName,
+        std::string const& tableFullName,
+        toml::table const& fcData
     );
 
     std::optional<size_t>
     Parse_VulnerableTo(
-            Simulation const &s,
-            toml::table const &fcData,
-            std::string const &tableFullName
+        Simulation const& s,
+        toml::table const& fcData,
+        std::string const& tableFullName
     );
 
     std::vector<size_t>
-    CalculateConnectionOrder(Simulation const &s);
+    CalculateConnectionOrder(Simulation const& s);
 
     std::vector<size_t>
-    CalculateScenarioOrder(Simulation const &s);
+    CalculateScenarioOrder(Simulation const& s);
 
     std::vector<size_t>
-    CalculateComponentOrder(Simulation const &s);
+    CalculateComponentOrder(Simulation const& s);
 
     std::vector<size_t>
-    CalculateStoreOrder(Simulation const &s);
+    CalculateStoreOrder(Simulation const& s);
 
     std::vector<size_t>
-    CalculateFailModeOrder(Simulation const &s);
+    CalculateFailModeOrder(Simulation const& s);
 
     std::vector<size_t>
-    CalculateFragilModeOrder(Simulation const &s);
+    CalculateFragilModeOrder(Simulation const& s);
 
     void
     WriteEventFileHeader(
-            std::ofstream &out,
-            Model const &m,
-            FlowDict const &fd,
-            std::vector<size_t> const &connOrder,
-            std::vector<size_t> const &storeOrder,
-            std::vector<size_t> const &compOrder,
-            TimeUnit outputTimeUnit = TimeUnit::Hour
+        std::ofstream& out,
+        Model const& m,
+        FlowDict const& fd,
+        std::vector<size_t> const& connOrder,
+        std::vector<size_t> const& storeOrder,
+        std::vector<size_t> const& compOrder,
+        TimeUnit outputTimeUnit = TimeUnit::Hour
     );
 
     void
     WriteResultsToEventFile(
-            std::ofstream &out,
-            std::vector<TimeAndFlows> results,
-            Simulation const &s,
-            std::string const &scenarioTag,
-            std::string const &scenarioStartTimeTag,
-            std::vector<size_t> const &connOrder,
-            TimeUnit outputTimeUnit = TimeUnit::Hour
+        std::ofstream& out,
+        std::vector<TimeAndFlows> results,
+        Simulation const& s,
+        std::string const& scenarioTag,
+        std::string const& scenarioStartTimeTag,
+        std::vector<size_t> const& connOrder,
+        TimeUnit outputTimeUnit = TimeUnit::Hour
     );
 
     void
     WriteStatisticsToFile(
-            Simulation const &s,
-            std::string const &statsFilePath,
-            std::vector<ScenarioOccurrenceStats> const &occurrenceStats,
-            std::vector<size_t> const &compOrder
+        Simulation const& s,
+        std::string const& statsFilePath,
+        std::vector<ScenarioOccurrenceStats> const& occurrenceStats,
+        std::vector<size_t> const& compOrder
     );
 
 } // namespace erin

--- a/include/erin_next/erin_next_simulation.h
+++ b/include/erin_next/erin_next_simulation.h
@@ -209,6 +209,12 @@ namespace erin {
             bool verbose
     );
 
+    std::vector<TimeAndFlows>
+    applyUniformTimeStep(
+            std::vector<TimeAndFlows> const &results,
+            double const time_step_h
+    );
+
     void
     Simulation_Run(
             Simulation &s,

--- a/include/erin_next/erin_next_simulation.h
+++ b/include/erin_next/erin_next_simulation.h
@@ -16,10 +16,8 @@
 #include <cstdlib>
 #include <unordered_set>
 
-namespace erin
-{
-    struct Simulation
-    {
+namespace erin {
+    struct Simulation {
         FlowDict FlowTypeMap;
         ScenarioDict ScenarioMap;
         LoadDict LoadMap;
@@ -43,259 +41,259 @@ namespace erin
     FlowToString(flow_t value_W, unsigned int precision);
 
     void
-    Simulation_Init(Simulation& s);
+    Simulation_Init(Simulation &s);
 
     size_t
-    Simulation_RegisterFlow(Simulation& s, std::string const& flowTag);
+    Simulation_RegisterFlow(Simulation &s, std::string const &flowTag);
 
     size_t
-    Simulation_RegisterScenario(Simulation& s, std::string const& scenarioTag);
+    Simulation_RegisterScenario(Simulation &s, std::string const &scenarioTag);
 
     size_t
-    Simulation_RegisterIntensity(Simulation& s, std::string const& tag);
+    Simulation_RegisterIntensity(Simulation &s, std::string const &tag);
 
     size_t
     Simulation_RegisterIntensityLevelForScenario(
-        Simulation& s,
-        size_t scenarioId,
-        size_t intensityId,
-        double intensityLevel
+            Simulation &s,
+            size_t scenarioId,
+            size_t intensityId,
+            double intensityLevel
     );
 
     size_t
     Simulation_RegisterLoadSchedule(
-        Simulation& s,
-        std::string const& tag,
-        std::vector<TimeAndAmount> const& loadSchedule
+            Simulation &s,
+            std::string const &tag,
+            std::vector<TimeAndAmount> const &loadSchedule
     );
 
     std::optional<size_t>
-    Simulation_GetLoadIdByTag(Simulation const& s, std::string const& tag);
+    Simulation_GetLoadIdByTag(Simulation const &s, std::string const &tag);
 
     void
-    Simulation_RegisterAllLoads(Simulation& s, std::vector<Load> const& loads);
+    Simulation_RegisterAllLoads(Simulation &s, std::vector<Load> const &loads);
 
     void
-    Simulation_PrintComponents(Simulation const& s);
+    Simulation_PrintComponents(Simulation const &s);
 
     void
-    Simulation_PrintFragilityCurves(Simulation const& s);
+    Simulation_PrintFragilityCurves(Simulation const &s);
 
     void
-    Simulation_PrintFailureModes(Simulation const& s);
+    Simulation_PrintFailureModes(Simulation const &s);
 
     void
-    Simulation_PrintFragilityModes(Simulation const& s);
+    Simulation_PrintFragilityModes(Simulation const &s);
 
     void
-    Simulation_PrintScenarios(Simulation const& s);
+    Simulation_PrintScenarios(Simulation const &s);
 
     void
-    Simulation_PrintLoads(Simulation const& s);
+    Simulation_PrintLoads(Simulation const &s);
 
     size_t
-    Simulation_ScenarioCount(Simulation const& s);
+    Simulation_ScenarioCount(Simulation const &s);
 
     Result
     Simulation_ParseSimulationInfo(
-        Simulation& s,
-        toml::value const& v,
-        ValidationInfo const& validationInfo
+            Simulation &s,
+            toml::value const &v,
+            ValidationInfo const &validationInfo
     );
 
     Result
     Simulation_ParseLoads(
-        Simulation& s,
-        toml::value const& v,
-        ValidationInfo const& explicitValidation,
-        ValidationInfo const& fileBasedValidation
+            Simulation &s,
+            toml::value const &v,
+            ValidationInfo const &explicitValidation,
+            ValidationInfo const &fileBasedValidation
     );
 
     size_t
-    Simulation_RegisterFragilityCurve(Simulation& s, std::string const& tag);
+    Simulation_RegisterFragilityCurve(Simulation &s, std::string const &tag);
 
     size_t
     Simulation_RegisterFragilityCurve(
-        Simulation& s,
-        std::string const& tag,
-        FragilityCurveType curveType,
-        size_t curveIdx
+            Simulation &s,
+            std::string const &tag,
+            FragilityCurveType curveType,
+            size_t curveIdx
     );
 
     size_t
     Simulation_RegisterFailureMode(
-        Simulation& s,
-        std::string const& tag,
-        size_t failureId,
-        size_t repairId
+            Simulation &s,
+            std::string const &tag,
+            size_t failureId,
+            size_t repairId
     );
 
     size_t
     Simulation_RegisterFragilityMode(
-        Simulation& s,
-        std::string const& tag,
-        size_t fragilityCurveId,
-        std::optional<size_t> maybeRepairDistId
+            Simulation &s,
+            std::string const &tag,
+            size_t fragilityCurveId,
+            std::optional<size_t> maybeRepairDistId
     );
 
     Result
-    Simulation_ParseFragilityCurves(Simulation& s, std::string const& v);
+    Simulation_ParseFragilityCurves(Simulation &s, std::string const &v);
 
     Result
-    Simulation_ParseFragilityModes(Simulation& s, toml::value const& v);
+    Simulation_ParseFragilityModes(Simulation &s, toml::value const &v);
 
     Result
     Simulation_ParseComponents(
-        Simulation& s,
-        toml::value const& v,
-        ComponentValidationMap const& compValidations,
-        std::unordered_set<std::string> const& componentTagsInUse
+            Simulation &s,
+            toml::value const &v,
+            ComponentValidationMap const &compValidations,
+            std::unordered_set<std::string> const &componentTagsInUse
     );
 
     Result
-    Simulation_ParseDistributions(Simulation& s, toml::value const& v);
+    Simulation_ParseDistributions(Simulation &s, toml::value const &v);
 
     Result
-    Simulation_ParseNetwork(Simulation& s, toml::value const& v);
+    Simulation_ParseNetwork(Simulation &s, toml::value const &v);
 
     Result
-    Simulation_ParseScenarios(Simulation& s, toml::value const& v);
+    Simulation_ParseScenarios(Simulation &s, toml::value const &v);
 
     std::optional<Simulation>
     Simulation_ReadFromToml(
-        toml::value const& v,
-        InputValidationMap const& validationInfo,
-        std::unordered_set<std::string> const& componentTagsInUse
+            toml::value const &v,
+            InputValidationMap const &validationInfo,
+            std::unordered_set<std::string> const &componentTagsInUse
     );
 
     void
-    Simulation_Print(Simulation const& s);
+    Simulation_Print(Simulation const &s);
 
     void
-    Simulation_PrintIntensities(Simulation const& s);
+    Simulation_PrintIntensities(Simulation const &s);
 
     Result
     SetLoadsForScenario(
-        std::vector<ScheduleBasedLoad>& loads,
-        LoadDict loadMap,
-        size_t scenarioIdx
+            std::vector<ScheduleBasedLoad> &loads,
+            LoadDict loadMap,
+            size_t scenarioIdx
     );
 
     Result
     SetSupplyForScenario(
-        std::vector<ScheduleBasedSource>& loads,
-        LoadDict loadMap,
-        size_t scenarioIdx
+            std::vector<ScheduleBasedSource> &loads,
+            LoadDict loadMap,
+            size_t scenarioIdx
     );
 
     std::vector<double>
     DetermineScenarioOccurrenceTimes(
-        Simulation& s,
-        size_t scenIdx,
-        bool isVerbose
+            Simulation &s,
+            size_t scenIdx,
+            bool isVerbose
     );
 
     std::map<size_t, double>
-    GetIntensitiesForScenario(Simulation& s, size_t scenIdx);
+    GetIntensitiesForScenario(Simulation &s, size_t scenIdx);
 
     std::vector<ScheduleBasedReliability>
-    CopyReliabilities(Simulation const& s);
+    CopyReliabilities(Simulation const &s);
 
     std::vector<ScheduleBasedReliability>
     ApplyReliabilitiesAndFragilities(
-        Simulation& s,
-        double startTime_s,
-        double endTime_s,
-        std::map<size_t, double> const& intensityIdToAmount,
-        std::map<size_t, std::vector<TimeState>> const& relSchByCompId,
-        bool verbose
+            Simulation &s,
+            double startTime_s,
+            double endTime_s,
+            std::map<size_t, double> const &intensityIdToAmount,
+            std::map<size_t, std::vector<TimeState>> const &relSchByCompId,
+            bool verbose
     );
 
     void
     Simulation_Run(
-        Simulation& s,
-        const std::string& eventsFilename,
-        const std::string& statsFilename = "stats.csv",
-        std::pair<bool, double> custom_cadence_h = {false, -1.},
-        const bool verbose = false
+            Simulation &s,
+            const std::string &eventsFilename,
+            const std::string &statsFilename = "stats.csv",
+            double time_step_h = -1.,
+            const bool verbose = false
     );
 
     bool
-    Simulation_IsFailureNameUnique(Simulation& s, std::string const& name);
+    Simulation_IsFailureNameUnique(Simulation &s, std::string const &name);
 
     bool
-    Simulation_IsFailureModeNameUnique(Simulation& s, std::string const& name);
+    Simulation_IsFailureModeNameUnique(Simulation &s, std::string const &name);
 
     bool
     Simulation_IsFragilityModeNameUnique(
-        Simulation& s,
-        std::string const& name
+            Simulation &s,
+            std::string const &name
     );
 
     Result
-    Simulation_ParseFailureModes(Simulation& s, toml::value const& v);
+    Simulation_ParseFailureModes(Simulation &s, toml::value const &v);
 
     Result
     Simulation_ParseLinearFragilityCurve(
-        Simulation& s,
-        std::string const& fcName,
-        std::string const& tableFullName,
-        toml::table const& fcData
+            Simulation &s,
+            std::string const &fcName,
+            std::string const &tableFullName,
+            toml::table const &fcData
     );
 
     std::optional<size_t>
     Parse_VulnerableTo(
-        Simulation const& s,
-        toml::table const& fcData,
-        std::string const& tableFullName
+            Simulation const &s,
+            toml::table const &fcData,
+            std::string const &tableFullName
     );
 
     std::vector<size_t>
-    CalculateConnectionOrder(Simulation const& s);
+    CalculateConnectionOrder(Simulation const &s);
 
     std::vector<size_t>
-    CalculateScenarioOrder(Simulation const& s);
+    CalculateScenarioOrder(Simulation const &s);
 
     std::vector<size_t>
-    CalculateComponentOrder(Simulation const& s);
+    CalculateComponentOrder(Simulation const &s);
 
     std::vector<size_t>
-    CalculateStoreOrder(Simulation const& s);
+    CalculateStoreOrder(Simulation const &s);
 
     std::vector<size_t>
-    CalculateFailModeOrder(Simulation const& s);
+    CalculateFailModeOrder(Simulation const &s);
 
     std::vector<size_t>
-    CalculateFragilModeOrder(Simulation const& s);
+    CalculateFragilModeOrder(Simulation const &s);
 
     void
     WriteEventFileHeader(
-        std::ofstream& out,
-        Model const& m,
-        FlowDict const& fd,
-        std::vector<size_t> const& connOrder,
-        std::vector<size_t> const& storeOrder,
-        std::vector<size_t> const& compOrder,
-        TimeUnit outputTimeUnit = TimeUnit::Hour
+            std::ofstream &out,
+            Model const &m,
+            FlowDict const &fd,
+            std::vector<size_t> const &connOrder,
+            std::vector<size_t> const &storeOrder,
+            std::vector<size_t> const &compOrder,
+            TimeUnit outputTimeUnit = TimeUnit::Hour
     );
 
     void
     WriteResultsToEventFile(
-        std::ofstream& out,
-        std::vector<TimeAndFlows> results,
-        Simulation const& s,
-        std::string const& scenarioTag,
-        std::string const& scenarioStartTimeTag,
-        std::vector<size_t> const& connOrder,
-        TimeUnit outputTimeUnit = TimeUnit::Hour
+            std::ofstream &out,
+            std::vector<TimeAndFlows> results,
+            Simulation const &s,
+            std::string const &scenarioTag,
+            std::string const &scenarioStartTimeTag,
+            std::vector<size_t> const &connOrder,
+            TimeUnit outputTimeUnit = TimeUnit::Hour
     );
 
     void
     WriteStatisticsToFile(
-        Simulation const& s,
-        std::string const& statsFilePath,
-        std::vector<ScenarioOccurrenceStats> const& occurrenceStats,
-        std::vector<size_t> const& compOrder
+            Simulation const &s,
+            std::string const &statsFilePath,
+            std::vector<ScenarioOccurrenceStats> const &occurrenceStats,
+            std::vector<size_t> const &compOrder
     );
 
 } // namespace erin

--- a/include/erin_next/erin_next_simulation.h
+++ b/include/erin_next/erin_next_simulation.h
@@ -216,6 +216,7 @@ namespace erin
         Simulation& s,
         const std::string& eventsFilename,
         const std::string& statsFilename = "stats.csv",
+        std::pair<bool, double> custom_cadence_h = {false, -1.},
         const bool verbose = false
     );
 

--- a/include/erin_next/erin_next_simulation.h
+++ b/include/erin_next/erin_next_simulation.h
@@ -212,7 +212,7 @@ namespace erin
     );
 
     std::vector<TimeAndFlows>
-    applyUniformTimeStep(
+    ApplyUniformTimeStep(
         std::vector<TimeAndFlows> const& results,
         double const time_step_h
     );
@@ -222,7 +222,7 @@ namespace erin
         Simulation& s,
         const std::string& eventsFilename,
         const std::string& statsFilename = "stats.csv",
-        double time_step_h = -1.,
+        double time_step_h = -1.0,
         const bool verbose = false
     );
 

--- a/src/erin_next_simulation.cpp
+++ b/src/erin_next_simulation.cpp
@@ -1631,13 +1631,17 @@ namespace erin
     std::string
     FlowInWattsToString(flow_t value_W, unsigned int precision)
     {
+        bool const printDebugInfo = false;
         if (value_W == max_flow_W)
         {
-            std::cout << "Found infinity:" << std::endl;
-            std::cout << "- value_W   : " << fmt::format("{}", value_W)
-                      << std::endl;
-            std::cout << "- max_flow_W: " << fmt::format("{}", max_flow_W)
-                      << std::endl;
+            if (printDebugInfo)
+            {
+                std::cout << "Found infinity:" << std::endl;
+                std::cout << "- value_W   : " << fmt::format("{}", value_W)
+                          << std::endl;
+                std::cout << "- max_flow_W: " << fmt::format("{}", max_flow_W)
+                          << std::endl;
+            }
             return "inf";
         }
         double value_kW = value_W / W_per_kW;

--- a/src/erin_next_simulation.cpp
+++ b/src/erin_next_simulation.cpp
@@ -2380,25 +2380,27 @@ namespace erin {
                 // -- use that to set things like the print flag below
 
                 auto results = Simulate(s.TheModel, verbose);
-                auto *output_results = &results;
-                std::vector<TimeAndFlows> modified_results = {};
-                if (time_step_h > 0.) {
-                    modified_results = applyUniformTimeStep(results, time_step_h);
-                    output_results = &modified_results;
-                }
+                {
+                    auto *output_results = &results;
+                    std::vector<TimeAndFlows> modified_results = {};
+                    if (time_step_h > 0.) {
+                        modified_results = applyUniformTimeStep(results, time_step_h);
+                        output_results = &modified_results;
+                    }
 
-                // TODO: investigate putting output on another thread
-                WriteResultsToEventFile(
-                        out,
-                        *output_results,
-                        s,
-                        scenarioTag,
-                        scenarioStartTimeTag,
-                        connOrder,
-                        storeOrder,
-                        compOrder,
-                        outputTimeUnit
-                );
+                    // TODO: investigate putting output on another thread
+                    WriteResultsToEventFile(
+                            out,
+                            *output_results,
+                            s,
+                            scenarioTag,
+                            scenarioStartTimeTag,
+                            connOrder,
+                            storeOrder,
+                            compOrder,
+                            outputTimeUnit
+                    );
+                }
                 ScenarioOccurrenceStats sos =
                         ModelResults_CalculateScenarioOccurrenceStats(
                                 scenIdx, occIdx + 1, s.TheModel, s.FlowTypeMap, results

--- a/src/erin_next_simulation.cpp
+++ b/src/erin_next_simulation.cpp
@@ -2472,14 +2472,16 @@ namespace erin
     }
 
     std::vector<TimeAndFlows>
-    applyUniformTimeStep(
+    ApplyUniformTimeStep(
         std::vector<TimeAndFlows> const& results,
         double const time_step_h
     )
     {
         auto num_events = results.size();
-        if ((num_events == 0) || (time_step_h <= 0.))
+        if ((num_events == 0) || (time_step_h <= 0.0))
+        {
             return results;
+        }
 
         auto taf = results.front();
         auto num_flows = taf.Flows.size();
@@ -2487,10 +2489,10 @@ namespace erin
 
         std::vector<TimeAndFlows> modified_results = {taf};
 
-        double t_prev_report_s = 0.;
-        double T_report_s = 3600. * time_step_h;
+        double t_prev_report_s = 0.0;
+        double T_report_s = 3600.0 * time_step_h;
 
-        std::vector<double> storage_totals_J(num_flows, 0.);
+        std::vector<double> storage_totals_J(num_flows, 0.0);
 
         for (auto& next_taf : results)
         {
@@ -2505,7 +2507,7 @@ namespace erin
 
                 mod_taf.Time = t_next_report_s;
                 double dt_orig_s = next_taf.Time - taf.Time;
-                if (dt_orig_s > 0.)
+                if (dt_orig_s > 0.0)
                 {
                     double dt_s = t_next_report_s - taf.Time;
                     double time_frac = dt_s / dt_orig_s;
@@ -2531,7 +2533,7 @@ namespace erin
         Simulation& s,
         std::string const& eventsFilename,
         std::string const& statsFilename,
-        double time_step_h /*-1.*/,
+        double time_step_h /*-1.0*/,
         bool const verbose
     )
     {
@@ -2774,10 +2776,10 @@ namespace erin
                 {
                     auto* output_results = &results;
                     std::vector<TimeAndFlows> modified_results = {};
-                    if (time_step_h > 0.)
+                    if (time_step_h > 0.0)
                     {
                         modified_results =
-                            applyUniformTimeStep(results, time_step_h);
+                            ApplyUniformTimeStep(results, time_step_h);
                         output_results = &modified_results;
                     }
 

--- a/src/erin_next_simulation.cpp
+++ b/src/erin_next_simulation.cpp
@@ -24,9 +24,11 @@
 #include <sstream>
 #include <cstdlib>
 
-namespace erin {
+namespace erin
+{
     void
-    Simulation_Init(Simulation &s) {
+    Simulation_Init(Simulation& s)
+    {
         // NOTE: we register a 'null' flow. This allows users to 'opt-out'
         // of flow specification by passing empty strings. Effectively, this
         // allows any connections to occur which is nice for simple examples.
@@ -34,10 +36,13 @@ namespace erin {
     }
 
     size_t
-    Simulation_RegisterFlow(Simulation &s, std::string const &flowTag) {
+    Simulation_RegisterFlow(Simulation& s, std::string const& flowTag)
+    {
         size_t id = s.FlowTypeMap.Type.size();
-        for (size_t i = 0; i < id; ++i) {
-            if (s.FlowTypeMap.Type[i] == flowTag) {
+        for (size_t i = 0; i < id; ++i)
+        {
+            if (s.FlowTypeMap.Type[i] == flowTag)
+            {
                 return i;
             }
         }
@@ -46,14 +51,18 @@ namespace erin {
     }
 
     size_t
-    Simulation_RegisterScenario(Simulation &s, std::string const &scenarioTag) {
+    Simulation_RegisterScenario(Simulation& s, std::string const& scenarioTag)
+    {
         return ScenarioDict_RegisterScenario(s.ScenarioMap, scenarioTag);
     }
 
     size_t
-    Simulation_RegisterIntensity(Simulation &s, std::string const &tag) {
-        for (size_t i = 0; i < s.Intensities.Tags.size(); ++i) {
-            if (s.Intensities.Tags[i] == tag) {
+    Simulation_RegisterIntensity(Simulation& s, std::string const& tag)
+    {
+        for (size_t i = 0; i < s.Intensities.Tags.size(); ++i)
+        {
+            if (s.Intensities.Tags[i] == tag)
+            {
                 return i;
             }
         }
@@ -64,14 +73,17 @@ namespace erin {
 
     size_t
     Simulation_RegisterIntensityLevelForScenario(
-            Simulation &s,
-            size_t scenarioId,
-            size_t intensityId,
-            double intensityLevel
-    ) {
-        for (size_t i = 0; i < s.ScenarioIntensities.IntensityIds.size(); ++i) {
+        Simulation& s,
+        size_t scenarioId,
+        size_t intensityId,
+        double intensityLevel
+    )
+    {
+        for (size_t i = 0; i < s.ScenarioIntensities.IntensityIds.size(); ++i)
+        {
             if (s.ScenarioIntensities.IntensityIds[i] == intensityId
-                && s.ScenarioIntensities.ScenarioIds[i] == scenarioId) {
+                && s.ScenarioIntensities.ScenarioIds[i] == scenarioId)
+            {
                 s.ScenarioIntensities.IntensityLevels[i] = intensityLevel;
                 return i;
             }
@@ -85,14 +97,17 @@ namespace erin {
 
     size_t
     Simulation_RegisterLoadSchedule(
-            Simulation &s,
-            std::string const &tag,
-            std::vector<TimeAndAmount> const &loadSchedule
-    ) {
+        Simulation& s,
+        std::string const& tag,
+        std::vector<TimeAndAmount> const& loadSchedule
+    )
+    {
         size_t id = s.LoadMap.Tags.size();
         assert(s.LoadMap.Tags.size() == s.LoadMap.Loads.size());
-        for (size_t i = 0; i < id; ++i) {
-            if (s.LoadMap.Tags[i] == tag) {
+        for (size_t i = 0; i < id; ++i)
+        {
+            if (s.LoadMap.Tags[i] == tag)
+            {
                 s.LoadMap.Loads[i].clear();
                 s.LoadMap.Loads[i] = loadSchedule;
                 return i;
@@ -104,9 +119,12 @@ namespace erin {
     }
 
     std::optional<size_t>
-    Simulation_GetLoadIdByTag(Simulation const &s, std::string const &tag) {
-        for (size_t i = 0; i < s.LoadMap.Tags.size(); ++i) {
-            if (s.LoadMap.Tags[i] == tag) {
+    Simulation_GetLoadIdByTag(Simulation const& s, std::string const& tag)
+    {
+        for (size_t i = 0; i < s.LoadMap.Tags.size(); ++i)
+        {
+            if (s.LoadMap.Tags[i] == tag)
+            {
                 return i;
             }
         }
@@ -114,60 +132,74 @@ namespace erin {
     }
 
     void
-    Simulation_RegisterAllLoads(Simulation &s, std::vector<Load> const &loads) {
+    Simulation_RegisterAllLoads(Simulation& s, std::vector<Load> const& loads)
+    {
         s.LoadMap.Tags.clear();
         s.LoadMap.Loads.clear();
         auto numLoads = loads.size();
         s.LoadMap.Tags.reserve(numLoads);
         s.LoadMap.Loads.reserve(numLoads);
-        for (size_t i = 0; i < numLoads; ++i) {
+        for (size_t i = 0; i < numLoads; ++i)
+        {
             s.LoadMap.Tags.push_back(loads[i].Tag);
             s.LoadMap.Loads.push_back(loads[i].TimeAndLoads);
         }
     }
 
     void
-    Simulation_PrintComponents(Simulation const &s) {
-        Model const &m = s.TheModel;
-        for (size_t i = 0; i < m.ComponentMap.CompType.size(); ++i) {
+    Simulation_PrintComponents(Simulation const& s)
+    {
+        Model const& m = s.TheModel;
+        for (size_t i = 0; i < m.ComponentMap.CompType.size(); ++i)
+        {
             assert(i < m.ComponentMap.OutflowType.size());
             assert(i < m.ComponentMap.InflowType.size());
             assert(i < m.ComponentMap.CompType.size());
             assert(i < m.ComponentMap.Tag.size());
             assert(i < m.ComponentMap.Idx.size());
-            std::vector<size_t> const &outflowTypes =
-                    m.ComponentMap.OutflowType[i];
+            std::vector<size_t> const& outflowTypes =
+                m.ComponentMap.OutflowType[i];
             std::vector<size_t> inflowTypes = m.ComponentMap.InflowType[i];
             std::cout << i << ": " << ToString(m.ComponentMap.CompType[i]);
-            if (!m.ComponentMap.Tag[i].empty()) {
+            if (!m.ComponentMap.Tag[i].empty())
+            {
                 std::cout << " -- " << m.ComponentMap.Tag[i] << std::endl;
-            } else {
+            }
+            else
+            {
                 std::cout << std::endl;
             }
             for (size_t inportIdx = 0; inportIdx < inflowTypes.size();
-                 ++inportIdx) {
+                 ++inportIdx)
+            {
                 size_t inflowType = inflowTypes[inportIdx];
                 if (inflowType < s.FlowTypeMap.Type.size()
-                    && !s.FlowTypeMap.Type[inflowType].empty()) {
+                    && !s.FlowTypeMap.Type[inflowType].empty())
+                {
                     std::cout << "- inport " << inportIdx << ": "
                               << s.FlowTypeMap.Type[inflowType] << std::endl;
                 }
             }
             for (size_t outportIdx = 0; outportIdx < outflowTypes.size();
-                 ++outportIdx) {
+                 ++outportIdx)
+            {
                 size_t outflowType = outflowTypes[outportIdx];
                 if (outflowType < s.FlowTypeMap.Type.size()
-                    && !s.FlowTypeMap.Type[outflowType].empty()) {
+                    && !s.FlowTypeMap.Type[outflowType].empty())
+                {
                     std::cout << "- outport " << outportIdx << ": "
                               << s.FlowTypeMap.Type[outflowType] << std::endl;
                 }
             }
             size_t subtypeIdx = m.ComponentMap.Idx[i];
-            switch (m.ComponentMap.CompType[i]) {
-                case ComponentType::ScheduleBasedLoadType: {
+            switch (m.ComponentMap.CompType[i])
+            {
+                case ComponentType::ScheduleBasedLoadType:
+                {
                     assert(subtypeIdx < m.ScheduledLoads.size());
-                    ScheduleBasedLoad const &sbl = m.ScheduledLoads[subtypeIdx];
-                    for (auto const &keyValue: sbl.ScenarioIdToLoadId) {
+                    ScheduleBasedLoad const& sbl = m.ScheduledLoads[subtypeIdx];
+                    for (auto const& keyValue : sbl.ScenarioIdToLoadId)
+                    {
                         size_t scenarioIdx = keyValue.first;
                         size_t loadIdx = keyValue.second;
                         assert(scenarioIdx < s.ScenarioMap.Tags.size());
@@ -178,12 +210,14 @@ namespace erin {
                                   << std::endl;
                     }
                 }
-                    break;
-                case ComponentType::ScheduleBasedSourceType: {
+                break;
+                case ComponentType::ScheduleBasedSourceType:
+                {
                     assert(subtypeIdx < m.ScheduledSrcs.size());
-                    ScheduleBasedSource const &sbs =
-                            m.ScheduledSrcs[subtypeIdx];
-                    for (auto const &keyValue: sbs.ScenarioIdToSourceId) {
+                    ScheduleBasedSource const& sbs =
+                        m.ScheduledSrcs[subtypeIdx];
+                    for (auto const& keyValue : sbs.ScenarioIdToSourceId)
+                    {
                         size_t scenarioIdx = keyValue.first;
                         size_t loadIdx = keyValue.second;
                         assert(scenarioIdx < s.ScenarioMap.Tags.size());
@@ -195,92 +229,99 @@ namespace erin {
                     }
                     std::cout << "-- max outflow (W): "
                               << (sbs.MaxOutflow_W == max_flow_W
-                                  ? "unlimited"
-                                  : std::to_string(sbs.MaxOutflow_W))
+                                      ? "unlimited"
+                                      : std::to_string(sbs.MaxOutflow_W))
                               << std::endl;
                 }
-                    break;
-                case ComponentType::ConstantEfficiencyConverterType: {
+                break;
+                case ComponentType::ConstantEfficiencyConverterType:
+                {
                     assert(subtypeIdx < m.ConstEffConvs.size());
-                    ConstantEfficiencyConverter const &cec =
-                            m.ConstEffConvs[subtypeIdx];
+                    ConstantEfficiencyConverter const& cec =
+                        m.ConstEffConvs[subtypeIdx];
                     std::cout << "-- efficiency: " << cec.Efficiency * 100.0
                               << "%" << std::endl;
                     std::cout << "-- max outflow (W): "
                               << (cec.MaxOutflow_W == max_flow_W
-                                  ? "unlimited"
-                                  : std::to_string(cec.MaxOutflow_W))
+                                      ? "unlimited"
+                                      : std::to_string(cec.MaxOutflow_W))
                               << std::endl;
                     std::cout << "-- max lossflow (W): "
                               << (cec.MaxLossflow_W == max_flow_W
-                                  ? "unlimited"
-                                  : std::to_string(cec.MaxLossflow_W))
+                                      ? "unlimited"
+                                      : std::to_string(cec.MaxLossflow_W))
                               << std::endl;
                 }
-                    break;
-                case ComponentType::VariableEfficiencyConverterType: {
+                break;
+                case ComponentType::VariableEfficiencyConverterType:
+                {
                     assert(subtypeIdx < m.VarEffConvs.size());
-                    VariableEfficiencyConverter const &vec =
-                            m.VarEffConvs[subtypeIdx];
+                    VariableEfficiencyConverter const& vec =
+                        m.VarEffConvs[subtypeIdx];
                     std::cout << "-- efficiencies by load fraction:"
                               << std::endl;
                     double maxOutflow_W = static_cast<double>(vec.MaxOutflow_W);
-                    for (size_t i = 0; i < vec.Efficiencies.size(); ++i) {
+                    for (size_t i = 0; i < vec.Efficiencies.size(); ++i)
+                    {
                         std::cout << fmt::format(
-                                "  -- {:5.3f}",
-                                (vec.OutflowsForEfficiency_W[i] / maxOutflow_W)
+                            "  -- {:5.3f}",
+                            (vec.OutflowsForEfficiency_W[i] / maxOutflow_W)
                         );
                         std::cout << fmt::format(
-                                ": {:5.2f}%", (vec.Efficiencies[i] * 100.0)
+                            ": {:5.2f}%", (vec.Efficiencies[i] * 100.0)
                         ) << std::endl;
                     }
                     std::cout << "-- max outflow (W): "
                               << (vec.MaxOutflow_W == max_flow_W
-                                  ? "unlimited"
-                                  : std::to_string(vec.MaxOutflow_W))
+                                      ? "unlimited"
+                                      : std::to_string(vec.MaxOutflow_W))
                               << std::endl;
                     std::cout << "-- max lossflow (W): "
                               << (vec.MaxLossflow_W == max_flow_W
-                                  ? "unlimited"
-                                  : std::to_string(vec.MaxLossflow_W))
+                                      ? "unlimited"
+                                      : std::to_string(vec.MaxLossflow_W))
                               << std::endl;
                 }
-                    break;
-                case ComponentType::MoverType: {
+                break;
+                case ComponentType::MoverType:
+                {
                     assert(subtypeIdx < m.Movers.size());
-                    Mover const &mov = m.Movers[subtypeIdx];
+                    Mover const& mov = m.Movers[subtypeIdx];
                     std::cout << "-- cop: " << mov.COP << std::endl;
                     std::cout << "-- max outflow (W): "
                               << (mov.MaxOutflow_W == max_flow_W
-                                  ? "unlimited"
-                                  : std::to_string(mov.MaxOutflow_W))
+                                      ? "unlimited"
+                                      : std::to_string(mov.MaxOutflow_W))
                               << std::endl;
                 }
-                    break;
-                case ComponentType::VariableEfficiencyMoverType: {
+                break;
+                case ComponentType::VariableEfficiencyMoverType:
+                {
                     assert(subtypeIdx < m.VarEffMovers.size());
-                    VariableEfficiencyMover const &mov =
-                            m.VarEffMovers[subtypeIdx];
+                    VariableEfficiencyMover const& mov =
+                        m.VarEffMovers[subtypeIdx];
                     std::cout << "-- cop by load fraction:" << std::endl;
                     double maxOutflow_W = mov.MaxOutflow_W;
-                    for (size_t i = 0; i < mov.COPs.size(); ++i) {
+                    for (size_t i = 0; i < mov.COPs.size(); ++i)
+                    {
                         std::cout << fmt::format(
-                                " -- {:5.3f}",
-                                (mov.OutflowsForCop_W[i] / maxOutflow_W)
+                            " -- {:5.3f}",
+                            (mov.OutflowsForCop_W[i] / maxOutflow_W)
                         );
                         std::cout << fmt::format(": {:5.2f}", (mov.COPs[i]))
                                   << std::endl;
                     }
                     std::cout << "-- max outflow (W): "
                               << (mov.MaxOutflow_W == max_flow_W
-                                  ? "unlimited"
-                                  : std::to_string(maxOutflow_W))
+                                      ? "unlimited"
+                                      : std::to_string(maxOutflow_W))
                               << std::endl;
                 }
-                    break;
-                case ComponentType::StoreType: {
+                break;
+                case ComponentType::StoreType:
+                {
                     assert(subtypeIdx < m.Stores.size());
-                    Store const &store = m.Stores[subtypeIdx];
+                    Store const& store = m.Stores[subtypeIdx];
                     std::cout << "-- capacity (J): " << store.Capacity_J
                               << std::endl;
                     std::cout << "-- initial SOC: "
@@ -294,76 +335,86 @@ namespace erin {
                                   / static_cast<double>(store.Capacity_J))
                               << std::endl;
                     std::cout
-                            << "-- max charge rate (W): " << store.MaxChargeRate_W
-                            << std::endl;
+                        << "-- max charge rate (W): " << store.MaxChargeRate_W
+                        << std::endl;
                     std::cout << "-- max discharge rate (W): "
                               << store.MaxDischargeRate_W << std::endl;
                     std::cout << "-- max outflow (W): "
                               << (store.MaxOutflow_W == max_flow_W
-                                  ? "unlimited"
-                                  : std::to_string(store.MaxOutflow_W))
+                                      ? "unlimited"
+                                      : std::to_string(store.MaxOutflow_W))
                               << std::endl;
                     std::cout << "-- roundtrip efficiency: "
                               << store.RoundTripEfficiency * 100.0 << "%"
                               << std::endl;
                 }
-                    break;
-                case ComponentType::PassThroughType: {
+                break;
+                case ComponentType::PassThroughType:
+                {
                     assert(subtypeIdx < m.PassThroughs.size());
-                    PassThrough const &pt = m.PassThroughs[subtypeIdx];
+                    PassThrough const& pt = m.PassThroughs[subtypeIdx];
                     std::cout << "-- max outflow (W): "
                               << (pt.MaxOutflow_W == max_flow_W
-                                  ? "unlimited"
-                                  : std::to_string(pt.MaxOutflow_W))
+                                      ? "unlimited"
+                                      : std::to_string(pt.MaxOutflow_W))
                               << std::endl;
                 }
-                    break;
-                default: {
+                break;
+                default:
+                {
                 }
-                    break;
+                break;
             }
             for (size_t compFailModeIdx = 0;
                  compFailModeIdx < s.ComponentFailureModes.ComponentIds.size();
-                 ++compFailModeIdx) {
-                if (s.ComponentFailureModes.ComponentIds[compFailModeIdx] == i) {
+                 ++compFailModeIdx)
+            {
+                if (s.ComponentFailureModes.ComponentIds[compFailModeIdx] == i)
+                {
                     size_t fmId =
-                            s.ComponentFailureModes.FailureModeIds[compFailModeIdx];
+                        s.ComponentFailureModes.FailureModeIds[compFailModeIdx];
                     std::cout
-                            << "-- failure-mode: " << s.FailureModes.Tags[fmId]
-                            << "[" << fmId << "]" << std::endl;
+                        << "-- failure-mode: " << s.FailureModes.Tags[fmId]
+                        << "[" << fmId << "]" << std::endl;
                 }
             }
             for (size_t compFragIdx = 0;
                  compFragIdx < s.ComponentFragilities.ComponentIds.size();
-                 ++compFragIdx) {
-                if (s.ComponentFragilities.ComponentIds[compFragIdx] == i) {
+                 ++compFragIdx)
+            {
+                if (s.ComponentFragilities.ComponentIds[compFragIdx] == i)
+                {
                     size_t fmId =
-                            s.ComponentFragilities.FragilityModeIds[compFragIdx];
+                        s.ComponentFragilities.FragilityModeIds[compFragIdx];
                     std::cout
-                            << "-- fragility mode: " << s.FragilityModes.Tags[fmId]
-                            << "[" << fmId << "]" << std::endl;
+                        << "-- fragility mode: " << s.FragilityModes.Tags[fmId]
+                        << "[" << fmId << "]" << std::endl;
                 }
             }
         }
     }
 
     void
-    Simulation_PrintFragilityCurves(Simulation const &s) {
+    Simulation_PrintFragilityCurves(Simulation const& s)
+    {
         assert(
-                s.FragilityCurves.CurveId.size()
-                == s.FragilityCurves.CurveTypes.size()
+            s.FragilityCurves.CurveId.size()
+            == s.FragilityCurves.CurveTypes.size()
         );
         assert(
-                s.FragilityCurves.CurveId.size() == s.FragilityCurves.Tags.size()
+            s.FragilityCurves.CurveId.size() == s.FragilityCurves.Tags.size()
         );
-        for (size_t i = 0; i < s.FragilityCurves.CurveId.size(); ++i) {
+        for (size_t i = 0; i < s.FragilityCurves.CurveId.size(); ++i)
+        {
             std::cout << i << ": "
                       << FragilityCurveTypeToTag(s.FragilityCurves.CurveTypes[i]
-                      )
+                         )
                       << " -- " << s.FragilityCurves.Tags[i] << std::endl;
             size_t idx = s.FragilityCurves.CurveId[i];
-            switch (s.FragilityCurves.CurveTypes[i]) {
-                case (FragilityCurveType::Linear): {
+            switch (s.FragilityCurves.CurveTypes[i])
+            {
+                case (FragilityCurveType::Linear):
+                {
                     std::cout << "-- lower bound: "
                               << s.LinearFragilityCurves[idx].LowerBound
                               << std::endl;
@@ -371,68 +422,79 @@ namespace erin {
                               << s.LinearFragilityCurves[idx].UpperBound
                               << std::endl;
                     size_t intensityId =
-                            s.LinearFragilityCurves[idx].VulnerabilityId;
+                        s.LinearFragilityCurves[idx].VulnerabilityId;
                     std::cout << "-- vulnerable to: "
                               << s.Intensities.Tags[intensityId] << "["
                               << intensityId << "]" << std::endl;
                 }
-                    break;
-                case (FragilityCurveType::Tabular): {
+                break;
+                case (FragilityCurveType::Tabular):
+                {
                     size_t size =
-                            s.TabularFragilityCurves[idx].Intensities.size();
+                        s.TabularFragilityCurves[idx].Intensities.size();
                     size_t intensityId =
-                            s.TabularFragilityCurves[idx].VulnerabilityId;
-                    if (size > 0) {
+                        s.TabularFragilityCurves[idx].VulnerabilityId;
+                    if (size > 0)
+                    {
                         std::cout
-                                << "-- intensity from "
-                                << s.TabularFragilityCurves[idx].Intensities[0]
-                                << " to "
-                                << s.TabularFragilityCurves[idx]
-                                        .Intensities[size - 1]
-                                << std::endl;
+                            << "-- intensity from "
+                            << s.TabularFragilityCurves[idx].Intensities[0]
+                            << " to "
+                            << s.TabularFragilityCurves[idx]
+                                   .Intensities[size - 1]
+                            << std::endl;
                         std::cout << "-- vulnerable to: "
                                   << s.Intensities.Tags[intensityId] << "["
                                   << intensityId << "]" << std::endl;
                     }
                 }
-                    break;
-                default: {
+                break;
+                default:
+                {
                     std::cout << "unhandled fragility curve type" << std::endl;
                     std::exit(1);
                 }
-                    break;
+                break;
             }
         }
     }
 
     void
-    Simulation_PrintFailureModes(Simulation const &s) {
-        for (size_t i = 0; i < s.FailureModes.Tags.size(); ++i) {
+    Simulation_PrintFailureModes(Simulation const& s)
+    {
+        for (size_t i = 0; i < s.FailureModes.Tags.size(); ++i)
+        {
             auto maybeFailureDist = s.TheModel.DistSys.get_dist_by_id(
-                    s.FailureModes.FailureDistIds[i]
+                s.FailureModes.FailureDistIds[i]
             );
             auto maybeRepairDist = s.TheModel.DistSys.get_dist_by_id(
-                    s.FailureModes.RepairDistIds[i]
+                s.FailureModes.RepairDistIds[i]
             );
             std::cout << i << ": " << s.FailureModes.Tags[i] << std::endl;
-            if (maybeFailureDist.has_value()) {
+            if (maybeFailureDist.has_value())
+            {
                 Distribution failureDist = maybeFailureDist.value();
                 std::cout << "-- failure distribution: " << failureDist.Tag
                           << ", " << dist_type_to_tag(failureDist.Type) << "["
                           << s.FailureModes.FailureDistIds[i] << "]"
                           << std::endl;
-            } else {
+            }
+            else
+            {
                 std::cout << "-- ERROR! Problem finding failure distribution "
                           << " with id = " << s.FailureModes.FailureDistIds[i]
                           << std::endl;
             }
-            if (maybeRepairDist.has_value()) {
+            if (maybeRepairDist.has_value())
+            {
                 Distribution repairDist = maybeRepairDist.value();
                 std::cout << "-- repair distribution: " << repairDist.Tag
                           << ", " << dist_type_to_tag(repairDist.Type) << "["
                           << s.FailureModes.RepairDistIds[i] << "]"
                           << std::endl;
-            } else {
+            }
+            else
+            {
                 std::cout << "-- ERROR! Problem finding repair distribution "
                           << " with id = " << s.FailureModes.RepairDistIds[i]
                           << std::endl;
@@ -441,20 +503,24 @@ namespace erin {
     }
 
     void
-    Simulation_PrintFragilityModes(Simulation const &s) {
-        for (size_t i = 0; i < s.FragilityModes.Tags.size(); ++i) {
+    Simulation_PrintFragilityModes(Simulation const& s)
+    {
+        for (size_t i = 0; i < s.FragilityModes.Tags.size(); ++i)
+        {
             std::cout << i << ": " << s.FragilityModes.Tags[i] << std::endl;
             std::cout
-                    << "-- fragility curve: "
-                    << s.FragilityCurves.Tags[s.FragilityModes.FragilityCurveId[i]]
-                    << "[" << s.FragilityModes.FragilityCurveId[i] << "]"
-                    << std::endl;
-            if (s.FragilityModes.RepairDistIds[i].has_value()) {
+                << "-- fragility curve: "
+                << s.FragilityCurves.Tags[s.FragilityModes.FragilityCurveId[i]]
+                << "[" << s.FragilityModes.FragilityCurveId[i] << "]"
+                << std::endl;
+            if (s.FragilityModes.RepairDistIds[i].has_value())
+            {
                 std::optional<Distribution> maybeDist =
-                        s.TheModel.DistSys.get_dist_by_id(
-                                s.FragilityModes.RepairDistIds[i].value()
-                        );
-                if (maybeDist.has_value()) {
+                    s.TheModel.DistSys.get_dist_by_id(
+                        s.FragilityModes.RepairDistIds[i].value()
+                    );
+                if (maybeDist.has_value())
+                {
                     Distribution d = maybeDist.value();
                     std::cout << "-- repair dist: " << d.Tag << "["
                               << s.FragilityModes.RepairDistIds[i].value()
@@ -465,15 +531,18 @@ namespace erin {
     }
 
     void
-    Simulation_PrintScenarios(Simulation const &s) {
-        for (size_t i = 0; i < s.ScenarioMap.Tags.size(); ++i) {
+    Simulation_PrintScenarios(Simulation const& s)
+    {
+        for (size_t i = 0; i < s.ScenarioMap.Tags.size(); ++i)
+        {
             std::cout << i << ": " << s.ScenarioMap.Tags[i] << std::endl;
             std::cout << "- duration: " << s.ScenarioMap.Durations[i] << " "
                       << TimeUnitToTag(s.ScenarioMap.TimeUnits[i]) << std::endl;
             auto maybeDist = s.TheModel.DistSys.get_dist_by_id(
-                    s.ScenarioMap.OccurrenceDistributionIds[i]
+                s.ScenarioMap.OccurrenceDistributionIds[i]
             );
-            if (maybeDist.has_value()) {
+            if (maybeDist.has_value())
+            {
                 Distribution d = maybeDist.value();
                 std::cout << "- occurrence distribution: "
                           << dist_type_to_tag(d.Type) << "["
@@ -481,47 +550,56 @@ namespace erin {
                           << "] -- " << d.Tag << std::endl;
             }
             std::cout << "- max occurrences: ";
-            if (s.ScenarioMap.MaxOccurrences[i].has_value()) {
+            if (s.ScenarioMap.MaxOccurrences[i].has_value())
+            {
                 std::cout << s.ScenarioMap.MaxOccurrences[i].value()
                           << std::endl;
-            } else {
+            }
+            else
+            {
                 std::cout << "no limit" << std::endl;
             }
             bool printedHeader = false;
             for (size_t siIdx = 0;
                  siIdx < s.ScenarioIntensities.IntensityIds.size();
-                 ++siIdx) {
-                if (s.ScenarioIntensities.ScenarioIds[siIdx] == i) {
-                    if (!printedHeader) {
+                 ++siIdx)
+            {
+                if (s.ScenarioIntensities.ScenarioIds[siIdx] == i)
+                {
+                    if (!printedHeader)
+                    {
                         std::cout << "- intensities:" << std::endl;
                         printedHeader = true;
                     }
                     auto intId = s.ScenarioIntensities.IntensityIds[siIdx];
-                    auto const &intTag = s.Intensities.Tags[intId];
+                    auto const& intTag = s.Intensities.Tags[intId];
                     std::cout
-                            << "-- " << intTag << "[" << intId
-                            << "]: " << s.ScenarioIntensities.IntensityLevels[siIdx]
-                            << std::endl;
+                        << "-- " << intTag << "[" << intId
+                        << "]: " << s.ScenarioIntensities.IntensityLevels[siIdx]
+                        << std::endl;
                 }
             }
         }
     }
 
     void
-    Simulation_PrintLoads(Simulation const &s) {
-        for (size_t i = 0; i < s.LoadMap.Tags.size(); ++i) {
+    Simulation_PrintLoads(Simulation const& s)
+    {
+        for (size_t i = 0; i < s.LoadMap.Tags.size(); ++i)
+        {
             std::cout << i << ": " << s.LoadMap.Tags[i] << std::endl;
             std::cout << "- load entries: " << s.LoadMap.Loads[i].size()
                       << std::endl;
-            if (s.LoadMap.Loads[i].size() > 0) {
+            if (s.LoadMap.Loads[i].size() > 0)
+            {
                 // TODO: add time units
                 std::cout << "- initial time: " << s.LoadMap.Loads[i][0].Time_s
                           << std::endl;
                 // TODO: add time units
                 std::cout
-                        << "- final time  : "
-                        << s.LoadMap.Loads[i][s.LoadMap.Loads[i].size() - 1].Time_s
-                        << std::endl;
+                    << "- final time  : "
+                    << s.LoadMap.Loads[i][s.LoadMap.Loads[i].size() - 1].Time_s
+                    << std::endl;
                 // TODO: add max rate
                 // TODO: add min rate
                 // TODO: add average rate
@@ -537,57 +615,66 @@ namespace erin {
     }
 
     size_t
-    Simulation_ScenarioCount(Simulation const &s) {
+    Simulation_ScenarioCount(Simulation const& s)
+    {
         return s.ScenarioMap.Tags.size();
     }
 
     Result
     Simulation_ParseSimulationInfo(
-            Simulation &s,
-            toml::value const &v,
-            ValidationInfo const &validationInfo
-    ) {
-        if (!v.contains("simulation_info")) {
+        Simulation& s,
+        toml::value const& v,
+        ValidationInfo const& validationInfo
+    )
+    {
+        if (!v.contains("simulation_info"))
+        {
             WriteErrorMessage(
-                    "simulation_info",
-                    "Required section [simulation_info] not found"
+                "simulation_info",
+                "Required section [simulation_info] not found"
             );
             return Result::Failure;
         }
-        toml::value const &simInfoValue = v.at("simulation_info");
-        if (!simInfoValue.is_table()) {
+        toml::value const& simInfoValue = v.at("simulation_info");
+        if (!simInfoValue.is_table())
+        {
             WriteErrorMessage(
-                    "simulation_info",
-                    "Required section [simulation_info] is not a table"
+                "simulation_info",
+                "Required section [simulation_info] is not a table"
             );
             return Result::Failure;
         }
-        toml::table const &simInfoTable = simInfoValue.as_table();
+        toml::table const& simInfoTable = simInfoValue.as_table();
         std::vector<std::string> errors;
         std::vector<std::string> warnings;
-        std::unordered_map < std::string, InputValue > inputs =
-                                                  TOMLTable_ParseWithValidation(
-                                                          simInfoTable,
-                                                          validationInfo,
-                                                          "simulation_info",
-                                                          errors,
-                                                          warnings
-                                                  );
-        if (warnings.size() > 0) {
+        std::unordered_map<std::string, InputValue> inputs =
+            TOMLTable_ParseWithValidation(
+                simInfoTable,
+                validationInfo,
+                "simulation_info",
+                errors,
+                warnings
+            );
+        if (warnings.size() > 0)
+        {
             std::cout << "WARNINGS:" << std::endl;
-            for (auto const &w: warnings) {
+            for (auto const& w : warnings)
+            {
                 std::cerr << w << std::endl;
             }
         }
-        if (errors.size() > 0) {
+        if (errors.size() > 0)
+        {
             std::cout << "ERRORS:" << std::endl;
-            for (auto const &err: errors) {
+            for (auto const& err : errors)
+            {
                 std::cerr << err << std::endl;
             }
             return Result::Failure;
         }
         auto maybeSimInfo = ParseSimulationInfo(inputs);
-        if (!maybeSimInfo.has_value()) {
+        if (!maybeSimInfo.has_value())
+        {
             return Result::Failure;
         }
         s.Info = std::move(maybeSimInfo.value());
@@ -596,16 +683,18 @@ namespace erin {
 
     Result
     Simulation_ParseLoads(
-            Simulation &s,
-            toml::value const &v,
-            ValidationInfo const &explicitValidation,
-            ValidationInfo const &fileValidation
-    ) {
-        toml::value const &loadTable = v.at("loads");
+        Simulation& s,
+        toml::value const& v,
+        ValidationInfo const& explicitValidation,
+        ValidationInfo const& fileValidation
+    )
+    {
+        toml::value const& loadTable = v.at("loads");
         auto maybeLoads = ParseLoads(
-                loadTable.as_table(), explicitValidation, fileValidation
+            loadTable.as_table(), explicitValidation, fileValidation
         );
-        if (!maybeLoads.has_value()) {
+        if (!maybeLoads.has_value())
+        {
             return Result::Failure;
         }
         std::vector<Load> loads = std::move(maybeLoads.value());
@@ -616,21 +705,25 @@ namespace erin {
     // TODO: change this to a std::optional<size_t> GetFragilityCurveByTag()
     // if it returns !*.has_value(), register with the bogus data explicitly.
     size_t
-    Simulation_RegisterFragilityCurve(Simulation &s, std::string const &tag) {
+    Simulation_RegisterFragilityCurve(Simulation& s, std::string const& tag)
+    {
         return Simulation_RegisterFragilityCurve(
-                s, tag, FragilityCurveType::Linear, 0
+            s, tag, FragilityCurveType::Linear, 0
         );
     }
 
     size_t
     Simulation_RegisterFragilityCurve(
-            Simulation &s,
-            std::string const &tag,
-            FragilityCurveType curveType,
-            size_t curveIdx
-    ) {
-        for (size_t i = 0; i < s.FragilityCurves.Tags.size(); ++i) {
-            if (s.FragilityCurves.Tags[i] == tag) {
+        Simulation& s,
+        std::string const& tag,
+        FragilityCurveType curveType,
+        size_t curveIdx
+    )
+    {
+        for (size_t i = 0; i < s.FragilityCurves.Tags.size(); ++i)
+        {
+            if (s.FragilityCurves.Tags[i] == tag)
+            {
                 s.FragilityCurves.CurveId[i] = curveIdx;
                 s.FragilityCurves.CurveTypes[i] = curveType;
                 return i;
@@ -645,14 +738,17 @@ namespace erin {
 
     size_t
     Simulation_RegisterFailureMode(
-            Simulation &s,
-            std::string const &tag,
-            size_t failureId,
-            size_t repairId
-    ) {
+        Simulation& s,
+        std::string const& tag,
+        size_t failureId,
+        size_t repairId
+    )
+    {
         size_t size = s.FailureModes.Tags.size();
-        for (size_t i = 0; i < size; ++i) {
-            if (s.FailureModes.Tags[i] == tag) {
+        for (size_t i = 0; i < size; ++i)
+        {
+            if (s.FailureModes.Tags[i] == tag)
+            {
                 s.FailureModes.FailureDistIds[i] = failureId;
                 s.FailureModes.RepairDistIds[i] = repairId;
                 return i;
@@ -667,14 +763,17 @@ namespace erin {
 
     size_t
     Simulation_RegisterFragilityMode(
-            Simulation &s,
-            std::string const &tag,
-            size_t fragilityCurveId,
-            std::optional<size_t> maybeRepairDistId
-    ) {
+        Simulation& s,
+        std::string const& tag,
+        size_t fragilityCurveId,
+        std::optional<size_t> maybeRepairDistId
+    )
+    {
         size_t size = s.FragilityModes.Tags.size();
-        for (size_t i = 0; i < size; ++i) {
-            if (s.FragilityModes.Tags[i] == tag) {
+        for (size_t i = 0; i < size; ++i)
+        {
+            if (s.FragilityModes.Tags[i] == tag)
+            {
                 s.FragilityModes.FragilityCurveId[i] = fragilityCurveId;
                 s.FragilityModes.RepairDistIds[i] = maybeRepairDistId;
                 return i;
@@ -689,29 +788,33 @@ namespace erin {
 
     std::optional<size_t>
     Parse_VulnerableTo(
-            Simulation const &s,
-            toml::table const &fcData,
-            std::string const &tableFullName
-    ) {
-        if (!fcData.contains("vulnerable_to")) {
+        Simulation const& s,
+        toml::table const& fcData,
+        std::string const& tableFullName
+    )
+    {
+        if (!fcData.contains("vulnerable_to"))
+        {
             WriteErrorMessage(
-                    tableFullName, "missing required field 'vulnerable_to'"
+                tableFullName, "missing required field 'vulnerable_to'"
             );
             return {};
         }
-        if (!fcData.at("vulnerable_to").is_string()) {
+        if (!fcData.at("vulnerable_to").is_string())
+        {
             WriteErrorMessage(
-                    tableFullName, "field 'vulnerable_to' not a string"
+                tableFullName, "field 'vulnerable_to' not a string"
             );
             return {};
         }
-        std::string const &vulnerStr = fcData.at("vulnerable_to").as_string();
+        std::string const& vulnerStr = fcData.at("vulnerable_to").as_string();
         std::optional<size_t> maybeIntId =
-                GetIntensityIdByTag(s.Intensities, vulnerStr);
-        if (!maybeIntId.has_value()) {
+            GetIntensityIdByTag(s.Intensities, vulnerStr);
+        if (!maybeIntId.has_value())
+        {
             WriteErrorMessage(
-                    tableFullName,
-                    "could not find referenced intensity '" + vulnerStr
+                tableFullName,
+                "could not find referenced intensity '" + vulnerStr
                     + "' for 'vulnerable_to'"
             );
             return {};
@@ -721,52 +824,60 @@ namespace erin {
 
     Result
     Simulation_ParseLinearFragilityCurve(
-            Simulation &s,
-            std::string const &fcName,
-            std::string const &tableFullName,
-            toml::table const &fcData
-    ) {
-        if (!fcData.contains("lower_bound")) {
+        Simulation& s,
+        std::string const& fcName,
+        std::string const& tableFullName,
+        toml::table const& fcData
+    )
+    {
+        if (!fcData.contains("lower_bound"))
+        {
             std::cout << "[" << tableFullName << "] "
                       << "missing required field 'lower_bound'" << std::endl;
             return Result::Failure;
         }
         if (!(fcData.at("lower_bound").is_floating()
-              || fcData.at("lower_bound").is_integer())) {
+              || fcData.at("lower_bound").is_integer()))
+        {
             std::cout << "[" << tableFullName << "] "
                       << "field 'lower_bound' not a number" << std::endl;
             return Result::Failure;
         }
         std::optional<double> maybeLowerBound =
-                TOMLTable_ParseDouble(fcData, "lower_bound", tableFullName);
-        if (!maybeLowerBound.has_value()) {
+            TOMLTable_ParseDouble(fcData, "lower_bound", tableFullName);
+        if (!maybeLowerBound.has_value())
+        {
             std::cout << "[" << tableFullName << "] "
                       << "field 'lower_bound' has no value" << std::endl;
             return Result::Failure;
         }
         double lowerBound = maybeLowerBound.value();
-        if (!fcData.contains("upper_bound")) {
+        if (!fcData.contains("upper_bound"))
+        {
             std::cout << "[" << tableFullName << "] "
                       << "missing required field 'upper_bound'" << std::endl;
             return Result::Failure;
         }
         if (!(fcData.at("upper_bound").is_floating()
-              || fcData.at("upper_bound").is_integer())) {
+              || fcData.at("upper_bound").is_integer()))
+        {
             std::cout << "[" << tableFullName << "] "
                       << "field 'upper_bound' not a number" << std::endl;
             return Result::Failure;
         }
         std::optional<double> maybeUpperBound =
-                TOMLTable_ParseDouble(fcData, "upper_bound", tableFullName);
-        if (!maybeUpperBound.has_value()) {
+            TOMLTable_ParseDouble(fcData, "upper_bound", tableFullName);
+        if (!maybeUpperBound.has_value())
+        {
             std::cout << "[" << tableFullName << "] "
                       << "field 'upper_bound' has no value" << std::endl;
             return Result::Failure;
         }
         double upperBound = maybeUpperBound.value();
         std::optional<size_t> maybeIntId =
-                Parse_VulnerableTo(s, fcData, tableFullName);
-        if (!maybeIntId.has_value()) {
+            Parse_VulnerableTo(s, fcData, tableFullName);
+        if (!maybeIntId.has_value())
+        {
             return Result::Failure;
         }
         size_t intensityId = maybeIntId.value();
@@ -777,64 +888,77 @@ namespace erin {
         size_t idx = s.LinearFragilityCurves.size();
         s.LinearFragilityCurves.push_back(std::move(lfc));
         Simulation_RegisterFragilityCurve(
-                s, fcName, FragilityCurveType::Linear, idx
+            s, fcName, FragilityCurveType::Linear, idx
         );
         return Result::Success;
     }
 
     Result
-    Simulation_ParseFragilityCurves(Simulation &s, toml::value const &v) {
-        if (v.contains("fragility_curve")) {
-            if (!v.at("fragility_curve").is_table()) {
+    Simulation_ParseFragilityCurves(Simulation& s, toml::value const& v)
+    {
+        if (v.contains("fragility_curve"))
+        {
+            if (!v.at("fragility_curve").is_table())
+            {
                 std::cout << "[fragility_curve] not a table" << std::endl;
                 return Result::Failure;
             }
-            for (auto const &pair: v.at("fragility_curve").as_table()) {
-                std::string const &fcName = pair.first;
+            for (auto const& pair : v.at("fragility_curve").as_table())
+            {
+                std::string const& fcName = pair.first;
                 std::string tableFullName = "fragility_curve." + fcName;
-                if (!pair.second.is_table()) {
+                if (!pair.second.is_table())
+                {
                     std::cout << "[" << tableFullName << "] not a table"
                               << std::endl;
                     return Result::Failure;
                 }
-                toml::table const &fcData = pair.second.as_table();
-                if (!fcData.contains("type")) {
+                toml::table const& fcData = pair.second.as_table();
+                if (!fcData.contains("type"))
+                {
                     std::cout << "[" << tableFullName << "] "
                               << "does not contain required value 'type'"
                               << std::endl;
                     return Result::Failure;
                 }
-                std::string const &typeStr = fcData.at("type").as_string();
+                std::string const& typeStr = fcData.at("type").as_string();
                 std::optional<FragilityCurveType> maybeFct =
-                        TagToFragilityCurveType(typeStr);
-                if (!maybeFct.has_value()) {
+                    TagToFragilityCurveType(typeStr);
+                if (!maybeFct.has_value())
+                {
                     std::cout << "[" << tableFullName << "] "
                               << "could not interpret type as string"
                               << std::endl;
                     return Result::Failure;
                 }
                 FragilityCurveType fct = maybeFct.value();
-                switch (fct) {
-                    case (FragilityCurveType::Linear): {
+                switch (fct)
+                {
+                    case (FragilityCurveType::Linear):
+                    {
                         if (Simulation_ParseLinearFragilityCurve(
                                 s, fcName, tableFullName, fcData
-                        )
-                            == Result::Failure) {
+                            )
+                            == Result::Failure)
+                        {
                             return Result::Failure;
                         }
                     }
-                        break;
-                    case (FragilityCurveType::Tabular): {
+                    break;
+                    case (FragilityCurveType::Tabular):
+                    {
                         std::optional<size_t> maybeIntId =
-                                Parse_VulnerableTo(s, fcData, tableFullName);
-                        if (!maybeIntId.has_value()) {
+                            Parse_VulnerableTo(s, fcData, tableFullName);
+                        if (!maybeIntId.has_value())
+                        {
                             return Result::Failure;
                         }
                         size_t intensityId = maybeIntId.value();
                         auto maybePairs = TOMLTable_ParseArrayOfPairsOfDouble(
-                                fcData, "intensity_failure_pairs", tableFullName
+                            fcData, "intensity_failure_pairs", tableFullName
                         );
-                        if (!maybePairs.has_value()) {
+                        if (!maybePairs.has_value())
+                        {
                             return Result::Failure;
                         }
                         PairsVector pv = maybePairs.value();
@@ -845,18 +969,19 @@ namespace erin {
                         size_t subtypeIdx = s.TabularFragilityCurves.size();
                         s.TabularFragilityCurves.push_back(std::move(tfc));
                         Simulation_RegisterFragilityCurve(
-                                s, fcName, FragilityCurveType::Tabular, subtypeIdx
+                            s, fcName, FragilityCurveType::Tabular, subtypeIdx
                         );
                     }
-                        break;
-                    default: {
+                    break;
+                    default:
+                    {
                         WriteErrorMessage(
-                                tableFullName,
-                                "unhandled fragility curve type '" + typeStr + "'"
+                            tableFullName,
+                            "unhandled fragility curve type '" + typeStr + "'"
                         );
                         std::exit(1);
                     }
-                        break;
+                    break;
                 }
             }
         }
@@ -864,9 +989,12 @@ namespace erin {
     }
 
     bool
-    Simulation_IsFailureModeNameUnique(Simulation &s, std::string const &name) {
-        for (size_t i = 0; i < s.FailureModes.Tags.size(); ++i) {
-            if (s.FailureModes.Tags[i] == name) {
+    Simulation_IsFailureModeNameUnique(Simulation& s, std::string const& name)
+    {
+        for (size_t i = 0; i < s.FailureModes.Tags.size(); ++i)
+        {
+            if (s.FailureModes.Tags[i] == name)
+            {
                 return false;
             }
         }
@@ -874,9 +1002,12 @@ namespace erin {
     }
 
     bool
-    Simulation_IsFragilityModeNameUnique(Simulation &s, std::string const &name) {
-        for (size_t i = 0; i < s.FragilityModes.Tags.size(); ++i) {
-            if (s.FragilityModes.Tags[i] == name) {
+    Simulation_IsFragilityModeNameUnique(Simulation& s, std::string const& name)
+    {
+        for (size_t i = 0; i < s.FragilityModes.Tags.size(); ++i)
+        {
+            if (s.FragilityModes.Tags[i] == name)
+            {
                 return false;
             }
         }
@@ -884,73 +1015,84 @@ namespace erin {
     }
 
     bool
-    Simulation_IsFailureNameUnique(Simulation &s, std::string const &name) {
+    Simulation_IsFailureNameUnique(Simulation& s, std::string const& name)
+    {
         return Simulation_IsFailureModeNameUnique(s, name)
-               && Simulation_IsFragilityModeNameUnique(s, name);
+            && Simulation_IsFragilityModeNameUnique(s, name);
     }
 
     Result
-    Simulation_ParseFailureModes(Simulation &s, toml::value const &v) {
-        if (v.contains("failure_mode")) {
-            if (!v.at("failure_mode").is_table()) {
+    Simulation_ParseFailureModes(Simulation& s, toml::value const& v)
+    {
+        if (v.contains("failure_mode"))
+        {
+            if (!v.at("failure_mode").is_table())
+            {
                 WriteErrorMessage(
-                        "failure_mode", "failure_mode section must be a table"
+                    "failure_mode", "failure_mode section must be a table"
                 );
                 return Result::Failure;
             }
-            toml::table const &fmTable = v.at("failure_mode").as_table();
-            for (auto const &pair: fmTable) {
-                std::string const &fmName = pair.first;
+            toml::table const& fmTable = v.at("failure_mode").as_table();
+            for (auto const& pair : fmTable)
+            {
+                std::string const& fmName = pair.first;
                 std::string const fullName = "failue_mode." + fmName;
-                if (!Simulation_IsFragilityModeNameUnique(s, fmName)) {
+                if (!Simulation_IsFragilityModeNameUnique(s, fmName))
+                {
                     WriteErrorMessage(
-                            fmName,
-                            "failure mode name must be unique within both "
-                            "failure_mode and fragility_mode names"
+                        fmName,
+                        "failure mode name must be unique within both "
+                        "failure_mode and fragility_mode names"
                     );
                     return Result::Failure;
                 }
-                if (!pair.second.is_table()) {
+                if (!pair.second.is_table())
+                {
                     WriteErrorMessage(fullName, "value must be a table");
                     return Result::Failure;
                 }
-                toml::table const &fmValueTable = pair.second.as_table();
-                if (!fmValueTable.contains("failure_dist")) {
+                toml::table const& fmValueTable = pair.second.as_table();
+                if (!fmValueTable.contains("failure_dist"))
+                {
                     WriteErrorMessage(
-                            fullName, "missing required field 'failure_dist'"
+                        fullName, "missing required field 'failure_dist'"
                     );
                     return Result::Failure;
                 }
                 auto maybeFailureDistTag = TOMLTable_ParseString(
-                        fmValueTable, "failure_dist", fullName
+                    fmValueTable, "failure_dist", fullName
                 );
-                if (!maybeFailureDistTag.has_value()) {
+                if (!maybeFailureDistTag.has_value())
+                {
                     WriteErrorMessage(
-                            fullName, "could not parse 'failure_dist' as string"
+                        fullName, "could not parse 'failure_dist' as string"
                     );
                     return Result::Failure;
                 }
-                std::string const &failureDistTag = maybeFailureDistTag.value();
-                if (!fmValueTable.contains("repair_dist")) {
+                std::string const& failureDistTag = maybeFailureDistTag.value();
+                if (!fmValueTable.contains("repair_dist"))
+                {
                     WriteErrorMessage(
-                            fullName, "missing required field 'repair_dist'"
+                        fullName, "missing required field 'repair_dist'"
                     );
                     return Result::Failure;
                 }
                 auto maybeRepairDistTag = TOMLTable_ParseString(
-                        fmValueTable, "repair_dist", fullName
+                    fmValueTable, "repair_dist", fullName
                 );
-                if (!maybeRepairDistTag.has_value()) {
+                if (!maybeRepairDistTag.has_value())
+                {
                     WriteErrorMessage(
-                            fullName, "could not parse 'repair_dist' as string"
+                        fullName, "could not parse 'repair_dist' as string"
                     );
                     return Result::Failure;
                 }
-                std::string const &repairDistTag = maybeRepairDistTag.value();
+                std::string const& repairDistTag = maybeRepairDistTag.value();
                 size_t failureId =
-                        s.TheModel.DistSys.lookup_dist_by_tag(failureDistTag);
+                    s.TheModel.DistSys.lookup_dist_by_tag(failureDistTag);
                 size_t repairId =
-                        s.TheModel.DistSys.lookup_dist_by_tag(repairDistTag);
+                    s.TheModel.DistSys.lookup_dist_by_tag(repairDistTag);
                 Simulation_RegisterFailureMode(s, fmName, failureId, repairId);
             }
         }
@@ -958,60 +1100,70 @@ namespace erin {
     }
 
     Result
-    Simulation_ParseFragilityModes(Simulation &s, toml::value const &v) {
-        if (v.contains("fragility_mode")) {
-            if (!v.at("fragility_mode").is_table()) {
+    Simulation_ParseFragilityModes(Simulation& s, toml::value const& v)
+    {
+        if (v.contains("fragility_mode"))
+        {
+            if (!v.at("fragility_mode").is_table())
+            {
                 return Result::Failure;
             }
-            toml::table const &fmTable = v.at("fragility_mode").as_table();
-            for (auto const &pair: fmTable) {
-                std::string const &fmName = pair.first;
+            toml::table const& fmTable = v.at("fragility_mode").as_table();
+            for (auto const& pair : fmTable)
+            {
+                std::string const& fmName = pair.first;
                 std::string const fullName = "fragility_mode." + fmName;
-                if (!Simulation_IsFailureModeNameUnique(s, fmName)) {
+                if (!Simulation_IsFailureModeNameUnique(s, fmName))
+                {
                     WriteErrorMessage(
-                            fullName,
-                            "fragility mode name must be unique within both "
-                            "failure_mode and fragility_mode names"
+                        fullName,
+                        "fragility mode name must be unique within both "
+                        "failure_mode and fragility_mode names"
                     );
                     return Result::Failure;
                 }
-                if (!pair.second.is_table()) {
+                if (!pair.second.is_table())
+                {
                     WriteErrorMessage(
-                            fullName, "fragility_mode section must be a table"
+                        fullName, "fragility_mode section must be a table"
                     );
                     return Result::Failure;
                 }
-                toml::table const &fmValueTable = pair.second.as_table();
-                if (!fmValueTable.contains("fragility_curve")) {
+                toml::table const& fmValueTable = pair.second.as_table();
+                if (!fmValueTable.contains("fragility_curve"))
+                {
                     WriteErrorMessage(
-                            fullName, "missing required field 'fragility_curve'"
+                        fullName, "missing required field 'fragility_curve'"
                     );
                     return Result::Failure;
                 }
-                if (!fmValueTable.at("fragility_curve").is_string()) {
+                if (!fmValueTable.at("fragility_curve").is_string())
+                {
                     WriteErrorMessage(
-                            fullName, "'fragility_curve' field must be a string"
+                        fullName, "'fragility_curve' field must be a string"
                     );
                     return Result::Failure;
                 }
-                std::string const &fcTag =
-                        fmValueTable.at("fragility_curve").as_string();
+                std::string const& fcTag =
+                    fmValueTable.at("fragility_curve").as_string();
                 size_t fcId = Simulation_RegisterFragilityCurve(s, fcTag);
                 std::optional<size_t> maybeRepairDistId = {};
-                if (fmValueTable.contains("repair_dist")) {
-                    if (!fmValueTable.at("repair_dist").is_string()) {
+                if (fmValueTable.contains("repair_dist"))
+                {
+                    if (!fmValueTable.at("repair_dist").is_string())
+                    {
                         WriteErrorMessage(
-                                fullName, "field 'repair_dist' must be a string"
+                            fullName, "field 'repair_dist' must be a string"
                         );
                         return Result::Failure;
                     }
-                    std::string const &repairDistTag =
-                            fmValueTable.at("repair_dist").as_string();
+                    std::string const& repairDistTag =
+                        fmValueTable.at("repair_dist").as_string();
                     maybeRepairDistId =
-                            s.TheModel.DistSys.lookup_dist_by_tag(repairDistTag);
+                        s.TheModel.DistSys.lookup_dist_by_tag(repairDistTag);
                 }
                 Simulation_RegisterFragilityMode(
-                        s, fmName, fcId, maybeRepairDistId
+                    s, fmName, fcId, maybeRepairDistId
                 );
             }
         }
@@ -1020,17 +1172,19 @@ namespace erin {
 
     Result
     Simulation_ParseComponents(
-            Simulation &s,
-            toml::value const &v,
-            ComponentValidationMap const &compValidations,
-            std::unordered_set<std::string> const &componentTagsInUse
-    ) {
-        if (v.contains("components") && v.at("components").is_table()) {
+        Simulation& s,
+        toml::value const& v,
+        ComponentValidationMap const& compValidations,
+        std::unordered_set<std::string> const& componentTagsInUse
+    )
+    {
+        if (v.contains("components") && v.at("components").is_table())
+        {
             return ParseComponents(
-                    s,
-                    v.at("components").as_table(),
-                    compValidations,
-                    componentTagsInUse
+                s,
+                v.at("components").as_table(),
+                compValidations,
+                componentTagsInUse
             );
         }
         WriteErrorMessage("<top>", "required field 'components' not found");
@@ -1039,14 +1193,16 @@ namespace erin {
 
     Result
     Simulation_ParseDistributions(
-            Simulation &s,
-            toml::value const &v,
-            DistributionValidationMap const &dvm
-    ) {
-        if (v.contains("dist") && v.at("dist").is_table()) {
+        Simulation& s,
+        toml::value const& v,
+        DistributionValidationMap const& dvm
+    )
+    {
+        if (v.contains("dist") && v.at("dist").is_table())
+        {
             // TODO: have ParseDistributions return a Result
             return ParseDistributions(
-                    s.TheModel.DistSys, v.at("dist").as_table(), dvm
+                s.TheModel.DistSys, v.at("dist").as_table(), dvm
             );
         }
         std::cout << "required field 'dist' not found" << std::endl;
@@ -1054,30 +1210,39 @@ namespace erin {
     }
 
     Result
-    Simulation_ParseNetwork(Simulation &s, toml::value const &v) {
+    Simulation_ParseNetwork(Simulation& s, toml::value const& v)
+    {
         std::string const n = "network";
-        if (v.contains(n) && v.at(n).is_table()) {
+        if (v.contains(n) && v.at(n).is_table())
+        {
             return ParseNetwork(s.FlowTypeMap, s.TheModel, v.at(n).as_table());
-        } else {
+        }
+        else
+        {
             std::cout << "required field '" << n << "' not found" << std::endl;
             return Result::Failure;
         }
     }
 
     Result
-    Simulation_ParseScenarios(Simulation &s, toml::value const &v) {
-        if (v.contains("scenarios") && v.at("scenarios").is_table()) {
+    Simulation_ParseScenarios(Simulation& s, toml::value const& v)
+    {
+        if (v.contains("scenarios") && v.at("scenarios").is_table())
+        {
             auto result = ParseScenarios(
-                    s.ScenarioMap, s.TheModel.DistSys, v.at("scenarios").as_table()
+                s.ScenarioMap, s.TheModel.DistSys, v.at("scenarios").as_table()
             );
-            if (result == Result::Success) {
-                for (auto const &pair: v.at("scenarios").as_table()) {
-                    std::string const &scenarioName = pair.first;
+            if (result == Result::Success)
+            {
+                for (auto const& pair : v.at("scenarios").as_table())
+                {
+                    std::string const& scenarioName = pair.first;
                     std::optional<size_t> maybeScenarioId =
-                            ScenarioDict_GetScenarioByTag(
-                                    s.ScenarioMap, scenarioName
-                            );
-                    if (!maybeScenarioId.has_value()) {
+                        ScenarioDict_GetScenarioByTag(
+                            s.ScenarioMap, scenarioName
+                        );
+                    if (!maybeScenarioId.has_value())
+                    {
                         std::cout << "[scenarios] "
                                   << "could not find scenario id for '"
                                   << scenarioName << "'" << std::endl;
@@ -1085,29 +1250,35 @@ namespace erin {
                     }
                     size_t scenarioId = maybeScenarioId.value();
                     std::string fullName = "scenarios." + scenarioName;
-                    if (!pair.second.is_table()) {
+                    if (!pair.second.is_table())
+                    {
                         std::cout << "[" << fullName << "] "
                                   << "must be a table" << std::endl;
                     }
-                    toml::table const &data = pair.second.as_table();
-                    if (data.contains("intensity")) {
-                        if (!data.at("intensity").is_table()) {
+                    toml::table const& data = pair.second.as_table();
+                    if (data.contains("intensity"))
+                    {
+                        if (!data.at("intensity").is_table())
+                        {
                             std::cout << "[" << fullName << ".intensity] "
                                       << "must be a table" << std::endl;
                             return Result::Failure;
                         }
-                        for (auto const &p: data.at("intensity").as_table()) {
-                            std::string const &intensityTag = p.first;
+                        for (auto const& p : data.at("intensity").as_table())
+                        {
+                            std::string const& intensityTag = p.first;
                             if (!(p.second.is_integer()
-                                  || p.second.is_floating())) {
+                                  || p.second.is_floating()))
+                            {
                                 std::cout << "[" << fullName << ".intensity."
                                           << intensityTag << "] "
                                           << "must be a number" << std::endl;
                                 return Result::Failure;
                             }
                             std::optional<double> maybeValue =
-                                    TOML_ParseNumericValueAsDouble(p.second);
-                            if (!maybeValue.has_value()) {
+                                TOML_ParseNumericValueAsDouble(p.second);
+                            if (!maybeValue.has_value())
+                            {
                                 std::cout << "[" << fullName << ".intensity."
                                           << intensityTag << "] "
                                           << "must be a number" << std::endl;
@@ -1115,9 +1286,9 @@ namespace erin {
                             }
                             double value = maybeValue.value();
                             size_t intensityId =
-                                    Simulation_RegisterIntensity(s, intensityTag);
+                                Simulation_RegisterIntensity(s, intensityTag);
                             Simulation_RegisterIntensityLevelForScenario(
-                                    s, scenarioId, intensityId, value
+                                s, scenarioId, intensityId, value
                             );
                         }
                     }
@@ -1132,58 +1303,68 @@ namespace erin {
 
     std::optional<Simulation>
     Simulation_ReadFromToml(
-            toml::value const &v,
-            InputValidationMap const &validationInfo,
-            std::unordered_set<std::string> const &componentTagsInUse
-    ) {
+        toml::value const& v,
+        InputValidationMap const& validationInfo,
+        std::unordered_set<std::string> const& componentTagsInUse
+    )
+    {
         Simulation s = {};
         Simulation_Init(s);
         auto simInfoResult =
-                Simulation_ParseSimulationInfo(s, v, validationInfo.SimulationInfo);
-        if (simInfoResult == Result::Failure) {
+            Simulation_ParseSimulationInfo(s, v, validationInfo.SimulationInfo);
+        if (simInfoResult == Result::Failure)
+        {
             WriteErrorMessage("simulation_info", "problem parsing...");
             return {};
         }
         auto loadsResult = Simulation_ParseLoads(
-                s,
-                v,
-                validationInfo.Load_01Explicit,
-                validationInfo.Load_02FileBased
+            s,
+            v,
+            validationInfo.Load_01Explicit,
+            validationInfo.Load_02FileBased
         );
-        if (loadsResult == Result::Failure) {
+        if (loadsResult == Result::Failure)
+        {
             WriteErrorMessage("loads", "problem parsing...");
             return {};
         }
         auto compResult = Simulation_ParseComponents(
-                s, v, validationInfo.Comp, componentTagsInUse
+            s, v, validationInfo.Comp, componentTagsInUse
         );
-        if (compResult == Result::Failure) {
+        if (compResult == Result::Failure)
+        {
             WriteErrorMessage("components", "problem parsing...");
             return {};
         }
         auto distResult =
-                Simulation_ParseDistributions(s, v, validationInfo.Dist);
-        if (distResult == Result::Failure) {
+            Simulation_ParseDistributions(s, v, validationInfo.Dist);
+        if (distResult == Result::Failure)
+        {
             WriteErrorMessage("dist", "problem parsing...");
             return {};
         }
-        if (Simulation_ParseFailureModes(s, v) == Result::Failure) {
+        if (Simulation_ParseFailureModes(s, v) == Result::Failure)
+        {
             WriteErrorMessage("failure_mode", "problem parsing...");
             return {};
         }
-        if (Simulation_ParseFragilityModes(s, v) == Result::Failure) {
+        if (Simulation_ParseFragilityModes(s, v) == Result::Failure)
+        {
             WriteErrorMessage("fragility_mode", "problem parsing...");
             return {};
         }
-        if (Simulation_ParseNetwork(s, v) == Result::Failure) {
+        if (Simulation_ParseNetwork(s, v) == Result::Failure)
+        {
             WriteErrorMessage("network", "problem parsing...");
             return {};
         }
-        if (Simulation_ParseScenarios(s, v) == Result::Failure) {
+        if (Simulation_ParseScenarios(s, v) == Result::Failure)
+        {
             WriteErrorMessage("scenarios", "problem parsing...");
             return {};
         }
-        if (Simulation_ParseFragilityCurves(s, v) == Result::Failure) {
+        if (Simulation_ParseFragilityCurves(s, v) == Result::Failure)
+        {
             WriteErrorMessage("fragility_curve", "problem parsing...");
             return {};
         }
@@ -1191,7 +1372,8 @@ namespace erin {
     }
 
     void
-    Simulation_Print(Simulation const &s) {
+    Simulation_Print(Simulation const& s)
+    {
         std::cout << "-----------------" << std::endl;
         std::cout << s.Info << std::endl;
         std::cout << "\nLoads:" << std::endl;
@@ -1215,48 +1397,56 @@ namespace erin {
     }
 
     void
-    Simulation_PrintIntensities(Simulation const &s) {
-        for (size_t i = 0; i < s.Intensities.Tags.size(); ++i) {
+    Simulation_PrintIntensities(Simulation const& s)
+    {
+        for (size_t i = 0; i < s.Intensities.Tags.size(); ++i)
+        {
             std::cout << i << ": " << s.Intensities.Tags[i] << std::endl;
         }
     }
 
     void
     WriteEventFileHeader(
-            std::ofstream &out,
-            Model const &m,
-            FlowDict const &fd,
-            std::vector<size_t> const &connOrder,
-            std::vector<size_t> const &storeOrder,
-            std::vector<size_t> const &compOrder,
-            TimeUnit outputTimeUnit
-    ) {
-        ComponentDict const &compMap = m.ComponentMap;
-        std::vector<Connection> const &conns = m.Connections;
+        std::ofstream& out,
+        Model const& m,
+        FlowDict const& fd,
+        std::vector<size_t> const& connOrder,
+        std::vector<size_t> const& storeOrder,
+        std::vector<size_t> const& compOrder,
+        TimeUnit outputTimeUnit
+    )
+    {
+        ComponentDict const& compMap = m.ComponentMap;
+        std::vector<Connection> const& conns = m.Connections;
         out << "scenario id,"
             << "scenario start time (P[YYYY]-[MM]-[DD]T[hh]:[mm]:[ss]),"
             << "elapsed ("
             << (outputTimeUnit == TimeUnit::Hour
-                ? "hours"
-                : TimeUnitToTag(outputTimeUnit))
+                    ? "hours"
+                    : TimeUnitToTag(outputTimeUnit))
             << ")";
-        for (std::string const &prefix:
-                std::vector<std::string>{"", "REQUEST:", "AVAILABLE:"}) {
-            for (auto const &connId: connOrder) {
-                auto const &conn = conns[connId];
+        for (std::string const& prefix :
+             std::vector<std::string>{"", "REQUEST:", "AVAILABLE:"})
+        {
+            for (auto const& connId : connOrder)
+            {
+                auto const& conn = conns[connId];
                 out << "," << prefix
                     << ConnectionToString(compMap, fd, conn, true) << " (kW)";
             }
         }
-        for (std::pair<std::string, std::string> const &prePostFix:
-                std::vector<std::pair<std::string, std::string>>{
-                        {"Stored: ", " (kJ)"},
-                        {"SOC: ",    ""}
-                }) {
-            for (size_t storeIdx: storeOrder) {
-                for (size_t compId = 0; compId < compMap.Tag.size(); ++compId) {
+        for (std::pair<std::string, std::string> const& prePostFix :
+             std::vector<std::pair<std::string, std::string>>{
+                 {"Stored: ", " (kJ)"}, {"SOC: ", ""}
+             })
+        {
+            for (size_t storeIdx : storeOrder)
+            {
+                for (size_t compId = 0; compId < compMap.Tag.size(); ++compId)
+                {
                     if (compMap.CompType[compId] == ComponentType::StoreType
-                        && compMap.Idx[compId] == storeIdx) {
+                        && compMap.Idx[compId] == storeIdx)
+                    {
                         out << "," << prePostFix.first << compMap.Tag[compId]
                             << prePostFix.second;
                     }
@@ -1264,8 +1454,10 @@ namespace erin {
             }
         }
         // op-state: <component-name>
-        for (size_t compId: compOrder) {
-            if (!m.ComponentMap.Tag[compId].empty()) {
+        for (size_t compId : compOrder)
+        {
+            if (!m.ComponentMap.Tag[compId].empty())
+            {
                 out << ",op-state: " << m.ComponentMap.Tag[compId];
             }
         }
@@ -1273,7 +1465,8 @@ namespace erin {
     }
 
     std::vector<size_t>
-    CalculateConnectionOrder(Simulation const &s) {
+    CalculateConnectionOrder(Simulation const& s)
+    {
         // TODO: need to enforce connections are unique
         size_t const numConns = s.TheModel.Connections.size();
         std::vector<size_t> result;
@@ -1282,17 +1475,21 @@ namespace erin {
         result.reserve(numConns);
         originalConnTags.reserve(numConns);
         connTags.reserve(numConns);
-        for (auto const &conn: s.TheModel.Connections) {
+        for (auto const& conn : s.TheModel.Connections)
+        {
             std::string connTag =
-                    ConnectionToString(s.TheModel.ComponentMap, conn, true);
+                ConnectionToString(s.TheModel.ComponentMap, conn, true);
             originalConnTags.push_back(connTag);
             connTags.push_back(connTag);
         }
         std::sort(connTags.begin(), connTags.end());
-        for (auto const &connTag: connTags) {
+        for (auto const& connTag : connTags)
+        {
             for (size_t connId = 0; connId < s.TheModel.Connections.size();
-                 ++connId) {
-                if (connTag == originalConnTags[connId]) {
+                 ++connId)
+            {
+                if (connTag == originalConnTags[connId])
+                {
                     result.push_back(connId);
                     break;
                 }
@@ -1303,16 +1500,20 @@ namespace erin {
     }
 
     std::vector<size_t>
-    CalculateScenarioOrder(Simulation const &s) {
+    CalculateScenarioOrder(Simulation const& s)
+    {
         std::vector<size_t> result;
         std::vector<std::string> scenarioTags(s.ScenarioMap.Tags);
         size_t numScenarios = s.ScenarioMap.Tags.size();
         std::sort(scenarioTags.begin(), scenarioTags.end());
         result.reserve(numScenarios);
-        for (std::string const &tag: scenarioTags) {
+        for (std::string const& tag : scenarioTags)
+        {
             for (size_t scenarioId = 0; scenarioId < s.ScenarioMap.Tags.size();
-                 ++scenarioId) {
-                if (tag == s.ScenarioMap.Tags[scenarioId]) {
+                 ++scenarioId)
+            {
+                if (tag == s.ScenarioMap.Tags[scenarioId])
+                {
                     result.push_back(scenarioId);
                     break;
                 }
@@ -1323,15 +1524,19 @@ namespace erin {
     }
 
     std::vector<size_t>
-    CalculateComponentOrder(Simulation const &s) {
+    CalculateComponentOrder(Simulation const& s)
+    {
         size_t const numComps = s.TheModel.ComponentMap.Tag.size();
         std::vector<size_t> result;
         result.reserve(numComps);
         std::vector<std::string> compTags(s.TheModel.ComponentMap.Tag);
         std::sort(compTags.begin(), compTags.end());
-        for (auto const &t: compTags) {
-            for (size_t compId = 0; compId < numComps; ++compId) {
-                if (s.TheModel.ComponentMap.Tag[compId] == t) {
+        for (auto const& t : compTags)
+        {
+            for (size_t compId = 0; compId < numComps; ++compId)
+            {
+                if (s.TheModel.ComponentMap.Tag[compId] == t)
+                {
                     result.push_back(compId);
                     break;
                 }
@@ -1342,17 +1547,21 @@ namespace erin {
     }
 
     std::vector<size_t>
-    CalculateStoreOrder(Simulation const &s) {
+    CalculateStoreOrder(Simulation const& s)
+    {
         std::vector<size_t> result;
         std::vector<std::string> storeTags;
         storeTags.reserve(s.TheModel.Stores.size());
         size_t const numComps = s.TheModel.ComponentMap.CompType.size();
         size_t const numStores = s.TheModel.Stores.size();
-        for (size_t storeId = 0; storeId < numStores; ++storeId) {
-            for (size_t compId = 0; compId < numComps; ++compId) {
+        for (size_t storeId = 0; storeId < numStores; ++storeId)
+        {
+            for (size_t compId = 0; compId < numComps; ++compId)
+            {
                 ComponentType type = s.TheModel.ComponentMap.CompType[compId];
                 size_t idx = s.TheModel.ComponentMap.Idx[compId];
-                if (type == ComponentType::StoreType && idx == storeId) {
+                if (type == ComponentType::StoreType && idx == storeId)
+                {
                     storeTags.push_back(s.TheModel.ComponentMap.Tag[compId]);
                     break;
                 }
@@ -1361,9 +1570,12 @@ namespace erin {
         assert(storeTags.size() == numStores);
         std::vector<std::string> originalStoreTags(storeTags);
         std::sort(storeTags.begin(), storeTags.end());
-        for (auto const &tag: storeTags) {
-            for (size_t storeId = 0; storeId < numStores; ++storeId) {
-                if (tag == originalStoreTags[storeId]) {
+        for (auto const& tag : storeTags)
+        {
+            for (size_t storeId = 0; storeId < numStores; ++storeId)
+            {
+                if (tag == originalStoreTags[storeId])
+                {
                     result.push_back(storeId);
                 }
             }
@@ -1373,14 +1585,18 @@ namespace erin {
     }
 
     std::vector<size_t>
-    CalculateFailModeOrder(Simulation const &s) {
+    CalculateFailModeOrder(Simulation const& s)
+    {
         size_t const numFailModes = s.FailureModes.Tags.size();
         std::vector<size_t> result;
         std::vector<std::string> failTags(s.FailureModes.Tags);
         std::sort(failTags.begin(), failTags.end());
-        for (auto const &t: failTags) {
-            for (size_t i = 0; i < numFailModes; ++i) {
-                if (s.FailureModes.Tags[i] == t) {
+        for (auto const& t : failTags)
+        {
+            for (size_t i = 0; i < numFailModes; ++i)
+            {
+                if (s.FailureModes.Tags[i] == t)
+                {
                     result.push_back(i);
                     break;
                 }
@@ -1391,14 +1607,18 @@ namespace erin {
     }
 
     std::vector<size_t>
-    CalculateFragilModeOrder(Simulation const &s) {
+    CalculateFragilModeOrder(Simulation const& s)
+    {
         size_t const numFragModes = s.FragilityModes.Tags.size();
         std::vector<size_t> result;
         std::vector<std::string> fragTags(s.FragilityModes.Tags);
         std::sort(fragTags.begin(), fragTags.end());
-        for (auto const &t: fragTags) {
-            for (size_t i = 0; i < numFragModes; ++i) {
-                if (s.FragilityModes.Tags[i] == t) {
+        for (auto const& t : fragTags)
+        {
+            for (size_t i = 0; i < numFragModes; ++i)
+            {
+                if (s.FragilityModes.Tags[i] == t)
+                {
                     result.push_back(i);
                     break;
                 }
@@ -1409,8 +1629,10 @@ namespace erin {
     }
 
     std::string
-    FlowInWattsToString(flow_t value_W, unsigned int precision) {
-        if (value_W == max_flow_W) {
+    FlowInWattsToString(flow_t value_W, unsigned int precision)
+    {
+        if (value_W == max_flow_W)
+        {
             std::cout << "Found infinity:" << std::endl;
             std::cout << "- value_W   : " << fmt::format("{}", value_W)
                       << std::endl;
@@ -1424,103 +1646,125 @@ namespace erin {
 
     void
     WriteResultsToEventFile(
-            std::ofstream &out,
-            std::vector<TimeAndFlows> results,
-            Simulation const &s,
-            std::string const &scenarioTag,
-            std::string const &scenarioStartTimeTag,
-            std::vector<size_t> const &connOrder,
-            std::vector<size_t> const &storeOrder,
-            std::vector<size_t> const &compOrder,
-            TimeUnit outputTimeUnit
-    ) {
+        std::ofstream& out,
+        std::vector<TimeAndFlows> results,
+        Simulation const& s,
+        std::string const& scenarioTag,
+        std::string const& scenarioStartTimeTag,
+        std::vector<size_t> const& connOrder,
+        std::vector<size_t> const& storeOrder,
+        std::vector<size_t> const& compOrder,
+        TimeUnit outputTimeUnit
+    )
+    {
         // TODO: pass in desired precision
         unsigned int precision = 1;
         unsigned int storePrecision = 3;
-        Model const &m = s.TheModel;
+        Model const& m = s.TheModel;
         std::map<size_t, std::vector<TimeState>> relSchByCompId;
-        for (size_t i = 0; i < m.Reliabilities.size(); ++i) {
+        for (size_t i = 0; i < m.Reliabilities.size(); ++i)
+        {
             size_t compId = m.Reliabilities[i].ComponentId;
             relSchByCompId[compId] = m.Reliabilities[i].TimeStates;
         }
-        for (auto const &r: results) {
+        for (auto const& r : results)
+        {
             assert(r.Flows.size() == connOrder.size());
             out << scenarioTag << "," << scenarioStartTimeTag << ",";
             out << TimeInSecondsToDesiredUnit(r.Time, outputTimeUnit);
-            for (size_t const &i: connOrder) {
+            for (size_t const& i : connOrder)
+            {
                 out << ","
                     << FlowInWattsToString(r.Flows[i].Actual_W, precision);
             }
-            for (size_t const &i: connOrder) {
+            for (size_t const& i : connOrder)
+            {
                 out << ","
                     << FlowInWattsToString(r.Flows[i].Requested_W, precision);
             }
-            for (size_t const &i: connOrder) {
+            for (size_t const& i : connOrder)
+            {
                 out << ","
                     << FlowInWattsToString(r.Flows[i].Available_W, precision);
             }
             // NOTE: Amounts in kJ
-            for (size_t i: storeOrder) {
+            for (size_t i : storeOrder)
+            {
                 double store_J = static_cast<double>(r.StorageAmounts_J[i]);
                 double store_kJ = store_J / J_per_kJ;
                 out << "," << std::fixed << std::setprecision(storePrecision)
                     << store_kJ;
             }
             // NOTE: Store state in SOC
-            for (size_t i: storeOrder) {
+            for (size_t i : storeOrder)
+            {
                 double soc = 0.0;
-                if (m.Stores[i].Capacity_J > 0) {
+                if (m.Stores[i].Capacity_J > 0)
+                {
                     soc = static_cast<double>(r.StorageAmounts_J[i])
-                          / static_cast<double>(m.Stores[i].Capacity_J);
+                        / static_cast<double>(m.Stores[i].Capacity_J);
                 }
                 out << "," << std::fixed << std::setprecision(storePrecision)
                     << soc;
             }
-            for (size_t i: compOrder) {
-                if (!m.ComponentMap.Tag[i].empty()) {
-                    if (relSchByCompId.contains(i)) {
+            for (size_t i : compOrder)
+            {
+                if (!m.ComponentMap.Tag[i].empty())
+                {
+                    if (relSchByCompId.contains(i))
+                    {
                         TimeState ts = TimeState_GetActiveTimeState(
-                                relSchByCompId[i], r.Time
+                            relSchByCompId[i], r.Time
                         );
-                        if (ts.state) {
+                        if (ts.state)
+                        {
                             out << ",available";
-                        } else {
+                        }
+                        else
+                        {
                             // lookup the failure and fragility modes
                             std::vector<size_t> failModes;
                             failModes.reserve(ts.failureModeCauses.size());
                             std::vector<size_t> fragModes;
                             fragModes.reserve(ts.fragilityModeCauses.size());
-                            for (size_t fm: ts.failureModeCauses) {
+                            for (size_t fm : ts.failureModeCauses)
+                            {
                                 failModes.push_back(fm);
                             }
-                            for (size_t fm: ts.fragilityModeCauses) {
+                            for (size_t fm : ts.fragilityModeCauses)
+                            {
                                 fragModes.push_back(fm);
                             }
                             std::sort(failModes.begin(), failModes.end());
                             std::sort(fragModes.begin(), fragModes.end());
                             std::vector<std::string> fmTags;
                             fmTags.reserve(
-                                    ts.failureModeCauses.size()
-                                    + ts.fragilityModeCauses.size()
+                                ts.failureModeCauses.size()
+                                + ts.fragilityModeCauses.size()
                             );
-                            for (auto const &failModeId: failModes) {
+                            for (auto const& failModeId : failModes)
+                            {
                                 fmTags.push_back(s.FailureModes.Tags[failModeId]
                                 );
                             }
-                            for (auto const &fragModeId: fragModes) {
+                            for (auto const& fragModeId : fragModes)
+                            {
                                 fmTags.push_back(
-                                        s.FragilityModes.Tags[fragModeId]
+                                    s.FragilityModes.Tags[fragModeId]
                                 );
                             }
                             bool first = true;
                             std::ostringstream oss{};
-                            for (std::string const &tag: fmTags) {
+                            for (std::string const& tag : fmTags)
+                            {
                                 oss << (first ? "" : " | ") << tag;
                                 first = false;
                             }
                             out << "," << oss.str();
                         }
-                    } else {
+                    }
+                    else
+                    {
                         out << ",available";
                     }
                 }
@@ -1531,24 +1775,30 @@ namespace erin {
 
     Result
     SetLoadsForScenario(
-            std::vector<ScheduleBasedLoad> &loads,
-            LoadDict loadMap,
-            size_t scenarioIdx
-    ) {
-        for (size_t sblIdx = 0; sblIdx < loads.size(); ++sblIdx) {
-            if (loads[sblIdx].ScenarioIdToLoadId.contains(scenarioIdx)) {
+        std::vector<ScheduleBasedLoad>& loads,
+        LoadDict loadMap,
+        size_t scenarioIdx
+    )
+    {
+        for (size_t sblIdx = 0; sblIdx < loads.size(); ++sblIdx)
+        {
+            if (loads[sblIdx].ScenarioIdToLoadId.contains(scenarioIdx))
+            {
                 auto loadId = loads[sblIdx].ScenarioIdToLoadId.at(scenarioIdx);
                 std::vector<TimeAndAmount> schedule{};
                 size_t numEntries = loadMap.Loads[loadId].size();
                 schedule.reserve(numEntries);
-                for (size_t i = 0; i < numEntries; ++i) {
+                for (size_t i = 0; i < numEntries; ++i)
+                {
                     TimeAndAmount tal{};
                     tal.Time_s = loadMap.Loads[loadId][i].Time_s;
                     tal.Amount_W = loadMap.Loads[loadId][i].Amount_W;
                     schedule.push_back(std::move(tal));
                 }
                 loads[sblIdx].TimesAndLoads = std::move(schedule);
-            } else {
+            }
+            else
+            {
                 std::cout << "ERROR:"
                           << "Unhandled scenario id in ScenarioIdToLoadId"
                           << std::endl;
@@ -1560,25 +1810,31 @@ namespace erin {
 
     Result
     SetSupplyForScenario(
-            std::vector<ScheduleBasedSource> &loads,
-            LoadDict loadMap,
-            size_t scenarioIdx
-    ) {
-        for (size_t sblIdx = 0; sblIdx < loads.size(); ++sblIdx) {
-            if (loads[sblIdx].ScenarioIdToSourceId.contains(scenarioIdx)) {
+        std::vector<ScheduleBasedSource>& loads,
+        LoadDict loadMap,
+        size_t scenarioIdx
+    )
+    {
+        for (size_t sblIdx = 0; sblIdx < loads.size(); ++sblIdx)
+        {
+            if (loads[sblIdx].ScenarioIdToSourceId.contains(scenarioIdx))
+            {
                 auto loadId =
-                        loads[sblIdx].ScenarioIdToSourceId.at(scenarioIdx);
+                    loads[sblIdx].ScenarioIdToSourceId.at(scenarioIdx);
                 std::vector<TimeAndAmount> schedule{};
                 size_t numEntries = loadMap.Loads[loadId].size();
                 schedule.reserve(numEntries);
-                for (size_t i = 0; i < numEntries; ++i) {
+                for (size_t i = 0; i < numEntries; ++i)
+                {
                     TimeAndAmount tal{};
                     tal.Time_s = loadMap.Loads[loadId][i].Time_s;
                     tal.Amount_W = loadMap.Loads[loadId][i].Amount_W;
                     schedule.push_back(std::move(tal));
                 }
                 loads[sblIdx].TimeAndAvails = std::move(schedule);
-            } else {
+            }
+            else
+            {
                 std::cout << "ERROR:"
                           << "Unhandled scenario id in ScenarioIdToSourceId"
                           << std::endl;
@@ -1590,29 +1846,34 @@ namespace erin {
 
     std::vector<double>
     DetermineScenarioOccurrenceTimes(
-            Simulation &s,
-            size_t scenIdx,
-            bool isVerbose
-    ) {
+        Simulation& s,
+        size_t scenIdx,
+        bool isVerbose
+    )
+    {
         std::vector<double> occurrenceTimes_s;
-        auto const &maybeMaxOccurrences = s.ScenarioMap.MaxOccurrences[scenIdx];
+        auto const& maybeMaxOccurrences = s.ScenarioMap.MaxOccurrences[scenIdx];
         size_t maxOccurrence = maybeMaxOccurrences.has_value()
-                               ? maybeMaxOccurrences.value()
-                               : 1'000;
+            ? maybeMaxOccurrences.value()
+            : 1'000;
         auto const distId = s.ScenarioMap.OccurrenceDistributionIds[scenIdx];
         double scenarioStartTime_s = 0.0;
         double maxTime_s = Time_ToSeconds(s.Info.MaxTime, s.Info.TheTimeUnit);
-        for (size_t i = 0; i < maxOccurrence; ++i) {
+        for (size_t i = 0; i < maxOccurrence; ++i)
+        {
             scenarioStartTime_s += s.TheModel.DistSys.next_time_advance(distId);
-            if (scenarioStartTime_s > maxTime_s) {
+            if (scenarioStartTime_s > maxTime_s)
+            {
                 break;
             }
             occurrenceTimes_s.push_back(scenarioStartTime_s);
         }
-        if (isVerbose) {
+        if (isVerbose)
+        {
             std::cout << "Occurrences: " << occurrenceTimes_s.size()
                       << std::endl;
-            for (size_t i = 0; i < occurrenceTimes_s.size(); ++i) {
+            for (size_t i = 0; i < occurrenceTimes_s.size(); ++i)
+            {
                 std::cout << "-- "
                           << SecondsToPrettyString(occurrenceTimes_s[i])
                           << std::endl;
@@ -1622,31 +1883,37 @@ namespace erin {
     }
 
     std::map<size_t, double>
-    GetIntensitiesForScenario(Simulation &s, size_t scenIdx) {
+    GetIntensitiesForScenario(Simulation& s, size_t scenIdx)
+    {
         std::map<size_t, double> intensityIdToAmount;
-        for (size_t i = 0; i < s.ScenarioIntensities.ScenarioIds.size(); ++i) {
-            if (s.ScenarioIntensities.ScenarioIds[i] == scenIdx) {
+        for (size_t i = 0; i < s.ScenarioIntensities.ScenarioIds.size(); ++i)
+        {
+            if (s.ScenarioIntensities.ScenarioIds[i] == scenIdx)
+            {
                 auto intensityId = s.ScenarioIntensities.IntensityIds[i];
                 intensityIdToAmount[intensityId] =
-                        s.ScenarioIntensities.IntensityLevels[i];
+                    s.ScenarioIntensities.IntensityLevels[i];
             }
         }
         return intensityIdToAmount;
     }
 
     std::vector<ScheduleBasedReliability>
-    CopyReliabilities(Simulation const &s) {
+    CopyReliabilities(Simulation const& s)
+    {
         std::vector<ScheduleBasedReliability> originalReliabilities;
         originalReliabilities.reserve(s.TheModel.Reliabilities.size());
         for (size_t sbrIdx = 0; sbrIdx < s.TheModel.Reliabilities.size();
-             ++sbrIdx) {
-            ScheduleBasedReliability const &sbrSrc =
-                    s.TheModel.Reliabilities[sbrIdx];
+             ++sbrIdx)
+        {
+            ScheduleBasedReliability const& sbrSrc =
+                s.TheModel.Reliabilities[sbrIdx];
             ScheduleBasedReliability sbrCopy{};
             sbrCopy.ComponentId = sbrSrc.ComponentId;
             sbrCopy.TimeStates.reserve(sbrSrc.TimeStates.size());
-            for (size_t tsIdx = 0; tsIdx < sbrSrc.TimeStates.size(); ++tsIdx) {
-                TimeState const &tsSrc = sbrSrc.TimeStates[tsIdx];
+            for (size_t tsIdx = 0; tsIdx < sbrSrc.TimeStates.size(); ++tsIdx)
+            {
+                TimeState const& tsSrc = sbrSrc.TimeStates[tsIdx];
                 TimeState tsCopy{};
                 tsCopy.time = tsSrc.time;
                 tsCopy.state = tsSrc.state;
@@ -1659,40 +1926,44 @@ namespace erin {
 
     std::vector<ScheduleBasedReliability>
     ApplyReliabilitiesAndFragilities(
-            Simulation &s,
-            double startTime_s,
-            double endTime_s,
-            std::map<size_t, double> const &intensityIdToAmount,
-            std::map<size_t, std::vector<TimeState>> const &relSchByCompId,
-            bool verbose
-    ) {
+        Simulation& s,
+        double startTime_s,
+        double endTime_s,
+        std::map<size_t, double> const& intensityIdToAmount,
+        std::map<size_t, std::vector<TimeState>> const& relSchByCompId,
+        bool verbose
+    )
+    {
         std::vector<ScheduleBasedReliability> orig = CopyReliabilities(s);
-        std::set < size_t > reliabilitiesAdded;
+        std::set<size_t> reliabilitiesAdded;
         for (size_t cfmIdx = 0;
              cfmIdx < s.ComponentFailureModes.ComponentIds.size();
-             ++cfmIdx) {
-            auto const &compId = s.ComponentFailureModes.ComponentIds[cfmIdx];
+             ++cfmIdx)
+        {
+            auto const& compId = s.ComponentFailureModes.ComponentIds[cfmIdx];
             // NOTE: there should be a reliability schedule for each entry in
             // ComponentFailureModes. However, since it is possible to have
             // more than one failure mode on one component (and those have
             // already been combined by this point), we need to check if we've
             // already added this reliability schedule
-            if (reliabilitiesAdded.contains(compId)) {
+            if (reliabilitiesAdded.contains(compId))
+            {
                 continue;
             }
-            std::vector<TimeState> const &sch = relSchByCompId.at(compId);
+            std::vector<TimeState> const& sch = relSchByCompId.at(compId);
             double initialAge_s = s.TheModel.ComponentMap.InitialAges_s[compId];
-            if (verbose) {
+            if (verbose)
+            {
                 std::cout << "component: "
                           << s.TheModel.ComponentMap.Tag[compId] << std::endl;
                 std::cout << "initial age (h): "
                           << (initialAge_s / seconds_per_hour) << std::endl;
             }
             std::vector<TimeState> clip = TimeState_Clip(
-                    TimeState_Translate(sch, initialAge_s),
-                    startTime_s,
-                    endTime_s,
-                    true
+                TimeState_Translate(sch, initialAge_s),
+                startTime_s,
+                endTime_s,
+                true
             );
             // NOTE: Reliabilities have not yet been assigned so we can
             // just push_back()
@@ -1702,80 +1973,96 @@ namespace erin {
             s.TheModel.Reliabilities.push_back(std::move(sbr));
             reliabilitiesAdded.insert(compId);
         }
-        if (intensityIdToAmount.size() > 0) {
-            if (verbose) {
+        if (intensityIdToAmount.size() > 0)
+        {
+            if (verbose)
+            {
                 std::cout << "... Applying fragilities" << std::endl;
             }
             // NOTE: if there are no components having fragility modes,
             // there is nothing to do.
             for (size_t cfmIdx = 0;
                  cfmIdx < s.ComponentFragilities.ComponentIds.size();
-                 ++cfmIdx) {
+                 ++cfmIdx)
+            {
                 size_t fmId = s.ComponentFragilities.FragilityModeIds[cfmIdx];
                 size_t fcId = s.FragilityModes.FragilityCurveId[fmId];
                 std::optional<size_t> repairId =
-                        s.FragilityModes.RepairDistIds[fmId];
+                    s.FragilityModes.RepairDistIds[fmId];
                 FragilityCurveType curveType =
-                        s.FragilityCurves.CurveTypes[fcId];
+                    s.FragilityCurves.CurveTypes[fcId];
                 size_t fcIdx = s.FragilityCurves.CurveId[fcId];
                 bool isFailed = false;
                 double failureFrac = 0.0;
-                switch (curveType) {
-                    case (FragilityCurveType::Linear): {
+                switch (curveType)
+                {
+                    case (FragilityCurveType::Linear):
+                    {
                         LinearFragilityCurve lfc =
-                                s.LinearFragilityCurves[fcIdx];
+                            s.LinearFragilityCurves[fcIdx];
                         size_t vulnerId = lfc.VulnerabilityId;
-                        if (intensityIdToAmount.contains(vulnerId)) {
+                        if (intensityIdToAmount.contains(vulnerId))
+                        {
                             double level = intensityIdToAmount.at(vulnerId);
                             failureFrac =
-                                    LinearFragilityCurve_GetFailureFraction(
-                                            lfc, level
-                                    );
+                                LinearFragilityCurve_GetFailureFraction(
+                                    lfc, level
+                                );
                         }
                     }
-                        break;
-                    case (FragilityCurveType::Tabular): {
+                    break;
+                    case (FragilityCurveType::Tabular):
+                    {
                         TabularFragilityCurve tfc =
-                                s.TabularFragilityCurves[fcIdx];
+                            s.TabularFragilityCurves[fcIdx];
                         size_t vulnerId = tfc.VulnerabilityId;
-                        if (intensityIdToAmount.contains(vulnerId)) {
+                        if (intensityIdToAmount.contains(vulnerId))
+                        {
                             double level = intensityIdToAmount.at(vulnerId);
                             failureFrac =
-                                    TabularFragilityCurve_GetFailureFraction(
-                                            tfc, level
-                                    );
+                                TabularFragilityCurve_GetFailureFraction(
+                                    tfc, level
+                                );
                         }
                     }
-                        break;
-                    default: {
+                    break;
+                    default:
+                    {
                         WriteErrorMessage(
-                                "fragility_curve", "unhandled fragility curve type"
+                            "fragility_curve", "unhandled fragility curve type"
                         );
                         std::exit(1);
                     }
-                        break;
+                    break;
                 }
-                if (failureFrac == 1.0) {
+                if (failureFrac == 1.0)
+                {
                     isFailed = true;
-                } else if (failureFrac == 0.0) {
+                }
+                else if (failureFrac == 0.0)
+                {
                     isFailed = false;
-                } else {
+                }
+                else
+                {
                     isFailed = s.TheModel.RandFn() <= failureFrac;
                 }
                 // NOTE: if we are not failed, there is nothing to do
-                if (isFailed) {
+                if (isFailed)
+                {
                     // now we have to find the affected component
                     // and assign/update a reliability schedule for it
                     // including any repair distribution if we have
                     // one.
                     size_t compId = s.ComponentFragilities.ComponentIds[cfmIdx];
-                    if (verbose) {
+                    if (verbose)
+                    {
                         std::cout << "... FAILED: "
                                   << s.TheModel.ComponentMap.Tag[compId]
                                   << " (cause: "
                                   << s.FragilityModes
-                                          .Tags[s.ComponentFragilities
-                                          .FragilityModeIds[cfmIdx]]
+                                         .Tags[s.ComponentFragilities
+                                                   .FragilityModeIds[cfmIdx]]
                                   << ")" << std::endl;
                     }
                     // does the component have a reliability signal?
@@ -1783,9 +2070,11 @@ namespace erin {
                     size_t reliabilityId = 0;
                     for (size_t rIdx = 0;
                          rIdx < s.TheModel.Reliabilities.size();
-                         ++rIdx) {
+                         ++rIdx)
+                    {
                         if (s.TheModel.Reliabilities[rIdx].ComponentId
-                            == compId) {
+                            == compId)
+                        {
                             hasReliabilityAlready = true;
                             reliabilityId = rIdx;
                             break;
@@ -1797,23 +2086,27 @@ namespace erin {
                     ts.time = 0.0;
                     ts.fragilityModeCauses.insert(fmId);
                     newTimeStates.push_back(std::move(ts));
-                    if (repairId.has_value()) {
+                    if (repairId.has_value())
+                    {
                         size_t repId = repairId.value();
                         double repairTime_s =
-                                s.TheModel.DistSys.next_time_advance(repId);
+                            s.TheModel.DistSys.next_time_advance(repId);
                         TimeState repairTime{};
                         repairTime.time = repairTime_s;
                         repairTime.state = true;
                         newTimeStates.push_back(std::move(repairTime));
                     }
-                    if (hasReliabilityAlready) {
-                        auto const &currentSch =
-                                s.TheModel.Reliabilities[reliabilityId].TimeStates;
+                    if (hasReliabilityAlready)
+                    {
+                        auto const& currentSch =
+                            s.TheModel.Reliabilities[reliabilityId].TimeStates;
                         std::vector<TimeState> combined =
-                                TimeState_Combine(currentSch, newTimeStates);
+                            TimeState_Combine(currentSch, newTimeStates);
                         s.TheModel.Reliabilities[reliabilityId].TimeStates =
-                                std::move(combined);
-                    } else {
+                            std::move(combined);
+                    }
+                    else
+                    {
                         ScheduleBasedReliability sbr{};
                         sbr.ComponentId = compId;
                         sbr.TimeStates = newTimeStates;
@@ -1831,16 +2124,18 @@ namespace erin {
     // names from data calculations.
     void
     WriteStatisticsToFile(
-            Simulation const &s,
-            std::string const &statsFilePath,
-            std::vector<ScenarioOccurrenceStats> const &occurrenceStats,
-            std::vector<size_t> const &compOrder,
-            std::vector<size_t> const &failOrder,
-            std::vector<size_t> const &fragOrder
-    ) {
+        Simulation const& s,
+        std::string const& statsFilePath,
+        std::vector<ScenarioOccurrenceStats> const& occurrenceStats,
+        std::vector<size_t> const& compOrder,
+        std::vector<size_t> const& failOrder,
+        std::vector<size_t> const& fragOrder
+    )
+    {
         std::ofstream stats;
         stats.open(statsFilePath);
-        if (!stats.good()) {
+        if (!stats.good())
+        {
             std::cout << "Could not open '" << statsFilePath << "' for writing."
                       << std::endl;
             return;
@@ -1854,96 +2149,123 @@ namespace erin {
               << "energy availability [EA],"
               << "max single event downtime [MaxSEDT] (h),"
               << "global availability";
-        if (occurrenceStats.size() > 0) {
-            for (auto const &statsByFlow: occurrenceStats[0].FlowTypeStats) {
-                std::string const &flowType =
-                        s.FlowTypeMap.Type[statsByFlow.FlowTypeId];
+        if (occurrenceStats.size() > 0)
+        {
+            for (auto const& statsByFlow : occurrenceStats[0].FlowTypeStats)
+            {
+                std::string const& flowType =
+                    s.FlowTypeMap.Type[statsByFlow.FlowTypeId];
                 stats << ",energy robustness [ER] for " << flowType;
                 stats << ",energy availability [EA] for " << flowType;
             }
-            for (auto const &statsByFlowLoad:
-                    occurrenceStats[0].LoadAndFlowTypeStats) {
-                std::string const &flowType =
-                        s.FlowTypeMap.Type[statsByFlowLoad.Stats.FlowTypeId];
-                std::string const &tag =
-                        s.TheModel.ComponentMap.Tag[statsByFlowLoad.ComponentId];
+            for (auto const& statsByFlowLoad :
+                 occurrenceStats[0].LoadAndFlowTypeStats)
+            {
+                std::string const& flowType =
+                    s.FlowTypeMap.Type[statsByFlowLoad.Stats.FlowTypeId];
+                std::string const& tag =
+                    s.TheModel.ComponentMap.Tag[statsByFlowLoad.ComponentId];
                 stats << ",energy robustness [ER] for " << tag
                       << " [flow: " << flowType << "]";
                 stats << ",energy availability [EA] for " << tag
                       << " [flow: " << flowType << "]";
             }
-            for (auto const &lnsByComp:
-                    occurrenceStats[0].LoadNotServedForComponents) {
-                std::string const &flowType =
-                        s.FlowTypeMap.Type[lnsByComp.FlowTypeId];
-                std::string const &tag =
-                        s.TheModel.ComponentMap.Tag[lnsByComp.ComponentId];
+            for (auto const& lnsByComp :
+                 occurrenceStats[0].LoadNotServedForComponents)
+            {
+                std::string const& flowType =
+                    s.FlowTypeMap.Type[lnsByComp.FlowTypeId];
+                std::string const& tag =
+                    s.TheModel.ComponentMap.Tag[lnsByComp.ComponentId];
                 stats << ",load not served (kJ) for " << tag
                       << " [flow: " << flowType << "]";
             }
         }
-        std::set < size_t > componentsToSkip;
-        for (size_t i: compOrder) {
-            if (s.TheModel.ComponentMap.Tag[i].empty()) {
+        std::set<size_t> componentsToSkip;
+        for (size_t i : compOrder)
+        {
+            if (s.TheModel.ComponentMap.Tag[i].empty())
+            {
                 componentsToSkip.insert(i);
-            } else {
+            }
+            else
+            {
                 stats << ",availability: " << s.TheModel.ComponentMap.Tag[i];
             }
         }
-        for (size_t i: failOrder) {
+        for (size_t i : failOrder)
+        {
             stats << ",global count: " << s.FailureModes.Tags[i];
         }
-        for (size_t i: fragOrder) {
+        for (size_t i : fragOrder)
+        {
             stats << ",global count: " << s.FragilityModes.Tags[i];
         }
-        for (size_t i: failOrder) {
+        for (size_t i : failOrder)
+        {
             stats << ",global time fraction: " << s.FailureModes.Tags[i];
         }
-        for (size_t i: fragOrder) {
+        for (size_t i : fragOrder)
+        {
             stats << ",global time fraction: " << s.FragilityModes.Tags[i];
         }
-        std::map < size_t, std::set < size_t >> failModeIdsByCompId;
-        std::map < size_t, std::set < size_t >> fragModeIdsByCompId;
-        for (size_t compId: compOrder) {
-            failModeIdsByCompId[compId] = std::set < size_t > {};
-            fragModeIdsByCompId[compId] = std::set < size_t > {};
-            for (auto const &occ: occurrenceStats) {
-                if (occ.EventCountByCompIdByFailureModeId.contains(compId)) {
-                    for (auto const &p:
-                            occ.EventCountByCompIdByFailureModeId.at(compId)) {
+        std::map<size_t, std::set<size_t>> failModeIdsByCompId;
+        std::map<size_t, std::set<size_t>> fragModeIdsByCompId;
+        for (size_t compId : compOrder)
+        {
+            failModeIdsByCompId[compId] = std::set<size_t>{};
+            fragModeIdsByCompId[compId] = std::set<size_t>{};
+            for (auto const& occ : occurrenceStats)
+            {
+                if (occ.EventCountByCompIdByFailureModeId.contains(compId))
+                {
+                    for (auto const& p :
+                         occ.EventCountByCompIdByFailureModeId.at(compId))
+                    {
                         failModeIdsByCompId[compId].insert(p.first);
                     }
                 }
-                if (occ.EventCountByCompIdByFragilityModeId.contains(compId)) {
-                    for (auto const &p:
-                            occ.EventCountByCompIdByFragilityModeId.at(compId)) {
+                if (occ.EventCountByCompIdByFragilityModeId.contains(compId))
+                {
+                    for (auto const& p :
+                         occ.EventCountByCompIdByFragilityModeId.at(compId))
+                    {
                         fragModeIdsByCompId[compId].insert(p.first);
                     }
                 }
             }
-            for (size_t failModeId: failOrder) {
-                if (failModeIdsByCompId[compId].contains(failModeId)) {
+            for (size_t failModeId : failOrder)
+            {
+                if (failModeIdsByCompId[compId].contains(failModeId))
+                {
                     stats << ",count: " << s.TheModel.ComponentMap.Tag[compId]
                           << " / " << s.FailureModes.Tags[failModeId];
                 }
             }
-            for (size_t fragModeId: fragOrder) {
-                if (fragModeIdsByCompId[compId].contains(fragModeId)) {
+            for (size_t fragModeId : fragOrder)
+            {
+                if (fragModeIdsByCompId[compId].contains(fragModeId))
+                {
                     stats << ",count: " << s.TheModel.ComponentMap.Tag[compId]
                           << " / " << s.FragilityModes.Tags[fragModeId];
                 }
             }
         }
-        for (size_t compId: compOrder) {
-            for (size_t failModeId: failOrder) {
-                if (failModeIdsByCompId[compId].contains(failModeId)) {
+        for (size_t compId : compOrder)
+        {
+            for (size_t failModeId : failOrder)
+            {
+                if (failModeIdsByCompId[compId].contains(failModeId))
+                {
                     stats << ",time fraction: "
                           << s.TheModel.ComponentMap.Tag[compId] << " / "
                           << s.FailureModes.Tags[failModeId];
                 }
             }
-            for (size_t fragModeId: fragOrder) {
-                if (fragModeIdsByCompId[compId].contains(fragModeId)) {
+            for (size_t fragModeId : fragOrder)
+            {
+                if (fragModeIdsByCompId[compId].contains(fragModeId))
+                {
                     stats << ",time fraction: "
                           << s.TheModel.ComponentMap.Tag[compId] << " / "
                           << s.FragilityModes.Tags[fragModeId];
@@ -1951,19 +2273,20 @@ namespace erin {
             }
         }
         stats << std::endl;
-        for (auto const &os: occurrenceStats) {
+        for (auto const& os : occurrenceStats)
+        {
             double stored_kJ = os.StorageCharge_kJ - os.StorageDischarge_kJ;
             double balance = os.Inflow_kJ + os.InFromEnv_kJ
-                             - (os.OutflowAchieved_kJ + stored_kJ + os.Wasteflow_kJ);
+                - (os.OutflowAchieved_kJ + stored_kJ + os.Wasteflow_kJ);
             double efficiency = (os.Inflow_kJ + os.StorageDischarge_kJ) > 0.0
-                                ? ((os.OutflowAchieved_kJ + os.StorageCharge_kJ)
-                                   / (os.Inflow_kJ + os.StorageDischarge_kJ))
-                                : 0.0;
+                ? ((os.OutflowAchieved_kJ + os.StorageCharge_kJ)
+                   / (os.Inflow_kJ + os.StorageDischarge_kJ))
+                : 0.0;
             double ER = os.OutflowRequest_kJ > 0.0
-                        ? (os.OutflowAchieved_kJ / os.OutflowRequest_kJ)
-                        : 1.0;
+                ? (os.OutflowAchieved_kJ / os.OutflowRequest_kJ)
+                : 1.0;
             double EA =
-                    os.Duration_s > 0.0 ? (os.Uptime_s / os.Duration_s) : 1.0;
+                os.Duration_s > 0.0 ? (os.Uptime_s / os.Duration_s) : 1.0;
             stats << s.ScenarioMap.Tags[os.Id];
             stats << "," << os.OccurrenceNumber;
             stats << "," << (os.Duration_s / seconds_per_hour);
@@ -1982,131 +2305,162 @@ namespace erin {
             stats << "," << (os.MaxSEDT_s / seconds_per_hour);
             stats << ","
                   << ((os.Duration_s > 0.0)
-                      ? (os.Availability_s / os.Duration_s)
-                      : 0.0);
+                          ? (os.Availability_s / os.Duration_s)
+                          : 0.0);
             // NOTE: written in alphabetical order by flowtype name
-            for (auto const &statsByFlow: os.FlowTypeStats) {
+            for (auto const& statsByFlow : os.FlowTypeStats)
+            {
 
                 double ER_by_flow = statsByFlow.TotalRequest_kJ > 0.0
-                                    ? (statsByFlow.TotalAchieved_kJ
-                                       / statsByFlow.TotalRequest_kJ)
-                                    : 0.0;
+                    ? (statsByFlow.TotalAchieved_kJ
+                       / statsByFlow.TotalRequest_kJ)
+                    : 0.0;
                 double EA_by_flow = os.Duration_s > 0.0
-                                    ? (statsByFlow.Uptime_s / os.Duration_s)
-                                    : 0.0;
+                    ? (statsByFlow.Uptime_s / os.Duration_s)
+                    : 0.0;
                 stats << "," << ER_by_flow;
                 stats << "," << EA_by_flow;
             }
-            for (auto const &statsByFlowLoad: os.LoadAndFlowTypeStats) {
+            for (auto const& statsByFlowLoad : os.LoadAndFlowTypeStats)
+            {
                 double ER_by_load = statsByFlowLoad.Stats.TotalRequest_kJ > 0.0
-                                    ? (statsByFlowLoad.Stats.TotalAchieved_kJ
-                                       / statsByFlowLoad.Stats.TotalRequest_kJ)
-                                    : 0.0;
+                    ? (statsByFlowLoad.Stats.TotalAchieved_kJ
+                       / statsByFlowLoad.Stats.TotalRequest_kJ)
+                    : 0.0;
                 double EA_by_load = os.Duration_s > 0.0
-                                    ? (statsByFlowLoad.Stats.Uptime_s / os.Duration_s)
-                                    : 0.0;
+                    ? (statsByFlowLoad.Stats.Uptime_s / os.Duration_s)
+                    : 0.0;
                 stats << "," << ER_by_load;
                 stats << "," << EA_by_load;
             }
-            for (auto const &lnsByComp: os.LoadNotServedForComponents) {
+            for (auto const& lnsByComp : os.LoadNotServedForComponents)
+            {
                 stats << "," << lnsByComp.LoadNotServed_kJ;
             }
-            for (size_t i: compOrder) {
-                if (!componentsToSkip.contains(i)) {
+            for (size_t i : compOrder)
+            {
+                if (!componentsToSkip.contains(i))
+                {
                     double availability = os.Duration_s > 0.0
-                                          ? os.AvailabilityByCompId_s.at(i) / os.Duration_s
-                                          : 1.0;
+                        ? os.AvailabilityByCompId_s.at(i) / os.Duration_s
+                        : 1.0;
                     stats << "," << availability;
                 }
             }
-            for (size_t i: failOrder) {
+            for (size_t i : failOrder)
+            {
                 size_t eventCount = os.EventCountByFailureModeId.contains(i)
-                                    ? os.EventCountByFailureModeId.at(i)
-                                    : 0;
+                    ? os.EventCountByFailureModeId.at(i)
+                    : 0;
                 stats << "," << eventCount;
             }
-            for (size_t i: fragOrder) {
+            for (size_t i : fragOrder)
+            {
                 size_t eventCount = os.EventCountByFragilityModeId.contains(i)
-                                    ? os.EventCountByFragilityModeId.at(i)
-                                    : 0;
+                    ? os.EventCountByFragilityModeId.at(i)
+                    : 0;
                 stats << "," << eventCount;
             }
-            for (size_t i: failOrder) {
+            for (size_t i : failOrder)
+            {
                 double time_s = os.TimeByFailureModeId_s.contains(i)
-                                ? os.TimeByFailureModeId_s.at(i)
-                                : 0.0;
+                    ? os.TimeByFailureModeId_s.at(i)
+                    : 0.0;
                 stats << ","
                       << (os.Duration_s > 0.0 ? time_s / os.Duration_s : 0.0);
             }
-            for (size_t i: fragOrder) {
+            for (size_t i : fragOrder)
+            {
                 double time_s = os.TimeByFragilityModeId_s.contains(i)
-                                ? os.TimeByFragilityModeId_s.at(i)
-                                : 0.0;
+                    ? os.TimeByFragilityModeId_s.at(i)
+                    : 0.0;
                 stats << ","
                       << (os.Duration_s > 0.0 ? time_s / os.Duration_s : 0.0);
             }
-            for (size_t compId: compOrder) {
-                for (size_t i: failOrder) {
-                    if (failModeIdsByCompId[compId].contains(i)) {
+            for (size_t compId : compOrder)
+            {
+                for (size_t i : failOrder)
+                {
+                    if (failModeIdsByCompId[compId].contains(i))
+                    {
                         if (os.EventCountByCompIdByFailureModeId.contains(compId
-                        )
+                            )
                             && os.EventCountByCompIdByFailureModeId.at(compId)
-                                    .contains(i)) {
+                                   .contains(i))
+                        {
                             stats << ","
                                   << os.EventCountByCompIdByFailureModeId
-                                          .at(compId)
-                                          .at(i);
-                        } else {
+                                         .at(compId)
+                                         .at(i);
+                        }
+                        else
+                        {
                             stats << ",0";
                         }
                     }
                 }
-                for (size_t i: fragOrder) {
-                    if (fragModeIdsByCompId[compId].contains(i)) {
+                for (size_t i : fragOrder)
+                {
+                    if (fragModeIdsByCompId[compId].contains(i))
+                    {
                         if (os.EventCountByCompIdByFragilityModeId.contains(
                                 compId
-                        )
+                            )
                             && os.EventCountByCompIdByFragilityModeId.at(compId)
-                                    .contains(i)) {
+                                   .contains(i))
+                        {
                             stats << ","
                                   << os.EventCountByCompIdByFragilityModeId
-                                          .at(compId)
-                                          .at(i);
-                        } else {
+                                         .at(compId)
+                                         .at(i);
+                        }
+                        else
+                        {
                             stats << ",0";
                         }
                     }
                 }
             }
-            for (size_t compId: compOrder) {
-                for (size_t i: failOrder) {
-                    if (failModeIdsByCompId[compId].contains(i)) {
+            for (size_t compId : compOrder)
+            {
+                for (size_t i : failOrder)
+                {
+                    if (failModeIdsByCompId[compId].contains(i))
+                    {
                         if (os.TimeByCompIdByFailureModeId_s.contains(compId)
                             && os.TimeByCompIdByFailureModeId_s.at(compId)
-                                    .contains(i)) {
+                                   .contains(i))
+                        {
                             double t =
-                                    os.TimeByCompIdByFailureModeId_s.at(compId).at(i
-                                    );
+                                os.TimeByCompIdByFailureModeId_s.at(compId).at(i
+                                );
                             stats << ","
                                   << (os.Duration_s > 0.0 ? t / os.Duration_s
                                                           : 0.0);
-                        } else {
+                        }
+                        else
+                        {
                             stats << ",0";
                         }
                     }
                 }
-                for (size_t i: fragOrder) {
-                    if (fragModeIdsByCompId[compId].contains(i)) {
+                for (size_t i : fragOrder)
+                {
+                    if (fragModeIdsByCompId[compId].contains(i))
+                    {
                         if (os.TimeByCompIdByFragilityModeId_s.contains(compId)
                             && os.TimeByCompIdByFragilityModeId_s.at(compId)
-                                    .contains(i)) {
+                                   .contains(i))
+                        {
                             double t =
-                                    os.TimeByCompIdByFragilityModeId_s.at(compId)
-                                            .at(i);
+                                os.TimeByCompIdByFragilityModeId_s.at(compId)
+                                    .at(i);
                             stats << ","
                                   << (os.Duration_s > 0.0 ? t / os.Duration_s
                                                           : 0.0);
-                        } else {
+                        }
+                        else
+                        {
                             stats << ",0";
                         }
                     }
@@ -2118,7 +2472,11 @@ namespace erin {
     }
 
     std::vector<TimeAndFlows>
-    applyUniformTimeStep(std::vector<TimeAndFlows> const &results, double const time_step_h) {
+    applyUniformTimeStep(
+        std::vector<TimeAndFlows> const& results,
+        double const time_step_h
+    )
+    {
         auto num_events = results.size();
         if ((num_events == 0) || (time_step_h <= 0.))
             return results;
@@ -2134,10 +2492,12 @@ namespace erin {
 
         std::vector<double> storage_totals_J(num_flows, 0.);
 
-        for (auto &next_taf: results) {
+        for (auto& next_taf : results)
+        {
 
             double t_next_report_s = t_prev_report_s + T_report_s;
-            while (t_next_report_s <= next_taf.Time) {
+            while (t_next_report_s <= next_taf.Time)
+            {
 
                 auto mod_taf = taf;
                 if (t_next_report_s == next_taf.Time)
@@ -2145,12 +2505,15 @@ namespace erin {
 
                 mod_taf.Time = t_next_report_s;
                 double dt_orig_s = next_taf.Time - taf.Time;
-                if (dt_orig_s > 0.) {
+                if (dt_orig_s > 0.)
+                {
                     double dt_s = t_next_report_s - taf.Time;
                     double time_frac = dt_s / dt_orig_s;
-                    for (std::size_t i = 0; i < num_stored; ++i) {
-                        mod_taf.StorageAmounts_J[i] = (1. - time_frac) * taf.StorageAmounts_J[i]
-                                                      + time_frac * next_taf.StorageAmounts_J[i];
+                    for (std::size_t i = 0; i < num_stored; ++i)
+                    {
+                        mod_taf.StorageAmounts_J[i] =
+                            (1. - time_frac) * taf.StorageAmounts_J[i]
+                            + time_frac * next_taf.StorageAmounts_J[i];
                     }
                 }
                 modified_results.push_back(mod_taf);
@@ -2165,19 +2528,23 @@ namespace erin {
 
     void
     Simulation_Run(
-            Simulation &s,
-            std::string const &eventsFilename,
-            std::string const &statsFilename,
-            double time_step_h /*-1.*/,
-            bool const verbose
-    ) {
+        Simulation& s,
+        std::string const& eventsFilename,
+        std::string const& statsFilename,
+        double time_step_h /*-1.*/,
+        bool const verbose
+    )
+    {
         // TODO: wrap into input options struct and pass in
         bool const checkNetwork = false;
-        if (checkNetwork) {
+        if (checkNetwork)
+        {
             std::vector<std::string> issues = Model_CheckNetwork(s.TheModel);
-            if (issues.size() > 0) {
+            if (issues.size() > 0)
+            {
                 std::cout << "NETWORK CONNECTION ISSUES:" << std::endl;
-                for (std::string const &issue: issues) {
+                for (std::string const& issue : issues)
+                {
                     std::cout << issue << std::endl;
                 }
             }
@@ -2189,33 +2556,39 @@ namespace erin {
         FixedRandom fixedRandom;
         FixedSeries fixedSeries;
         Random fullRandom;
-        switch (s.Info.TypeOfRandom) {
-            case (RandomType::FixedRandom): {
+        switch (s.Info.TypeOfRandom)
+        {
+            case (RandomType::FixedRandom):
+            {
                 fixedRandom.FixedValue = s.Info.FixedValue;
                 s.TheModel.RandFn = fixedRandom;
             }
-                break;
-            case (RandomType::FixedSeries): {
+            break;
+            case (RandomType::FixedSeries):
+            {
                 fixedSeries.Idx = 0;
                 fixedSeries.Series = s.Info.Series;
                 s.TheModel.RandFn = fixedSeries;
             }
-                break;
-            case (RandomType::RandomFromSeed): {
+            break;
+            case (RandomType::RandomFromSeed):
+            {
                 fullRandom = CreateRandomWithSeed(s.Info.Seed);
                 s.TheModel.RandFn = fullRandom;
             }
-                break;
-            case (RandomType::RandomFromClock): {
+            break;
+            case (RandomType::RandomFromClock):
+            {
                 fullRandom = CreateRandom();
                 s.TheModel.RandFn = fullRandom;
             }
-                break;
-            default: {
+            break;
+            default:
+            {
                 WriteErrorMessage("RandomType", "unhandled random type");
                 std::exit(1);
             }
-                break;
+            break;
         }
         // TODO: expose proper options
         // TODO: check the components and network:
@@ -2234,11 +2607,13 @@ namespace erin {
         // ... as fragility is "by scenario".
         double maxDuration_s = 0.0;
         for (size_t scenId = 0; scenId < s.ScenarioMap.Durations.size();
-             ++scenId) {
+             ++scenId)
+        {
             double duration_s = Time_ToSeconds(
-                    s.ScenarioMap.Durations[scenId], s.ScenarioMap.TimeUnits[scenId]
+                s.ScenarioMap.Durations[scenId], s.ScenarioMap.TimeUnits[scenId]
             );
-            if (duration_s > maxDuration_s) {
+            if (duration_s > maxDuration_s)
+            {
                 maxDuration_s = duration_s;
             }
         }
@@ -2252,30 +2627,34 @@ namespace erin {
         // NOTE: set up reliability manager
         // TODO: remove duplication of data here
         for (size_t fmIdx = 0; fmIdx < s.FailureModes.FailureDistIds.size();
-             ++fmIdx) {
+             ++fmIdx)
+        {
             s.TheModel.Rel.add_failure_mode(
-                    s.FailureModes.Tags[fmIdx],
-                    s.FailureModes.FailureDistIds[fmIdx],
-                    s.FailureModes.RepairDistIds[fmIdx]
+                s.FailureModes.Tags[fmIdx],
+                s.FailureModes.FailureDistIds[fmIdx],
+                s.FailureModes.RepairDistIds[fmIdx]
             );
         }
         for (size_t compFailId = 0;
              compFailId < s.ComponentFailureModes.ComponentIds.size();
-             ++compFailId) {
+             ++compFailId)
+        {
             size_t fmId = s.ComponentFailureModes.FailureModeIds[compFailId];
             s.TheModel.Rel.link_component_with_failure_mode(
-                    s.ComponentFailureModes.ComponentIds[compFailId],
-                    s.ComponentFailureModes.FailureModeIds[compFailId]
+                s.ComponentFailureModes.ComponentIds[compFailId],
+                s.ComponentFailureModes.FailureModeIds[compFailId]
             );
             double maxTime_s =
-                    Time_ToSeconds(s.Info.MaxTime, s.Info.TheTimeUnit)
-                    + maxDuration_s;
+                Time_ToSeconds(s.Info.MaxTime, s.Info.TheTimeUnit)
+                + maxDuration_s;
             std::vector<TimeState> relSch =
-                    s.TheModel.Rel.make_schedule_for_link(
-                            fmId, s.TheModel.RandFn, s.TheModel.DistSys, maxTime_s
-                    );
-            for (auto &ts: relSch) {
-                if (!ts.state) {
+                s.TheModel.Rel.make_schedule_for_link(
+                    fmId, s.TheModel.RandFn, s.TheModel.DistSys, maxTime_s
+                );
+            for (auto& ts : relSch)
+            {
+                if (!ts.state)
+                {
                     ts.failureModeCauses.insert(fmId);
                 }
             }
@@ -2283,14 +2662,18 @@ namespace erin {
         }
         // NOTE: combine reliability curves so they are per component
         std::map<size_t, std::vector<TimeState>> relSchByCompId;
-        for (auto const &pair: relSchByCompFailId) {
+        for (auto const& pair : relSchByCompFailId)
+        {
             size_t compId = s.ComponentFailureModes.ComponentIds[pair.first];
-            if (relSchByCompId.contains(compId)) {
+            if (relSchByCompId.contains(compId))
+            {
                 std::vector<TimeState> combined = TimeState_Combine(
-                        pair.second, relSchByCompId.at(pair.first)
+                    pair.second, relSchByCompId.at(pair.first)
                 );
                 relSchByCompId.insert({compId, std::move(combined)});
-            } else {
+            }
+            else
+            {
                 relSchByCompId.insert({compId, pair.second});
             }
         }
@@ -2303,39 +2686,44 @@ namespace erin {
         // NOW, we want to do a simulation for each scenario
         std::ofstream out;
         out.open(eventsFilename);
-        if (!out.good()) {
+        if (!out.good())
+        {
             std::cout << "Could not open '" << eventsFilename
                       << "' for writing." << std::endl;
             return;
         }
         WriteEventFileHeader(
-                out,
-                s.TheModel,
-                s.FlowTypeMap,
-                connOrder,
-                storeOrder,
-                compOrder,
-                outputTimeUnit
+            out,
+            s.TheModel,
+            s.FlowTypeMap,
+            connOrder,
+            storeOrder,
+            compOrder,
+            outputTimeUnit
         );
         std::vector<ScenarioOccurrenceStats> occurrenceStats;
-        for (size_t scenIdx: scenarioOrder) {
-            std::string const &scenarioTag = s.ScenarioMap.Tags[scenIdx];
-            if (verbose) {
+        for (size_t scenIdx : scenarioOrder)
+        {
+            std::string const& scenarioTag = s.ScenarioMap.Tags[scenIdx];
+            if (verbose)
+            {
                 std::cout << "Scenario: " << scenarioTag << std::endl;
             }
             // for this scenario, ensure all schedule-based components
             // have the right schedule set for this scenario
             if (SetLoadsForScenario(
                     s.TheModel.ScheduledLoads, s.LoadMap, scenIdx
-            )
-                == Result::Failure) {
+                )
+                == Result::Failure)
+            {
                 std::cout << "Issue setting schedule loads" << std::endl;
                 return;
             }
             if (SetSupplyForScenario(
                     s.TheModel.ScheduledSrcs, s.LoadMap, scenIdx
-            )
-                == Result::Failure) {
+                )
+                == Result::Failure)
+            {
                 std::cout << "Issue setting schedule sources" << std::endl;
                 return;
             }
@@ -2343,30 +2731,33 @@ namespace erin {
             // for (size_t sbsIdx = 0; sbsIdx < s.Model.ScheduleSrcs.size();
             // ++sbsIdx) {/* ... */}
             std::vector<double> occurrenceTimes_s =
-                    DetermineScenarioOccurrenceTimes(s, scenIdx, verbose);
+                DetermineScenarioOccurrenceTimes(s, scenIdx, verbose);
             // TODO: initialize total scenario stats (i.e.,
             // over all occurrences)
             std::map<size_t, double> intensityIdToAmount =
-                    GetIntensitiesForScenario(s, scenIdx);
-            for (size_t occIdx = 0; occIdx < occurrenceTimes_s.size(); ++occIdx) {
+                GetIntensitiesForScenario(s, scenIdx);
+            for (size_t occIdx = 0; occIdx < occurrenceTimes_s.size(); ++occIdx)
+            {
                 double t = occurrenceTimes_s[occIdx];
                 double duration_s = Time_ToSeconds(
-                        s.ScenarioMap.Durations[scenIdx],
-                        s.ScenarioMap.TimeUnits[scenIdx]
+                    s.ScenarioMap.Durations[scenIdx],
+                    s.ScenarioMap.TimeUnits[scenIdx]
                 );
                 double tEnd = t + duration_s;
-                if (verbose) {
+                if (verbose)
+                {
                     std::cout << "Occurrence #" << (occIdx + 1) << " at "
                               << SecondsToPrettyString(t) << std::endl;
                 }
                 // TODO: make initial age part of the ComponentMap
                 std::vector<ScheduleBasedReliability> originalReliabilities =
-                        ApplyReliabilitiesAndFragilities(
-                                s, t, tEnd, intensityIdToAmount, relSchByCompId, verbose
-                        );
+                    ApplyReliabilitiesAndFragilities(
+                        s, t, tEnd, intensityIdToAmount, relSchByCompId, verbose
+                    );
                 std::string scenarioStartTimeTag =
-                        TimeToISO8601Period(static_cast<uint64_t>(std::llround(t)));
-                if (verbose) {
+                    TimeToISO8601Period(static_cast<uint64_t>(std::llround(t)));
+                if (verbose)
+                {
                     std::cout << "Running " << s.ScenarioMap.Tags[scenIdx]
                               << " from " << scenarioStartTimeTag << " for "
                               << s.ScenarioMap.Durations[scenIdx] << " "
@@ -2381,34 +2772,37 @@ namespace erin {
 
                 auto results = Simulate(s.TheModel, verbose);
                 {
-                    auto *output_results = &results;
+                    auto* output_results = &results;
                     std::vector<TimeAndFlows> modified_results = {};
-                    if (time_step_h > 0.) {
-                        modified_results = applyUniformTimeStep(results, time_step_h);
+                    if (time_step_h > 0.)
+                    {
+                        modified_results =
+                            applyUniformTimeStep(results, time_step_h);
                         output_results = &modified_results;
                     }
 
                     // TODO: investigate putting output on another thread
                     WriteResultsToEventFile(
-                            out,
-                            *output_results,
-                            s,
-                            scenarioTag,
-                            scenarioStartTimeTag,
-                            connOrder,
-                            storeOrder,
-                            compOrder,
-                            outputTimeUnit
+                        out,
+                        *output_results,
+                        s,
+                        scenarioTag,
+                        scenarioStartTimeTag,
+                        connOrder,
+                        storeOrder,
+                        compOrder,
+                        outputTimeUnit
                     );
                 }
                 ScenarioOccurrenceStats sos =
-                        ModelResults_CalculateScenarioOccurrenceStats(
-                                scenIdx, occIdx + 1, s.TheModel, s.FlowTypeMap, results
-                        );
+                    ModelResults_CalculateScenarioOccurrenceStats(
+                        scenIdx, occIdx + 1, s.TheModel, s.FlowTypeMap, results
+                    );
                 occurrenceStats.push_back(std::move(sos));
                 s.TheModel.Reliabilities = originalReliabilities;
             }
-            if (verbose) {
+            if (verbose)
+            {
                 std::cout << "Scenario " << scenarioTag << " finished"
                           << std::endl;
             }
@@ -2417,7 +2811,7 @@ namespace erin {
         }
         out.close();
         WriteStatisticsToFile(
-                s, statsFilename, occurrenceStats, compOrder, failOrder, fragOrder
+            s, statsFilename, occurrenceStats, compOrder, failOrder, fragOrder
         );
     }
 } // namespace erin

--- a/src/erin_next_simulation.cpp
+++ b/src/erin_next_simulation.cpp
@@ -24,11 +24,9 @@
 #include <sstream>
 #include <cstdlib>
 
-namespace erin
-{
+namespace erin {
     void
-    Simulation_Init(Simulation& s)
-    {
+    Simulation_Init(Simulation &s) {
         // NOTE: we register a 'null' flow. This allows users to 'opt-out'
         // of flow specification by passing empty strings. Effectively, this
         // allows any connections to occur which is nice for simple examples.
@@ -36,13 +34,10 @@ namespace erin
     }
 
     size_t
-    Simulation_RegisterFlow(Simulation& s, std::string const& flowTag)
-    {
+    Simulation_RegisterFlow(Simulation &s, std::string const &flowTag) {
         size_t id = s.FlowTypeMap.Type.size();
-        for (size_t i = 0; i < id; ++i)
-        {
-            if (s.FlowTypeMap.Type[i] == flowTag)
-            {
+        for (size_t i = 0; i < id; ++i) {
+            if (s.FlowTypeMap.Type[i] == flowTag) {
                 return i;
             }
         }
@@ -51,18 +46,14 @@ namespace erin
     }
 
     size_t
-    Simulation_RegisterScenario(Simulation& s, std::string const& scenarioTag)
-    {
+    Simulation_RegisterScenario(Simulation &s, std::string const &scenarioTag) {
         return ScenarioDict_RegisterScenario(s.ScenarioMap, scenarioTag);
     }
 
     size_t
-    Simulation_RegisterIntensity(Simulation& s, std::string const& tag)
-    {
-        for (size_t i = 0; i < s.Intensities.Tags.size(); ++i)
-        {
-            if (s.Intensities.Tags[i] == tag)
-            {
+    Simulation_RegisterIntensity(Simulation &s, std::string const &tag) {
+        for (size_t i = 0; i < s.Intensities.Tags.size(); ++i) {
+            if (s.Intensities.Tags[i] == tag) {
                 return i;
             }
         }
@@ -73,17 +64,14 @@ namespace erin
 
     size_t
     Simulation_RegisterIntensityLevelForScenario(
-        Simulation& s,
-        size_t scenarioId,
-        size_t intensityId,
-        double intensityLevel
-    )
-    {
-        for (size_t i = 0; i < s.ScenarioIntensities.IntensityIds.size(); ++i)
-        {
+            Simulation &s,
+            size_t scenarioId,
+            size_t intensityId,
+            double intensityLevel
+    ) {
+        for (size_t i = 0; i < s.ScenarioIntensities.IntensityIds.size(); ++i) {
             if (s.ScenarioIntensities.IntensityIds[i] == intensityId
-                && s.ScenarioIntensities.ScenarioIds[i] == scenarioId)
-            {
+                && s.ScenarioIntensities.ScenarioIds[i] == scenarioId) {
                 s.ScenarioIntensities.IntensityLevels[i] = intensityLevel;
                 return i;
             }
@@ -97,17 +85,14 @@ namespace erin
 
     size_t
     Simulation_RegisterLoadSchedule(
-        Simulation& s,
-        std::string const& tag,
-        std::vector<TimeAndAmount> const& loadSchedule
-    )
-    {
+            Simulation &s,
+            std::string const &tag,
+            std::vector<TimeAndAmount> const &loadSchedule
+    ) {
         size_t id = s.LoadMap.Tags.size();
         assert(s.LoadMap.Tags.size() == s.LoadMap.Loads.size());
-        for (size_t i = 0; i < id; ++i)
-        {
-            if (s.LoadMap.Tags[i] == tag)
-            {
+        for (size_t i = 0; i < id; ++i) {
+            if (s.LoadMap.Tags[i] == tag) {
                 s.LoadMap.Loads[i].clear();
                 s.LoadMap.Loads[i] = loadSchedule;
                 return i;
@@ -119,12 +104,9 @@ namespace erin
     }
 
     std::optional<size_t>
-    Simulation_GetLoadIdByTag(Simulation const& s, std::string const& tag)
-    {
-        for (size_t i = 0; i < s.LoadMap.Tags.size(); ++i)
-        {
-            if (s.LoadMap.Tags[i] == tag)
-            {
+    Simulation_GetLoadIdByTag(Simulation const &s, std::string const &tag) {
+        for (size_t i = 0; i < s.LoadMap.Tags.size(); ++i) {
+            if (s.LoadMap.Tags[i] == tag) {
                 return i;
             }
         }
@@ -132,74 +114,60 @@ namespace erin
     }
 
     void
-    Simulation_RegisterAllLoads(Simulation& s, std::vector<Load> const& loads)
-    {
+    Simulation_RegisterAllLoads(Simulation &s, std::vector<Load> const &loads) {
         s.LoadMap.Tags.clear();
         s.LoadMap.Loads.clear();
         auto numLoads = loads.size();
         s.LoadMap.Tags.reserve(numLoads);
         s.LoadMap.Loads.reserve(numLoads);
-        for (size_t i = 0; i < numLoads; ++i)
-        {
+        for (size_t i = 0; i < numLoads; ++i) {
             s.LoadMap.Tags.push_back(loads[i].Tag);
             s.LoadMap.Loads.push_back(loads[i].TimeAndLoads);
         }
     }
 
     void
-    Simulation_PrintComponents(Simulation const& s)
-    {
-        Model const& m = s.TheModel;
-        for (size_t i = 0; i < m.ComponentMap.CompType.size(); ++i)
-        {
+    Simulation_PrintComponents(Simulation const &s) {
+        Model const &m = s.TheModel;
+        for (size_t i = 0; i < m.ComponentMap.CompType.size(); ++i) {
             assert(i < m.ComponentMap.OutflowType.size());
             assert(i < m.ComponentMap.InflowType.size());
             assert(i < m.ComponentMap.CompType.size());
             assert(i < m.ComponentMap.Tag.size());
             assert(i < m.ComponentMap.Idx.size());
-            std::vector<size_t> const& outflowTypes =
-                m.ComponentMap.OutflowType[i];
+            std::vector<size_t> const &outflowTypes =
+                    m.ComponentMap.OutflowType[i];
             std::vector<size_t> inflowTypes = m.ComponentMap.InflowType[i];
             std::cout << i << ": " << ToString(m.ComponentMap.CompType[i]);
-            if (!m.ComponentMap.Tag[i].empty())
-            {
+            if (!m.ComponentMap.Tag[i].empty()) {
                 std::cout << " -- " << m.ComponentMap.Tag[i] << std::endl;
-            }
-            else
-            {
+            } else {
                 std::cout << std::endl;
             }
             for (size_t inportIdx = 0; inportIdx < inflowTypes.size();
-                 ++inportIdx)
-            {
+                 ++inportIdx) {
                 size_t inflowType = inflowTypes[inportIdx];
                 if (inflowType < s.FlowTypeMap.Type.size()
-                    && !s.FlowTypeMap.Type[inflowType].empty())
-                {
+                    && !s.FlowTypeMap.Type[inflowType].empty()) {
                     std::cout << "- inport " << inportIdx << ": "
                               << s.FlowTypeMap.Type[inflowType] << std::endl;
                 }
             }
             for (size_t outportIdx = 0; outportIdx < outflowTypes.size();
-                 ++outportIdx)
-            {
+                 ++outportIdx) {
                 size_t outflowType = outflowTypes[outportIdx];
                 if (outflowType < s.FlowTypeMap.Type.size()
-                    && !s.FlowTypeMap.Type[outflowType].empty())
-                {
+                    && !s.FlowTypeMap.Type[outflowType].empty()) {
                     std::cout << "- outport " << outportIdx << ": "
                               << s.FlowTypeMap.Type[outflowType] << std::endl;
                 }
             }
             size_t subtypeIdx = m.ComponentMap.Idx[i];
-            switch (m.ComponentMap.CompType[i])
-            {
-                case ComponentType::ScheduleBasedLoadType:
-                {
+            switch (m.ComponentMap.CompType[i]) {
+                case ComponentType::ScheduleBasedLoadType: {
                     assert(subtypeIdx < m.ScheduledLoads.size());
-                    ScheduleBasedLoad const& sbl = m.ScheduledLoads[subtypeIdx];
-                    for (auto const& keyValue : sbl.ScenarioIdToLoadId)
-                    {
+                    ScheduleBasedLoad const &sbl = m.ScheduledLoads[subtypeIdx];
+                    for (auto const &keyValue: sbl.ScenarioIdToLoadId) {
                         size_t scenarioIdx = keyValue.first;
                         size_t loadIdx = keyValue.second;
                         assert(scenarioIdx < s.ScenarioMap.Tags.size());
@@ -210,14 +178,12 @@ namespace erin
                                   << std::endl;
                     }
                 }
-                break;
-                case ComponentType::ScheduleBasedSourceType:
-                {
+                    break;
+                case ComponentType::ScheduleBasedSourceType: {
                     assert(subtypeIdx < m.ScheduledSrcs.size());
-                    ScheduleBasedSource const& sbs =
-                        m.ScheduledSrcs[subtypeIdx];
-                    for (auto const& keyValue : sbs.ScenarioIdToSourceId)
-                    {
+                    ScheduleBasedSource const &sbs =
+                            m.ScheduledSrcs[subtypeIdx];
+                    for (auto const &keyValue: sbs.ScenarioIdToSourceId) {
                         size_t scenarioIdx = keyValue.first;
                         size_t loadIdx = keyValue.second;
                         assert(scenarioIdx < s.ScenarioMap.Tags.size());
@@ -229,99 +195,92 @@ namespace erin
                     }
                     std::cout << "-- max outflow (W): "
                               << (sbs.MaxOutflow_W == max_flow_W
-                                      ? "unlimited"
-                                      : std::to_string(sbs.MaxOutflow_W))
+                                  ? "unlimited"
+                                  : std::to_string(sbs.MaxOutflow_W))
                               << std::endl;
                 }
-                break;
-                case ComponentType::ConstantEfficiencyConverterType:
-                {
+                    break;
+                case ComponentType::ConstantEfficiencyConverterType: {
                     assert(subtypeIdx < m.ConstEffConvs.size());
-                    ConstantEfficiencyConverter const& cec =
-                        m.ConstEffConvs[subtypeIdx];
+                    ConstantEfficiencyConverter const &cec =
+                            m.ConstEffConvs[subtypeIdx];
                     std::cout << "-- efficiency: " << cec.Efficiency * 100.0
                               << "%" << std::endl;
                     std::cout << "-- max outflow (W): "
                               << (cec.MaxOutflow_W == max_flow_W
-                                      ? "unlimited"
-                                      : std::to_string(cec.MaxOutflow_W))
+                                  ? "unlimited"
+                                  : std::to_string(cec.MaxOutflow_W))
                               << std::endl;
                     std::cout << "-- max lossflow (W): "
                               << (cec.MaxLossflow_W == max_flow_W
-                                      ? "unlimited"
-                                      : std::to_string(cec.MaxLossflow_W))
+                                  ? "unlimited"
+                                  : std::to_string(cec.MaxLossflow_W))
                               << std::endl;
                 }
-                break;
-                case ComponentType::VariableEfficiencyConverterType:
-                {
+                    break;
+                case ComponentType::VariableEfficiencyConverterType: {
                     assert(subtypeIdx < m.VarEffConvs.size());
-                    VariableEfficiencyConverter const& vec =
-                        m.VarEffConvs[subtypeIdx];
+                    VariableEfficiencyConverter const &vec =
+                            m.VarEffConvs[subtypeIdx];
                     std::cout << "-- efficiencies by load fraction:"
                               << std::endl;
                     double maxOutflow_W = static_cast<double>(vec.MaxOutflow_W);
-                    for (size_t i = 0; i < vec.Efficiencies.size(); ++i)
-                    {
+                    for (size_t i = 0; i < vec.Efficiencies.size(); ++i) {
                         std::cout << fmt::format(
-                            "  -- {:5.3f}",
-                            (vec.OutflowsForEfficiency_W[i] / maxOutflow_W)
+                                "  -- {:5.3f}",
+                                (vec.OutflowsForEfficiency_W[i] / maxOutflow_W)
                         );
                         std::cout << fmt::format(
-                            ": {:5.2f}%", (vec.Efficiencies[i] * 100.0)
+                                ": {:5.2f}%", (vec.Efficiencies[i] * 100.0)
                         ) << std::endl;
                     }
                     std::cout << "-- max outflow (W): "
                               << (vec.MaxOutflow_W == max_flow_W
-                                      ? "unlimited"
-                                      : std::to_string(vec.MaxOutflow_W))
+                                  ? "unlimited"
+                                  : std::to_string(vec.MaxOutflow_W))
                               << std::endl;
                     std::cout << "-- max lossflow (W): "
                               << (vec.MaxLossflow_W == max_flow_W
-                                      ? "unlimited"
-                                      : std::to_string(vec.MaxLossflow_W))
+                                  ? "unlimited"
+                                  : std::to_string(vec.MaxLossflow_W))
                               << std::endl;
                 }
-                break;
-                case ComponentType::MoverType:
-                {
+                    break;
+                case ComponentType::MoverType: {
                     assert(subtypeIdx < m.Movers.size());
-                    Mover const& mov = m.Movers[subtypeIdx];
+                    Mover const &mov = m.Movers[subtypeIdx];
                     std::cout << "-- cop: " << mov.COP << std::endl;
                     std::cout << "-- max outflow (W): "
                               << (mov.MaxOutflow_W == max_flow_W
-                                      ? "unlimited"
-                                      : std::to_string(mov.MaxOutflow_W))
+                                  ? "unlimited"
+                                  : std::to_string(mov.MaxOutflow_W))
                               << std::endl;
                 }
-                break;
-                case ComponentType::VariableEfficiencyMoverType:
-                {
+                    break;
+                case ComponentType::VariableEfficiencyMoverType: {
                     assert(subtypeIdx < m.VarEffMovers.size());
-                    VariableEfficiencyMover const& mov =
-                        m.VarEffMovers[subtypeIdx];
+                    VariableEfficiencyMover const &mov =
+                            m.VarEffMovers[subtypeIdx];
                     std::cout << "-- cop by load fraction:" << std::endl;
                     double maxOutflow_W = mov.MaxOutflow_W;
-                    for (size_t i = 0; i < mov.COPs.size(); ++i)
-                    {
+                    for (size_t i = 0; i < mov.COPs.size(); ++i) {
                         std::cout << fmt::format(
-                            " -- {:5.3f}",
-                            (mov.OutflowsForCop_W[i] / maxOutflow_W)
+                                " -- {:5.3f}",
+                                (mov.OutflowsForCop_W[i] / maxOutflow_W)
                         );
                         std::cout << fmt::format(": {:5.2f}", (mov.COPs[i]))
                                   << std::endl;
                     }
                     std::cout << "-- max outflow (W): "
                               << (mov.MaxOutflow_W == max_flow_W
-                                      ? "unlimited"
-                                      : std::to_string(maxOutflow_W))
+                                  ? "unlimited"
+                                  : std::to_string(maxOutflow_W))
                               << std::endl;
                 }
-                break;
-                case ComponentType::StoreType:
-                {
+                    break;
+                case ComponentType::StoreType: {
                     assert(subtypeIdx < m.Stores.size());
-                    Store const& store = m.Stores[subtypeIdx];
+                    Store const &store = m.Stores[subtypeIdx];
                     std::cout << "-- capacity (J): " << store.Capacity_J
                               << std::endl;
                     std::cout << "-- initial SOC: "
@@ -335,86 +294,76 @@ namespace erin
                                   / static_cast<double>(store.Capacity_J))
                               << std::endl;
                     std::cout
-                        << "-- max charge rate (W): " << store.MaxChargeRate_W
-                        << std::endl;
+                            << "-- max charge rate (W): " << store.MaxChargeRate_W
+                            << std::endl;
                     std::cout << "-- max discharge rate (W): "
                               << store.MaxDischargeRate_W << std::endl;
                     std::cout << "-- max outflow (W): "
                               << (store.MaxOutflow_W == max_flow_W
-                                      ? "unlimited"
-                                      : std::to_string(store.MaxOutflow_W))
+                                  ? "unlimited"
+                                  : std::to_string(store.MaxOutflow_W))
                               << std::endl;
                     std::cout << "-- roundtrip efficiency: "
                               << store.RoundTripEfficiency * 100.0 << "%"
                               << std::endl;
                 }
-                break;
-                case ComponentType::PassThroughType:
-                {
+                    break;
+                case ComponentType::PassThroughType: {
                     assert(subtypeIdx < m.PassThroughs.size());
-                    PassThrough const& pt = m.PassThroughs[subtypeIdx];
+                    PassThrough const &pt = m.PassThroughs[subtypeIdx];
                     std::cout << "-- max outflow (W): "
                               << (pt.MaxOutflow_W == max_flow_W
-                                      ? "unlimited"
-                                      : std::to_string(pt.MaxOutflow_W))
+                                  ? "unlimited"
+                                  : std::to_string(pt.MaxOutflow_W))
                               << std::endl;
                 }
-                break;
-                default:
-                {
+                    break;
+                default: {
                 }
-                break;
+                    break;
             }
             for (size_t compFailModeIdx = 0;
                  compFailModeIdx < s.ComponentFailureModes.ComponentIds.size();
-                 ++compFailModeIdx)
-            {
-                if (s.ComponentFailureModes.ComponentIds[compFailModeIdx] == i)
-                {
+                 ++compFailModeIdx) {
+                if (s.ComponentFailureModes.ComponentIds[compFailModeIdx] == i) {
                     size_t fmId =
-                        s.ComponentFailureModes.FailureModeIds[compFailModeIdx];
+                            s.ComponentFailureModes.FailureModeIds[compFailModeIdx];
                     std::cout
-                        << "-- failure-mode: " << s.FailureModes.Tags[fmId]
-                        << "[" << fmId << "]" << std::endl;
+                            << "-- failure-mode: " << s.FailureModes.Tags[fmId]
+                            << "[" << fmId << "]" << std::endl;
                 }
             }
             for (size_t compFragIdx = 0;
                  compFragIdx < s.ComponentFragilities.ComponentIds.size();
-                 ++compFragIdx)
-            {
-                if (s.ComponentFragilities.ComponentIds[compFragIdx] == i)
-                {
+                 ++compFragIdx) {
+                if (s.ComponentFragilities.ComponentIds[compFragIdx] == i) {
                     size_t fmId =
-                        s.ComponentFragilities.FragilityModeIds[compFragIdx];
+                            s.ComponentFragilities.FragilityModeIds[compFragIdx];
                     std::cout
-                        << "-- fragility mode: " << s.FragilityModes.Tags[fmId]
-                        << "[" << fmId << "]" << std::endl;
+                            << "-- fragility mode: " << s.FragilityModes.Tags[fmId]
+                            << "[" << fmId << "]" << std::endl;
                 }
             }
         }
     }
 
     void
-    Simulation_PrintFragilityCurves(Simulation const& s)
-    {
+    Simulation_PrintFragilityCurves(Simulation const &s) {
         assert(
-            s.FragilityCurves.CurveId.size()
-            == s.FragilityCurves.CurveTypes.size()
+                s.FragilityCurves.CurveId.size()
+                == s.FragilityCurves.CurveTypes.size()
         );
         assert(
-            s.FragilityCurves.CurveId.size() == s.FragilityCurves.Tags.size()
+                s.FragilityCurves.CurveId.size() == s.FragilityCurves.Tags.size()
         );
-        for (size_t i = 0; i < s.FragilityCurves.CurveId.size(); ++i)
-        {
+        for (size_t i = 0; i < s.FragilityCurves.CurveId.size(); ++i) {
             std::cout << i << ": "
                       << FragilityCurveTypeToTag(s.FragilityCurves.CurveTypes[i]
-                         )
+                      )
                       << " -- " << s.FragilityCurves.Tags[i] << std::endl;
             size_t idx = s.FragilityCurves.CurveId[i];
-            switch (s.FragilityCurves.CurveTypes[i])
-            {
-                case (FragilityCurveType::Linear):
-                {
+            switch (s.FragilityCurves.CurveTypes[i]) {
+                case (FragilityCurveType::Linear): {
                     std::cout << "-- lower bound: "
                               << s.LinearFragilityCurves[idx].LowerBound
                               << std::endl;
@@ -422,79 +371,68 @@ namespace erin
                               << s.LinearFragilityCurves[idx].UpperBound
                               << std::endl;
                     size_t intensityId =
-                        s.LinearFragilityCurves[idx].VulnerabilityId;
+                            s.LinearFragilityCurves[idx].VulnerabilityId;
                     std::cout << "-- vulnerable to: "
                               << s.Intensities.Tags[intensityId] << "["
                               << intensityId << "]" << std::endl;
                 }
-                break;
-                case (FragilityCurveType::Tabular):
-                {
+                    break;
+                case (FragilityCurveType::Tabular): {
                     size_t size =
-                        s.TabularFragilityCurves[idx].Intensities.size();
+                            s.TabularFragilityCurves[idx].Intensities.size();
                     size_t intensityId =
-                        s.TabularFragilityCurves[idx].VulnerabilityId;
-                    if (size > 0)
-                    {
+                            s.TabularFragilityCurves[idx].VulnerabilityId;
+                    if (size > 0) {
                         std::cout
-                            << "-- intensity from "
-                            << s.TabularFragilityCurves[idx].Intensities[0]
-                            << " to "
-                            << s.TabularFragilityCurves[idx]
-                                   .Intensities[size - 1]
-                            << std::endl;
+                                << "-- intensity from "
+                                << s.TabularFragilityCurves[idx].Intensities[0]
+                                << " to "
+                                << s.TabularFragilityCurves[idx]
+                                        .Intensities[size - 1]
+                                << std::endl;
                         std::cout << "-- vulnerable to: "
                                   << s.Intensities.Tags[intensityId] << "["
                                   << intensityId << "]" << std::endl;
                     }
                 }
-                break;
-                default:
-                {
+                    break;
+                default: {
                     std::cout << "unhandled fragility curve type" << std::endl;
                     std::exit(1);
                 }
-                break;
+                    break;
             }
         }
     }
 
     void
-    Simulation_PrintFailureModes(Simulation const& s)
-    {
-        for (size_t i = 0; i < s.FailureModes.Tags.size(); ++i)
-        {
+    Simulation_PrintFailureModes(Simulation const &s) {
+        for (size_t i = 0; i < s.FailureModes.Tags.size(); ++i) {
             auto maybeFailureDist = s.TheModel.DistSys.get_dist_by_id(
-                s.FailureModes.FailureDistIds[i]
+                    s.FailureModes.FailureDistIds[i]
             );
             auto maybeRepairDist = s.TheModel.DistSys.get_dist_by_id(
-                s.FailureModes.RepairDistIds[i]
+                    s.FailureModes.RepairDistIds[i]
             );
             std::cout << i << ": " << s.FailureModes.Tags[i] << std::endl;
-            if (maybeFailureDist.has_value())
-            {
+            if (maybeFailureDist.has_value()) {
                 Distribution failureDist = maybeFailureDist.value();
                 std::cout << "-- failure distribution: " << failureDist.Tag
                           << ", " << dist_type_to_tag(failureDist.Type) << "["
                           << s.FailureModes.FailureDistIds[i] << "]"
                           << std::endl;
-            }
-            else
-            {
+            } else {
                 std::cout << "-- ERROR! Problem finding failure distribution "
                           << " with id = " << s.FailureModes.FailureDistIds[i]
                           << std::endl;
             }
-            if (maybeRepairDist.has_value())
-            {
+            if (maybeRepairDist.has_value()) {
                 Distribution repairDist = maybeRepairDist.value();
                 std::cout << "-- repair distribution: " << repairDist.Tag
                           << ", " << dist_type_to_tag(repairDist.Type) << "["
                           << s.FailureModes.RepairDistIds[i] << "]"
                           << std::endl;
-            }
-            else
-            {
+            } else {
                 std::cout << "-- ERROR! Problem finding repair distribution "
                           << " with id = " << s.FailureModes.RepairDistIds[i]
                           << std::endl;
@@ -503,24 +441,20 @@ namespace erin
     }
 
     void
-    Simulation_PrintFragilityModes(Simulation const& s)
-    {
-        for (size_t i = 0; i < s.FragilityModes.Tags.size(); ++i)
-        {
+    Simulation_PrintFragilityModes(Simulation const &s) {
+        for (size_t i = 0; i < s.FragilityModes.Tags.size(); ++i) {
             std::cout << i << ": " << s.FragilityModes.Tags[i] << std::endl;
             std::cout
-                << "-- fragility curve: "
-                << s.FragilityCurves.Tags[s.FragilityModes.FragilityCurveId[i]]
-                << "[" << s.FragilityModes.FragilityCurveId[i] << "]"
-                << std::endl;
-            if (s.FragilityModes.RepairDistIds[i].has_value())
-            {
+                    << "-- fragility curve: "
+                    << s.FragilityCurves.Tags[s.FragilityModes.FragilityCurveId[i]]
+                    << "[" << s.FragilityModes.FragilityCurveId[i] << "]"
+                    << std::endl;
+            if (s.FragilityModes.RepairDistIds[i].has_value()) {
                 std::optional<Distribution> maybeDist =
-                    s.TheModel.DistSys.get_dist_by_id(
-                        s.FragilityModes.RepairDistIds[i].value()
-                    );
-                if (maybeDist.has_value())
-                {
+                        s.TheModel.DistSys.get_dist_by_id(
+                                s.FragilityModes.RepairDistIds[i].value()
+                        );
+                if (maybeDist.has_value()) {
                     Distribution d = maybeDist.value();
                     std::cout << "-- repair dist: " << d.Tag << "["
                               << s.FragilityModes.RepairDistIds[i].value()
@@ -531,18 +465,15 @@ namespace erin
     }
 
     void
-    Simulation_PrintScenarios(Simulation const& s)
-    {
-        for (size_t i = 0; i < s.ScenarioMap.Tags.size(); ++i)
-        {
+    Simulation_PrintScenarios(Simulation const &s) {
+        for (size_t i = 0; i < s.ScenarioMap.Tags.size(); ++i) {
             std::cout << i << ": " << s.ScenarioMap.Tags[i] << std::endl;
             std::cout << "- duration: " << s.ScenarioMap.Durations[i] << " "
                       << TimeUnitToTag(s.ScenarioMap.TimeUnits[i]) << std::endl;
             auto maybeDist = s.TheModel.DistSys.get_dist_by_id(
-                s.ScenarioMap.OccurrenceDistributionIds[i]
+                    s.ScenarioMap.OccurrenceDistributionIds[i]
             );
-            if (maybeDist.has_value())
-            {
+            if (maybeDist.has_value()) {
                 Distribution d = maybeDist.value();
                 std::cout << "- occurrence distribution: "
                           << dist_type_to_tag(d.Type) << "["
@@ -550,56 +481,47 @@ namespace erin
                           << "] -- " << d.Tag << std::endl;
             }
             std::cout << "- max occurrences: ";
-            if (s.ScenarioMap.MaxOccurrences[i].has_value())
-            {
+            if (s.ScenarioMap.MaxOccurrences[i].has_value()) {
                 std::cout << s.ScenarioMap.MaxOccurrences[i].value()
                           << std::endl;
-            }
-            else
-            {
+            } else {
                 std::cout << "no limit" << std::endl;
             }
             bool printedHeader = false;
             for (size_t siIdx = 0;
                  siIdx < s.ScenarioIntensities.IntensityIds.size();
-                 ++siIdx)
-            {
-                if (s.ScenarioIntensities.ScenarioIds[siIdx] == i)
-                {
-                    if (!printedHeader)
-                    {
+                 ++siIdx) {
+                if (s.ScenarioIntensities.ScenarioIds[siIdx] == i) {
+                    if (!printedHeader) {
                         std::cout << "- intensities:" << std::endl;
                         printedHeader = true;
                     }
                     auto intId = s.ScenarioIntensities.IntensityIds[siIdx];
-                    auto const& intTag = s.Intensities.Tags[intId];
+                    auto const &intTag = s.Intensities.Tags[intId];
                     std::cout
-                        << "-- " << intTag << "[" << intId
-                        << "]: " << s.ScenarioIntensities.IntensityLevels[siIdx]
-                        << std::endl;
+                            << "-- " << intTag << "[" << intId
+                            << "]: " << s.ScenarioIntensities.IntensityLevels[siIdx]
+                            << std::endl;
                 }
             }
         }
     }
 
     void
-    Simulation_PrintLoads(Simulation const& s)
-    {
-        for (size_t i = 0; i < s.LoadMap.Tags.size(); ++i)
-        {
+    Simulation_PrintLoads(Simulation const &s) {
+        for (size_t i = 0; i < s.LoadMap.Tags.size(); ++i) {
             std::cout << i << ": " << s.LoadMap.Tags[i] << std::endl;
             std::cout << "- load entries: " << s.LoadMap.Loads[i].size()
                       << std::endl;
-            if (s.LoadMap.Loads[i].size() > 0)
-            {
+            if (s.LoadMap.Loads[i].size() > 0) {
                 // TODO: add time units
                 std::cout << "- initial time: " << s.LoadMap.Loads[i][0].Time_s
                           << std::endl;
                 // TODO: add time units
                 std::cout
-                    << "- final time  : "
-                    << s.LoadMap.Loads[i][s.LoadMap.Loads[i].size() - 1].Time_s
-                    << std::endl;
+                        << "- final time  : "
+                        << s.LoadMap.Loads[i][s.LoadMap.Loads[i].size() - 1].Time_s
+                        << std::endl;
                 // TODO: add max rate
                 // TODO: add min rate
                 // TODO: add average rate
@@ -615,66 +537,57 @@ namespace erin
     }
 
     size_t
-    Simulation_ScenarioCount(Simulation const& s)
-    {
+    Simulation_ScenarioCount(Simulation const &s) {
         return s.ScenarioMap.Tags.size();
     }
 
     Result
     Simulation_ParseSimulationInfo(
-        Simulation& s,
-        toml::value const& v,
-        ValidationInfo const& validationInfo
-    )
-    {
-        if (!v.contains("simulation_info"))
-        {
+            Simulation &s,
+            toml::value const &v,
+            ValidationInfo const &validationInfo
+    ) {
+        if (!v.contains("simulation_info")) {
             WriteErrorMessage(
-                "simulation_info",
-                "Required section [simulation_info] not found"
+                    "simulation_info",
+                    "Required section [simulation_info] not found"
             );
             return Result::Failure;
         }
-        toml::value const& simInfoValue = v.at("simulation_info");
-        if (!simInfoValue.is_table())
-        {
+        toml::value const &simInfoValue = v.at("simulation_info");
+        if (!simInfoValue.is_table()) {
             WriteErrorMessage(
-                "simulation_info",
-                "Required section [simulation_info] is not a table"
+                    "simulation_info",
+                    "Required section [simulation_info] is not a table"
             );
             return Result::Failure;
         }
-        toml::table const& simInfoTable = simInfoValue.as_table();
+        toml::table const &simInfoTable = simInfoValue.as_table();
         std::vector<std::string> errors;
         std::vector<std::string> warnings;
-        std::unordered_map<std::string, InputValue> inputs =
-            TOMLTable_ParseWithValidation(
-                simInfoTable,
-                validationInfo,
-                "simulation_info",
-                errors,
-                warnings
-            );
-        if (warnings.size() > 0)
-        {
+        std::unordered_map < std::string, InputValue > inputs =
+                                                  TOMLTable_ParseWithValidation(
+                                                          simInfoTable,
+                                                          validationInfo,
+                                                          "simulation_info",
+                                                          errors,
+                                                          warnings
+                                                  );
+        if (warnings.size() > 0) {
             std::cout << "WARNINGS:" << std::endl;
-            for (auto const& w : warnings)
-            {
+            for (auto const &w: warnings) {
                 std::cerr << w << std::endl;
             }
         }
-        if (errors.size() > 0)
-        {
+        if (errors.size() > 0) {
             std::cout << "ERRORS:" << std::endl;
-            for (auto const& err : errors)
-            {
+            for (auto const &err: errors) {
                 std::cerr << err << std::endl;
             }
             return Result::Failure;
         }
         auto maybeSimInfo = ParseSimulationInfo(inputs);
-        if (!maybeSimInfo.has_value())
-        {
+        if (!maybeSimInfo.has_value()) {
             return Result::Failure;
         }
         s.Info = std::move(maybeSimInfo.value());
@@ -683,18 +596,16 @@ namespace erin
 
     Result
     Simulation_ParseLoads(
-        Simulation& s,
-        toml::value const& v,
-        ValidationInfo const& explicitValidation,
-        ValidationInfo const& fileValidation
-    )
-    {
-        toml::value const& loadTable = v.at("loads");
+            Simulation &s,
+            toml::value const &v,
+            ValidationInfo const &explicitValidation,
+            ValidationInfo const &fileValidation
+    ) {
+        toml::value const &loadTable = v.at("loads");
         auto maybeLoads = ParseLoads(
-            loadTable.as_table(), explicitValidation, fileValidation
+                loadTable.as_table(), explicitValidation, fileValidation
         );
-        if (!maybeLoads.has_value())
-        {
+        if (!maybeLoads.has_value()) {
             return Result::Failure;
         }
         std::vector<Load> loads = std::move(maybeLoads.value());
@@ -705,25 +616,21 @@ namespace erin
     // TODO: change this to a std::optional<size_t> GetFragilityCurveByTag()
     // if it returns !*.has_value(), register with the bogus data explicitly.
     size_t
-    Simulation_RegisterFragilityCurve(Simulation& s, std::string const& tag)
-    {
+    Simulation_RegisterFragilityCurve(Simulation &s, std::string const &tag) {
         return Simulation_RegisterFragilityCurve(
-            s, tag, FragilityCurveType::Linear, 0
+                s, tag, FragilityCurveType::Linear, 0
         );
     }
 
     size_t
     Simulation_RegisterFragilityCurve(
-        Simulation& s,
-        std::string const& tag,
-        FragilityCurveType curveType,
-        size_t curveIdx
-    )
-    {
-        for (size_t i = 0; i < s.FragilityCurves.Tags.size(); ++i)
-        {
-            if (s.FragilityCurves.Tags[i] == tag)
-            {
+            Simulation &s,
+            std::string const &tag,
+            FragilityCurveType curveType,
+            size_t curveIdx
+    ) {
+        for (size_t i = 0; i < s.FragilityCurves.Tags.size(); ++i) {
+            if (s.FragilityCurves.Tags[i] == tag) {
                 s.FragilityCurves.CurveId[i] = curveIdx;
                 s.FragilityCurves.CurveTypes[i] = curveType;
                 return i;
@@ -738,17 +645,14 @@ namespace erin
 
     size_t
     Simulation_RegisterFailureMode(
-        Simulation& s,
-        std::string const& tag,
-        size_t failureId,
-        size_t repairId
-    )
-    {
+            Simulation &s,
+            std::string const &tag,
+            size_t failureId,
+            size_t repairId
+    ) {
         size_t size = s.FailureModes.Tags.size();
-        for (size_t i = 0; i < size; ++i)
-        {
-            if (s.FailureModes.Tags[i] == tag)
-            {
+        for (size_t i = 0; i < size; ++i) {
+            if (s.FailureModes.Tags[i] == tag) {
                 s.FailureModes.FailureDistIds[i] = failureId;
                 s.FailureModes.RepairDistIds[i] = repairId;
                 return i;
@@ -763,17 +667,14 @@ namespace erin
 
     size_t
     Simulation_RegisterFragilityMode(
-        Simulation& s,
-        std::string const& tag,
-        size_t fragilityCurveId,
-        std::optional<size_t> maybeRepairDistId
-    )
-    {
+            Simulation &s,
+            std::string const &tag,
+            size_t fragilityCurveId,
+            std::optional<size_t> maybeRepairDistId
+    ) {
         size_t size = s.FragilityModes.Tags.size();
-        for (size_t i = 0; i < size; ++i)
-        {
-            if (s.FragilityModes.Tags[i] == tag)
-            {
+        for (size_t i = 0; i < size; ++i) {
+            if (s.FragilityModes.Tags[i] == tag) {
                 s.FragilityModes.FragilityCurveId[i] = fragilityCurveId;
                 s.FragilityModes.RepairDistIds[i] = maybeRepairDistId;
                 return i;
@@ -788,33 +689,29 @@ namespace erin
 
     std::optional<size_t>
     Parse_VulnerableTo(
-        Simulation const& s,
-        toml::table const& fcData,
-        std::string const& tableFullName
-    )
-    {
-        if (!fcData.contains("vulnerable_to"))
-        {
+            Simulation const &s,
+            toml::table const &fcData,
+            std::string const &tableFullName
+    ) {
+        if (!fcData.contains("vulnerable_to")) {
             WriteErrorMessage(
-                tableFullName, "missing required field 'vulnerable_to'"
+                    tableFullName, "missing required field 'vulnerable_to'"
             );
             return {};
         }
-        if (!fcData.at("vulnerable_to").is_string())
-        {
+        if (!fcData.at("vulnerable_to").is_string()) {
             WriteErrorMessage(
-                tableFullName, "field 'vulnerable_to' not a string"
+                    tableFullName, "field 'vulnerable_to' not a string"
             );
             return {};
         }
-        std::string const& vulnerStr = fcData.at("vulnerable_to").as_string();
+        std::string const &vulnerStr = fcData.at("vulnerable_to").as_string();
         std::optional<size_t> maybeIntId =
-            GetIntensityIdByTag(s.Intensities, vulnerStr);
-        if (!maybeIntId.has_value())
-        {
+                GetIntensityIdByTag(s.Intensities, vulnerStr);
+        if (!maybeIntId.has_value()) {
             WriteErrorMessage(
-                tableFullName,
-                "could not find referenced intensity '" + vulnerStr
+                    tableFullName,
+                    "could not find referenced intensity '" + vulnerStr
                     + "' for 'vulnerable_to'"
             );
             return {};
@@ -824,60 +721,52 @@ namespace erin
 
     Result
     Simulation_ParseLinearFragilityCurve(
-        Simulation& s,
-        std::string const& fcName,
-        std::string const& tableFullName,
-        toml::table const& fcData
-    )
-    {
-        if (!fcData.contains("lower_bound"))
-        {
+            Simulation &s,
+            std::string const &fcName,
+            std::string const &tableFullName,
+            toml::table const &fcData
+    ) {
+        if (!fcData.contains("lower_bound")) {
             std::cout << "[" << tableFullName << "] "
                       << "missing required field 'lower_bound'" << std::endl;
             return Result::Failure;
         }
         if (!(fcData.at("lower_bound").is_floating()
-              || fcData.at("lower_bound").is_integer()))
-        {
+              || fcData.at("lower_bound").is_integer())) {
             std::cout << "[" << tableFullName << "] "
                       << "field 'lower_bound' not a number" << std::endl;
             return Result::Failure;
         }
         std::optional<double> maybeLowerBound =
-            TOMLTable_ParseDouble(fcData, "lower_bound", tableFullName);
-        if (!maybeLowerBound.has_value())
-        {
+                TOMLTable_ParseDouble(fcData, "lower_bound", tableFullName);
+        if (!maybeLowerBound.has_value()) {
             std::cout << "[" << tableFullName << "] "
                       << "field 'lower_bound' has no value" << std::endl;
             return Result::Failure;
         }
         double lowerBound = maybeLowerBound.value();
-        if (!fcData.contains("upper_bound"))
-        {
+        if (!fcData.contains("upper_bound")) {
             std::cout << "[" << tableFullName << "] "
                       << "missing required field 'upper_bound'" << std::endl;
             return Result::Failure;
         }
         if (!(fcData.at("upper_bound").is_floating()
-              || fcData.at("upper_bound").is_integer()))
-        {
+              || fcData.at("upper_bound").is_integer())) {
             std::cout << "[" << tableFullName << "] "
                       << "field 'upper_bound' not a number" << std::endl;
             return Result::Failure;
         }
         std::optional<double> maybeUpperBound =
-            TOMLTable_ParseDouble(fcData, "upper_bound", tableFullName);
-        if (!maybeUpperBound.has_value())
-        {
+                TOMLTable_ParseDouble(fcData, "upper_bound", tableFullName);
+        if (!maybeUpperBound.has_value()) {
             std::cout << "[" << tableFullName << "] "
                       << "field 'upper_bound' has no value" << std::endl;
             return Result::Failure;
         }
         double upperBound = maybeUpperBound.value();
         std::optional<size_t> maybeIntId =
-            Parse_VulnerableTo(s, fcData, tableFullName);
-        if (!maybeIntId.has_value())
-        {
+                Parse_VulnerableTo(s, fcData, tableFullName);
+        if (!maybeIntId.has_value()) {
             return Result::Failure;
         }
         size_t intensityId = maybeIntId.value();
@@ -888,77 +777,64 @@ namespace erin
         size_t idx = s.LinearFragilityCurves.size();
         s.LinearFragilityCurves.push_back(std::move(lfc));
         Simulation_RegisterFragilityCurve(
-            s, fcName, FragilityCurveType::Linear, idx
+                s, fcName, FragilityCurveType::Linear, idx
         );
         return Result::Success;
     }
 
     Result
-    Simulation_ParseFragilityCurves(Simulation& s, toml::value const& v)
-    {
-        if (v.contains("fragility_curve"))
-        {
-            if (!v.at("fragility_curve").is_table())
-            {
+    Simulation_ParseFragilityCurves(Simulation &s, toml::value const &v) {
+        if (v.contains("fragility_curve")) {
+            if (!v.at("fragility_curve").is_table()) {
                 std::cout << "[fragility_curve] not a table" << std::endl;
                 return Result::Failure;
             }
-            for (auto const& pair : v.at("fragility_curve").as_table())
-            {
-                std::string const& fcName = pair.first;
+            for (auto const &pair: v.at("fragility_curve").as_table()) {
+                std::string const &fcName = pair.first;
                 std::string tableFullName = "fragility_curve." + fcName;
-                if (!pair.second.is_table())
-                {
+                if (!pair.second.is_table()) {
                     std::cout << "[" << tableFullName << "] not a table"
                               << std::endl;
                     return Result::Failure;
                 }
-                toml::table const& fcData = pair.second.as_table();
-                if (!fcData.contains("type"))
-                {
+                toml::table const &fcData = pair.second.as_table();
+                if (!fcData.contains("type")) {
                     std::cout << "[" << tableFullName << "] "
                               << "does not contain required value 'type'"
                               << std::endl;
                     return Result::Failure;
                 }
-                std::string const& typeStr = fcData.at("type").as_string();
+                std::string const &typeStr = fcData.at("type").as_string();
                 std::optional<FragilityCurveType> maybeFct =
-                    TagToFragilityCurveType(typeStr);
-                if (!maybeFct.has_value())
-                {
+                        TagToFragilityCurveType(typeStr);
+                if (!maybeFct.has_value()) {
                     std::cout << "[" << tableFullName << "] "
                               << "could not interpret type as string"
                               << std::endl;
                     return Result::Failure;
                 }
                 FragilityCurveType fct = maybeFct.value();
-                switch (fct)
-                {
-                    case (FragilityCurveType::Linear):
-                    {
+                switch (fct) {
+                    case (FragilityCurveType::Linear): {
                         if (Simulation_ParseLinearFragilityCurve(
                                 s, fcName, tableFullName, fcData
-                            )
-                            == Result::Failure)
-                        {
+                        )
+                            == Result::Failure) {
                             return Result::Failure;
                         }
                     }
-                    break;
-                    case (FragilityCurveType::Tabular):
-                    {
+                        break;
+                    case (FragilityCurveType::Tabular): {
                         std::optional<size_t> maybeIntId =
-                            Parse_VulnerableTo(s, fcData, tableFullName);
-                        if (!maybeIntId.has_value())
-                        {
+                                Parse_VulnerableTo(s, fcData, tableFullName);
+                        if (!maybeIntId.has_value()) {
                             return Result::Failure;
                         }
                         size_t intensityId = maybeIntId.value();
                         auto maybePairs = TOMLTable_ParseArrayOfPairsOfDouble(
-                            fcData, "intensity_failure_pairs", tableFullName
+                                fcData, "intensity_failure_pairs", tableFullName
                         );
-                        if (!maybePairs.has_value())
-                        {
+                        if (!maybePairs.has_value()) {
                             return Result::Failure;
                         }
                         PairsVector pv = maybePairs.value();
@@ -969,19 +845,18 @@ namespace erin
                         size_t subtypeIdx = s.TabularFragilityCurves.size();
                         s.TabularFragilityCurves.push_back(std::move(tfc));
                         Simulation_RegisterFragilityCurve(
-                            s, fcName, FragilityCurveType::Tabular, subtypeIdx
+                                s, fcName, FragilityCurveType::Tabular, subtypeIdx
                         );
                     }
-                    break;
-                    default:
-                    {
+                        break;
+                    default: {
                         WriteErrorMessage(
-                            tableFullName,
-                            "unhandled fragility curve type '" + typeStr + "'"
+                                tableFullName,
+                                "unhandled fragility curve type '" + typeStr + "'"
                         );
                         std::exit(1);
                     }
-                    break;
+                        break;
                 }
             }
         }
@@ -989,12 +864,9 @@ namespace erin
     }
 
     bool
-    Simulation_IsFailureModeNameUnique(Simulation& s, std::string const& name)
-    {
-        for (size_t i = 0; i < s.FailureModes.Tags.size(); ++i)
-        {
-            if (s.FailureModes.Tags[i] == name)
-            {
+    Simulation_IsFailureModeNameUnique(Simulation &s, std::string const &name) {
+        for (size_t i = 0; i < s.FailureModes.Tags.size(); ++i) {
+            if (s.FailureModes.Tags[i] == name) {
                 return false;
             }
         }
@@ -1002,12 +874,9 @@ namespace erin
     }
 
     bool
-    Simulation_IsFragilityModeNameUnique(Simulation& s, std::string const& name)
-    {
-        for (size_t i = 0; i < s.FragilityModes.Tags.size(); ++i)
-        {
-            if (s.FragilityModes.Tags[i] == name)
-            {
+    Simulation_IsFragilityModeNameUnique(Simulation &s, std::string const &name) {
+        for (size_t i = 0; i < s.FragilityModes.Tags.size(); ++i) {
+            if (s.FragilityModes.Tags[i] == name) {
                 return false;
             }
         }
@@ -1015,84 +884,73 @@ namespace erin
     }
 
     bool
-    Simulation_IsFailureNameUnique(Simulation& s, std::string const& name)
-    {
+    Simulation_IsFailureNameUnique(Simulation &s, std::string const &name) {
         return Simulation_IsFailureModeNameUnique(s, name)
-            && Simulation_IsFragilityModeNameUnique(s, name);
+               && Simulation_IsFragilityModeNameUnique(s, name);
     }
 
     Result
-    Simulation_ParseFailureModes(Simulation& s, toml::value const& v)
-    {
-        if (v.contains("failure_mode"))
-        {
-            if (!v.at("failure_mode").is_table())
-            {
+    Simulation_ParseFailureModes(Simulation &s, toml::value const &v) {
+        if (v.contains("failure_mode")) {
+            if (!v.at("failure_mode").is_table()) {
                 WriteErrorMessage(
-                    "failure_mode", "failure_mode section must be a table"
+                        "failure_mode", "failure_mode section must be a table"
                 );
                 return Result::Failure;
             }
-            toml::table const& fmTable = v.at("failure_mode").as_table();
-            for (auto const& pair : fmTable)
-            {
-                std::string const& fmName = pair.first;
+            toml::table const &fmTable = v.at("failure_mode").as_table();
+            for (auto const &pair: fmTable) {
+                std::string const &fmName = pair.first;
                 std::string const fullName = "failue_mode." + fmName;
-                if (!Simulation_IsFragilityModeNameUnique(s, fmName))
-                {
+                if (!Simulation_IsFragilityModeNameUnique(s, fmName)) {
                     WriteErrorMessage(
-                        fmName,
-                        "failure mode name must be unique within both "
-                        "failure_mode and fragility_mode names"
+                            fmName,
+                            "failure mode name must be unique within both "
+                            "failure_mode and fragility_mode names"
                     );
                     return Result::Failure;
                 }
-                if (!pair.second.is_table())
-                {
+                if (!pair.second.is_table()) {
                     WriteErrorMessage(fullName, "value must be a table");
                     return Result::Failure;
                 }
-                toml::table const& fmValueTable = pair.second.as_table();
-                if (!fmValueTable.contains("failure_dist"))
-                {
+                toml::table const &fmValueTable = pair.second.as_table();
+                if (!fmValueTable.contains("failure_dist")) {
                     WriteErrorMessage(
-                        fullName, "missing required field 'failure_dist'"
+                            fullName, "missing required field 'failure_dist'"
                     );
                     return Result::Failure;
                 }
                 auto maybeFailureDistTag = TOMLTable_ParseString(
-                    fmValueTable, "failure_dist", fullName
+                        fmValueTable, "failure_dist", fullName
                 );
-                if (!maybeFailureDistTag.has_value())
-                {
+                if (!maybeFailureDistTag.has_value()) {
                     WriteErrorMessage(
-                        fullName, "could not parse 'failure_dist' as string"
+                            fullName, "could not parse 'failure_dist' as string"
                     );
                     return Result::Failure;
                 }
-                std::string const& failureDistTag = maybeFailureDistTag.value();
-                if (!fmValueTable.contains("repair_dist"))
-                {
+                std::string const &failureDistTag = maybeFailureDistTag.value();
+                if (!fmValueTable.contains("repair_dist")) {
                     WriteErrorMessage(
-                        fullName, "missing required field 'repair_dist'"
+                            fullName, "missing required field 'repair_dist'"
                     );
                     return Result::Failure;
                 }
                 auto maybeRepairDistTag = TOMLTable_ParseString(
-                    fmValueTable, "repair_dist", fullName
+                        fmValueTable, "repair_dist", fullName
                 );
-                if (!maybeRepairDistTag.has_value())
-                {
+                if (!maybeRepairDistTag.has_value()) {
                     WriteErrorMessage(
-                        fullName, "could not parse 'repair_dist' as string"
+                            fullName, "could not parse 'repair_dist' as string"
                     );
                     return Result::Failure;
                 }
-                std::string const& repairDistTag = maybeRepairDistTag.value();
+                std::string const &repairDistTag = maybeRepairDistTag.value();
                 size_t failureId =
-                    s.TheModel.DistSys.lookup_dist_by_tag(failureDistTag);
+                        s.TheModel.DistSys.lookup_dist_by_tag(failureDistTag);
                 size_t repairId =
-                    s.TheModel.DistSys.lookup_dist_by_tag(repairDistTag);
+                        s.TheModel.DistSys.lookup_dist_by_tag(repairDistTag);
                 Simulation_RegisterFailureMode(s, fmName, failureId, repairId);
             }
         }
@@ -1100,70 +958,60 @@ namespace erin
     }
 
     Result
-    Simulation_ParseFragilityModes(Simulation& s, toml::value const& v)
-    {
-        if (v.contains("fragility_mode"))
-        {
-            if (!v.at("fragility_mode").is_table())
-            {
+    Simulation_ParseFragilityModes(Simulation &s, toml::value const &v) {
+        if (v.contains("fragility_mode")) {
+            if (!v.at("fragility_mode").is_table()) {
                 return Result::Failure;
             }
-            toml::table const& fmTable = v.at("fragility_mode").as_table();
-            for (auto const& pair : fmTable)
-            {
-                std::string const& fmName = pair.first;
+            toml::table const &fmTable = v.at("fragility_mode").as_table();
+            for (auto const &pair: fmTable) {
+                std::string const &fmName = pair.first;
                 std::string const fullName = "fragility_mode." + fmName;
-                if (!Simulation_IsFailureModeNameUnique(s, fmName))
-                {
+                if (!Simulation_IsFailureModeNameUnique(s, fmName)) {
                     WriteErrorMessage(
-                        fullName,
-                        "fragility mode name must be unique within both "
-                        "failure_mode and fragility_mode names"
+                            fullName,
+                            "fragility mode name must be unique within both "
+                            "failure_mode and fragility_mode names"
                     );
                     return Result::Failure;
                 }
-                if (!pair.second.is_table())
-                {
+                if (!pair.second.is_table()) {
                     WriteErrorMessage(
-                        fullName, "fragility_mode section must be a table"
+                            fullName, "fragility_mode section must be a table"
                     );
                     return Result::Failure;
                 }
-                toml::table const& fmValueTable = pair.second.as_table();
-                if (!fmValueTable.contains("fragility_curve"))
-                {
+                toml::table const &fmValueTable = pair.second.as_table();
+                if (!fmValueTable.contains("fragility_curve")) {
                     WriteErrorMessage(
-                        fullName, "missing required field 'fragility_curve'"
+                            fullName, "missing required field 'fragility_curve'"
                     );
                     return Result::Failure;
                 }
-                if (!fmValueTable.at("fragility_curve").is_string())
-                {
+                if (!fmValueTable.at("fragility_curve").is_string()) {
                     WriteErrorMessage(
-                        fullName, "'fragility_curve' field must be a string"
+                            fullName, "'fragility_curve' field must be a string"
                     );
                     return Result::Failure;
                 }
-                std::string const& fcTag =
-                    fmValueTable.at("fragility_curve").as_string();
+                std::string const &fcTag =
+                        fmValueTable.at("fragility_curve").as_string();
                 size_t fcId = Simulation_RegisterFragilityCurve(s, fcTag);
                 std::optional<size_t> maybeRepairDistId = {};
-                if (fmValueTable.contains("repair_dist"))
-                {
-                    if (!fmValueTable.at("repair_dist").is_string())
-                    {
+                if (fmValueTable.contains("repair_dist")) {
+                    if (!fmValueTable.at("repair_dist").is_string()) {
                         WriteErrorMessage(
-                            fullName, "field 'repair_dist' must be a string"
+                                fullName, "field 'repair_dist' must be a string"
                         );
                         return Result::Failure;
                     }
-                    std::string const& repairDistTag =
-                        fmValueTable.at("repair_dist").as_string();
+                    std::string const &repairDistTag =
+                            fmValueTable.at("repair_dist").as_string();
                     maybeRepairDistId =
-                        s.TheModel.DistSys.lookup_dist_by_tag(repairDistTag);
+                            s.TheModel.DistSys.lookup_dist_by_tag(repairDistTag);
                 }
                 Simulation_RegisterFragilityMode(
-                    s, fmName, fcId, maybeRepairDistId
+                        s, fmName, fcId, maybeRepairDistId
                 );
             }
         }
@@ -1172,19 +1020,17 @@ namespace erin
 
     Result
     Simulation_ParseComponents(
-        Simulation& s,
-        toml::value const& v,
-        ComponentValidationMap const& compValidations,
-        std::unordered_set<std::string> const& componentTagsInUse
-    )
-    {
-        if (v.contains("components") && v.at("components").is_table())
-        {
+            Simulation &s,
+            toml::value const &v,
+            ComponentValidationMap const &compValidations,
+            std::unordered_set<std::string> const &componentTagsInUse
+    ) {
+        if (v.contains("components") && v.at("components").is_table()) {
             return ParseComponents(
-                s,
-                v.at("components").as_table(),
-                compValidations,
-                componentTagsInUse
+                    s,
+                    v.at("components").as_table(),
+                    compValidations,
+                    componentTagsInUse
             );
         }
         WriteErrorMessage("<top>", "required field 'components' not found");
@@ -1193,16 +1039,14 @@ namespace erin
 
     Result
     Simulation_ParseDistributions(
-        Simulation& s,
-        toml::value const& v,
-        DistributionValidationMap const& dvm
-    )
-    {
-        if (v.contains("dist") && v.at("dist").is_table())
-        {
+            Simulation &s,
+            toml::value const &v,
+            DistributionValidationMap const &dvm
+    ) {
+        if (v.contains("dist") && v.at("dist").is_table()) {
             // TODO: have ParseDistributions return a Result
             return ParseDistributions(
-                s.TheModel.DistSys, v.at("dist").as_table(), dvm
+                    s.TheModel.DistSys, v.at("dist").as_table(), dvm
             );
         }
         std::cout << "required field 'dist' not found" << std::endl;
@@ -1210,39 +1054,30 @@ namespace erin
     }
 
     Result
-    Simulation_ParseNetwork(Simulation& s, toml::value const& v)
-    {
+    Simulation_ParseNetwork(Simulation &s, toml::value const &v) {
         std::string const n = "network";
-        if (v.contains(n) && v.at(n).is_table())
-        {
+        if (v.contains(n) && v.at(n).is_table()) {
             return ParseNetwork(s.FlowTypeMap, s.TheModel, v.at(n).as_table());
-        }
-        else
-        {
+        } else {
             std::cout << "required field '" << n << "' not found" << std::endl;
             return Result::Failure;
         }
     }
 
     Result
-    Simulation_ParseScenarios(Simulation& s, toml::value const& v)
-    {
-        if (v.contains("scenarios") && v.at("scenarios").is_table())
-        {
+    Simulation_ParseScenarios(Simulation &s, toml::value const &v) {
+        if (v.contains("scenarios") && v.at("scenarios").is_table()) {
             auto result = ParseScenarios(
-                s.ScenarioMap, s.TheModel.DistSys, v.at("scenarios").as_table()
+                    s.ScenarioMap, s.TheModel.DistSys, v.at("scenarios").as_table()
             );
-            if (result == Result::Success)
-            {
-                for (auto const& pair : v.at("scenarios").as_table())
-                {
-                    std::string const& scenarioName = pair.first;
+            if (result == Result::Success) {
+                for (auto const &pair: v.at("scenarios").as_table()) {
+                    std::string const &scenarioName = pair.first;
                     std::optional<size_t> maybeScenarioId =
-                        ScenarioDict_GetScenarioByTag(
-                            s.ScenarioMap, scenarioName
-                        );
-                    if (!maybeScenarioId.has_value())
-                    {
+                            ScenarioDict_GetScenarioByTag(
+                                    s.ScenarioMap, scenarioName
+                            );
+                    if (!maybeScenarioId.has_value()) {
                         std::cout << "[scenarios] "
                                   << "could not find scenario id for '"
                                   << scenarioName << "'" << std::endl;
@@ -1250,35 +1085,29 @@ namespace erin
                     }
                     size_t scenarioId = maybeScenarioId.value();
                     std::string fullName = "scenarios." + scenarioName;
-                    if (!pair.second.is_table())
-                    {
+                    if (!pair.second.is_table()) {
                         std::cout << "[" << fullName << "] "
                                   << "must be a table" << std::endl;
                     }
-                    toml::table const& data = pair.second.as_table();
-                    if (data.contains("intensity"))
-                    {
-                        if (!data.at("intensity").is_table())
-                        {
+                    toml::table const &data = pair.second.as_table();
+                    if (data.contains("intensity")) {
+                        if (!data.at("intensity").is_table()) {
                             std::cout << "[" << fullName << ".intensity] "
                                       << "must be a table" << std::endl;
                             return Result::Failure;
                         }
-                        for (auto const& p : data.at("intensity").as_table())
-                        {
-                            std::string const& intensityTag = p.first;
+                        for (auto const &p: data.at("intensity").as_table()) {
+                            std::string const &intensityTag = p.first;
                             if (!(p.second.is_integer()
-                                  || p.second.is_floating()))
-                            {
+                                  || p.second.is_floating())) {
                                 std::cout << "[" << fullName << ".intensity."
                                           << intensityTag << "] "
                                           << "must be a number" << std::endl;
                                 return Result::Failure;
                             }
                             std::optional<double> maybeValue =
-                                TOML_ParseNumericValueAsDouble(p.second);
-                            if (!maybeValue.has_value())
-                            {
+                                    TOML_ParseNumericValueAsDouble(p.second);
+                            if (!maybeValue.has_value()) {
                                 std::cout << "[" << fullName << ".intensity."
                                           << intensityTag << "] "
                                           << "must be a number" << std::endl;
@@ -1286,9 +1115,9 @@ namespace erin
                             }
                             double value = maybeValue.value();
                             size_t intensityId =
-                                Simulation_RegisterIntensity(s, intensityTag);
+                                    Simulation_RegisterIntensity(s, intensityTag);
                             Simulation_RegisterIntensityLevelForScenario(
-                                s, scenarioId, intensityId, value
+                                    s, scenarioId, intensityId, value
                             );
                         }
                     }
@@ -1303,68 +1132,58 @@ namespace erin
 
     std::optional<Simulation>
     Simulation_ReadFromToml(
-        toml::value const& v,
-        InputValidationMap const& validationInfo,
-        std::unordered_set<std::string> const& componentTagsInUse
-    )
-    {
+            toml::value const &v,
+            InputValidationMap const &validationInfo,
+            std::unordered_set<std::string> const &componentTagsInUse
+    ) {
         Simulation s = {};
         Simulation_Init(s);
         auto simInfoResult =
-            Simulation_ParseSimulationInfo(s, v, validationInfo.SimulationInfo);
-        if (simInfoResult == Result::Failure)
-        {
+                Simulation_ParseSimulationInfo(s, v, validationInfo.SimulationInfo);
+        if (simInfoResult == Result::Failure) {
             WriteErrorMessage("simulation_info", "problem parsing...");
             return {};
         }
         auto loadsResult = Simulation_ParseLoads(
-            s,
-            v,
-            validationInfo.Load_01Explicit,
-            validationInfo.Load_02FileBased
+                s,
+                v,
+                validationInfo.Load_01Explicit,
+                validationInfo.Load_02FileBased
         );
-        if (loadsResult == Result::Failure)
-        {
+        if (loadsResult == Result::Failure) {
             WriteErrorMessage("loads", "problem parsing...");
             return {};
         }
         auto compResult = Simulation_ParseComponents(
-            s, v, validationInfo.Comp, componentTagsInUse
+                s, v, validationInfo.Comp, componentTagsInUse
         );
-        if (compResult == Result::Failure)
-        {
+        if (compResult == Result::Failure) {
             WriteErrorMessage("components", "problem parsing...");
             return {};
         }
         auto distResult =
-            Simulation_ParseDistributions(s, v, validationInfo.Dist);
-        if (distResult == Result::Failure)
-        {
+                Simulation_ParseDistributions(s, v, validationInfo.Dist);
+        if (distResult == Result::Failure) {
             WriteErrorMessage("dist", "problem parsing...");
             return {};
         }
-        if (Simulation_ParseFailureModes(s, v) == Result::Failure)
-        {
+        if (Simulation_ParseFailureModes(s, v) == Result::Failure) {
             WriteErrorMessage("failure_mode", "problem parsing...");
             return {};
         }
-        if (Simulation_ParseFragilityModes(s, v) == Result::Failure)
-        {
+        if (Simulation_ParseFragilityModes(s, v) == Result::Failure) {
             WriteErrorMessage("fragility_mode", "problem parsing...");
             return {};
         }
-        if (Simulation_ParseNetwork(s, v) == Result::Failure)
-        {
+        if (Simulation_ParseNetwork(s, v) == Result::Failure) {
             WriteErrorMessage("network", "problem parsing...");
             return {};
         }
-        if (Simulation_ParseScenarios(s, v) == Result::Failure)
-        {
+        if (Simulation_ParseScenarios(s, v) == Result::Failure) {
             WriteErrorMessage("scenarios", "problem parsing...");
             return {};
         }
-        if (Simulation_ParseFragilityCurves(s, v) == Result::Failure)
-        {
+        if (Simulation_ParseFragilityCurves(s, v) == Result::Failure) {
             WriteErrorMessage("fragility_curve", "problem parsing...");
             return {};
         }
@@ -1372,8 +1191,7 @@ namespace erin
     }
 
     void
-    Simulation_Print(Simulation const& s)
-    {
+    Simulation_Print(Simulation const &s) {
         std::cout << "-----------------" << std::endl;
         std::cout << s.Info << std::endl;
         std::cout << "\nLoads:" << std::endl;
@@ -1397,56 +1215,48 @@ namespace erin
     }
 
     void
-    Simulation_PrintIntensities(Simulation const& s)
-    {
-        for (size_t i = 0; i < s.Intensities.Tags.size(); ++i)
-        {
+    Simulation_PrintIntensities(Simulation const &s) {
+        for (size_t i = 0; i < s.Intensities.Tags.size(); ++i) {
             std::cout << i << ": " << s.Intensities.Tags[i] << std::endl;
         }
     }
 
     void
     WriteEventFileHeader(
-        std::ofstream& out,
-        Model const& m,
-        FlowDict const& fd,
-        std::vector<size_t> const& connOrder,
-        std::vector<size_t> const& storeOrder,
-        std::vector<size_t> const& compOrder,
-        TimeUnit outputTimeUnit
-    )
-    {
-        ComponentDict const& compMap = m.ComponentMap;
-        std::vector<Connection> const& conns = m.Connections;
+            std::ofstream &out,
+            Model const &m,
+            FlowDict const &fd,
+            std::vector<size_t> const &connOrder,
+            std::vector<size_t> const &storeOrder,
+            std::vector<size_t> const &compOrder,
+            TimeUnit outputTimeUnit
+    ) {
+        ComponentDict const &compMap = m.ComponentMap;
+        std::vector<Connection> const &conns = m.Connections;
         out << "scenario id,"
             << "scenario start time (P[YYYY]-[MM]-[DD]T[hh]:[mm]:[ss]),"
             << "elapsed ("
             << (outputTimeUnit == TimeUnit::Hour
-                    ? "hours"
-                    : TimeUnitToTag(outputTimeUnit))
+                ? "hours"
+                : TimeUnitToTag(outputTimeUnit))
             << ")";
-        for (std::string const& prefix :
-             std::vector<std::string>{"", "REQUEST:", "AVAILABLE:"})
-        {
-            for (auto const& connId : connOrder)
-            {
-                auto const& conn = conns[connId];
+        for (std::string const &prefix:
+                std::vector<std::string>{"", "REQUEST:", "AVAILABLE:"}) {
+            for (auto const &connId: connOrder) {
+                auto const &conn = conns[connId];
                 out << "," << prefix
                     << ConnectionToString(compMap, fd, conn, true) << " (kW)";
             }
         }
-        for (std::pair<std::string, std::string> const& prePostFix :
-             std::vector<std::pair<std::string, std::string>>{
-                 {"Stored: ", " (kJ)"}, {"SOC: ", ""}
-             })
-        {
-            for (size_t storeIdx : storeOrder)
-            {
-                for (size_t compId = 0; compId < compMap.Tag.size(); ++compId)
-                {
+        for (std::pair<std::string, std::string> const &prePostFix:
+                std::vector<std::pair<std::string, std::string>>{
+                        {"Stored: ", " (kJ)"},
+                        {"SOC: ",    ""}
+                }) {
+            for (size_t storeIdx: storeOrder) {
+                for (size_t compId = 0; compId < compMap.Tag.size(); ++compId) {
                     if (compMap.CompType[compId] == ComponentType::StoreType
-                        && compMap.Idx[compId] == storeIdx)
-                    {
+                        && compMap.Idx[compId] == storeIdx) {
                         out << "," << prePostFix.first << compMap.Tag[compId]
                             << prePostFix.second;
                     }
@@ -1454,10 +1264,8 @@ namespace erin
             }
         }
         // op-state: <component-name>
-        for (size_t compId : compOrder)
-        {
-            if (!m.ComponentMap.Tag[compId].empty())
-            {
+        for (size_t compId: compOrder) {
+            if (!m.ComponentMap.Tag[compId].empty()) {
                 out << ",op-state: " << m.ComponentMap.Tag[compId];
             }
         }
@@ -1465,8 +1273,7 @@ namespace erin
     }
 
     std::vector<size_t>
-    CalculateConnectionOrder(Simulation const& s)
-    {
+    CalculateConnectionOrder(Simulation const &s) {
         // TODO: need to enforce connections are unique
         size_t const numConns = s.TheModel.Connections.size();
         std::vector<size_t> result;
@@ -1475,21 +1282,17 @@ namespace erin
         result.reserve(numConns);
         originalConnTags.reserve(numConns);
         connTags.reserve(numConns);
-        for (auto const& conn : s.TheModel.Connections)
-        {
+        for (auto const &conn: s.TheModel.Connections) {
             std::string connTag =
-                ConnectionToString(s.TheModel.ComponentMap, conn, true);
+                    ConnectionToString(s.TheModel.ComponentMap, conn, true);
             originalConnTags.push_back(connTag);
             connTags.push_back(connTag);
         }
         std::sort(connTags.begin(), connTags.end());
-        for (auto const& connTag : connTags)
-        {
+        for (auto const &connTag: connTags) {
             for (size_t connId = 0; connId < s.TheModel.Connections.size();
-                 ++connId)
-            {
-                if (connTag == originalConnTags[connId])
-                {
+                 ++connId) {
+                if (connTag == originalConnTags[connId]) {
                     result.push_back(connId);
                     break;
                 }
@@ -1500,20 +1303,16 @@ namespace erin
     }
 
     std::vector<size_t>
-    CalculateScenarioOrder(Simulation const& s)
-    {
+    CalculateScenarioOrder(Simulation const &s) {
         std::vector<size_t> result;
         std::vector<std::string> scenarioTags(s.ScenarioMap.Tags);
         size_t numScenarios = s.ScenarioMap.Tags.size();
         std::sort(scenarioTags.begin(), scenarioTags.end());
         result.reserve(numScenarios);
-        for (std::string const& tag : scenarioTags)
-        {
+        for (std::string const &tag: scenarioTags) {
             for (size_t scenarioId = 0; scenarioId < s.ScenarioMap.Tags.size();
-                 ++scenarioId)
-            {
-                if (tag == s.ScenarioMap.Tags[scenarioId])
-                {
+                 ++scenarioId) {
+                if (tag == s.ScenarioMap.Tags[scenarioId]) {
                     result.push_back(scenarioId);
                     break;
                 }
@@ -1524,19 +1323,15 @@ namespace erin
     }
 
     std::vector<size_t>
-    CalculateComponentOrder(Simulation const& s)
-    {
+    CalculateComponentOrder(Simulation const &s) {
         size_t const numComps = s.TheModel.ComponentMap.Tag.size();
         std::vector<size_t> result;
         result.reserve(numComps);
         std::vector<std::string> compTags(s.TheModel.ComponentMap.Tag);
         std::sort(compTags.begin(), compTags.end());
-        for (auto const& t : compTags)
-        {
-            for (size_t compId = 0; compId < numComps; ++compId)
-            {
-                if (s.TheModel.ComponentMap.Tag[compId] == t)
-                {
+        for (auto const &t: compTags) {
+            for (size_t compId = 0; compId < numComps; ++compId) {
+                if (s.TheModel.ComponentMap.Tag[compId] == t) {
                     result.push_back(compId);
                     break;
                 }
@@ -1547,21 +1342,17 @@ namespace erin
     }
 
     std::vector<size_t>
-    CalculateStoreOrder(Simulation const& s)
-    {
+    CalculateStoreOrder(Simulation const &s) {
         std::vector<size_t> result;
         std::vector<std::string> storeTags;
         storeTags.reserve(s.TheModel.Stores.size());
         size_t const numComps = s.TheModel.ComponentMap.CompType.size();
         size_t const numStores = s.TheModel.Stores.size();
-        for (size_t storeId = 0; storeId < numStores; ++storeId)
-        {
-            for (size_t compId = 0; compId < numComps; ++compId)
-            {
+        for (size_t storeId = 0; storeId < numStores; ++storeId) {
+            for (size_t compId = 0; compId < numComps; ++compId) {
                 ComponentType type = s.TheModel.ComponentMap.CompType[compId];
                 size_t idx = s.TheModel.ComponentMap.Idx[compId];
-                if (type == ComponentType::StoreType && idx == storeId)
-                {
+                if (type == ComponentType::StoreType && idx == storeId) {
                     storeTags.push_back(s.TheModel.ComponentMap.Tag[compId]);
                     break;
                 }
@@ -1570,12 +1361,9 @@ namespace erin
         assert(storeTags.size() == numStores);
         std::vector<std::string> originalStoreTags(storeTags);
         std::sort(storeTags.begin(), storeTags.end());
-        for (auto const& tag : storeTags)
-        {
-            for (size_t storeId = 0; storeId < numStores; ++storeId)
-            {
-                if (tag == originalStoreTags[storeId])
-                {
+        for (auto const &tag: storeTags) {
+            for (size_t storeId = 0; storeId < numStores; ++storeId) {
+                if (tag == originalStoreTags[storeId]) {
                     result.push_back(storeId);
                 }
             }
@@ -1585,18 +1373,14 @@ namespace erin
     }
 
     std::vector<size_t>
-    CalculateFailModeOrder(Simulation const& s)
-    {
+    CalculateFailModeOrder(Simulation const &s) {
         size_t const numFailModes = s.FailureModes.Tags.size();
         std::vector<size_t> result;
         std::vector<std::string> failTags(s.FailureModes.Tags);
         std::sort(failTags.begin(), failTags.end());
-        for (auto const& t : failTags)
-        {
-            for (size_t i = 0; i < numFailModes; ++i)
-            {
-                if (s.FailureModes.Tags[i] == t)
-                {
+        for (auto const &t: failTags) {
+            for (size_t i = 0; i < numFailModes; ++i) {
+                if (s.FailureModes.Tags[i] == t) {
                     result.push_back(i);
                     break;
                 }
@@ -1607,18 +1391,14 @@ namespace erin
     }
 
     std::vector<size_t>
-    CalculateFragilModeOrder(Simulation const& s)
-    {
+    CalculateFragilModeOrder(Simulation const &s) {
         size_t const numFragModes = s.FragilityModes.Tags.size();
         std::vector<size_t> result;
         std::vector<std::string> fragTags(s.FragilityModes.Tags);
         std::sort(fragTags.begin(), fragTags.end());
-        for (auto const& t : fragTags)
-        {
-            for (size_t i = 0; i < numFragModes; ++i)
-            {
-                if (s.FragilityModes.Tags[i] == t)
-                {
+        for (auto const &t: fragTags) {
+            for (size_t i = 0; i < numFragModes; ++i) {
+                if (s.FragilityModes.Tags[i] == t) {
                     result.push_back(i);
                     break;
                 }
@@ -1629,10 +1409,8 @@ namespace erin
     }
 
     std::string
-    FlowInWattsToString(flow_t value_W, unsigned int precision)
-    {
-        if (value_W == max_flow_W)
-        {
+    FlowInWattsToString(flow_t value_W, unsigned int precision) {
+        if (value_W == max_flow_W) {
             std::cout << "Found infinity:" << std::endl;
             std::cout << "- value_W   : " << fmt::format("{}", value_W)
                       << std::endl;
@@ -1646,125 +1424,103 @@ namespace erin
 
     void
     WriteResultsToEventFile(
-        std::ofstream& out,
-        std::vector<TimeAndFlows> results,
-        Simulation const& s,
-        std::string const& scenarioTag,
-        std::string const& scenarioStartTimeTag,
-        std::vector<size_t> const& connOrder,
-        std::vector<size_t> const& storeOrder,
-        std::vector<size_t> const& compOrder,
-        TimeUnit outputTimeUnit
-    )
-    {
+            std::ofstream &out,
+            std::vector<TimeAndFlows> results,
+            Simulation const &s,
+            std::string const &scenarioTag,
+            std::string const &scenarioStartTimeTag,
+            std::vector<size_t> const &connOrder,
+            std::vector<size_t> const &storeOrder,
+            std::vector<size_t> const &compOrder,
+            TimeUnit outputTimeUnit
+    ) {
         // TODO: pass in desired precision
         unsigned int precision = 1;
         unsigned int storePrecision = 3;
-        Model const& m = s.TheModel;
+        Model const &m = s.TheModel;
         std::map<size_t, std::vector<TimeState>> relSchByCompId;
-        for (size_t i = 0; i < m.Reliabilities.size(); ++i)
-        {
+        for (size_t i = 0; i < m.Reliabilities.size(); ++i) {
             size_t compId = m.Reliabilities[i].ComponentId;
             relSchByCompId[compId] = m.Reliabilities[i].TimeStates;
         }
-        for (auto const& r : results)
-        {
+        for (auto const &r: results) {
             assert(r.Flows.size() == connOrder.size());
             out << scenarioTag << "," << scenarioStartTimeTag << ",";
             out << TimeInSecondsToDesiredUnit(r.Time, outputTimeUnit);
-            for (size_t const& i : connOrder)
-            {
+            for (size_t const &i: connOrder) {
                 out << ","
                     << FlowInWattsToString(r.Flows[i].Actual_W, precision);
             }
-            for (size_t const& i : connOrder)
-            {
+            for (size_t const &i: connOrder) {
                 out << ","
                     << FlowInWattsToString(r.Flows[i].Requested_W, precision);
             }
-            for (size_t const& i : connOrder)
-            {
+            for (size_t const &i: connOrder) {
                 out << ","
                     << FlowInWattsToString(r.Flows[i].Available_W, precision);
             }
             // NOTE: Amounts in kJ
-            for (size_t i : storeOrder)
-            {
+            for (size_t i: storeOrder) {
                 double store_J = static_cast<double>(r.StorageAmounts_J[i]);
                 double store_kJ = store_J / J_per_kJ;
                 out << "," << std::fixed << std::setprecision(storePrecision)
                     << store_kJ;
             }
             // NOTE: Store state in SOC
-            for (size_t i : storeOrder)
-            {
+            for (size_t i: storeOrder) {
                 double soc = 0.0;
-                if (m.Stores[i].Capacity_J > 0)
-                {
+                if (m.Stores[i].Capacity_J > 0) {
                     soc = static_cast<double>(r.StorageAmounts_J[i])
-                        / static_cast<double>(m.Stores[i].Capacity_J);
+                          / static_cast<double>(m.Stores[i].Capacity_J);
                 }
                 out << "," << std::fixed << std::setprecision(storePrecision)
                     << soc;
             }
-            for (size_t i : compOrder)
-            {
-                if (!m.ComponentMap.Tag[i].empty())
-                {
-                    if (relSchByCompId.contains(i))
-                    {
+            for (size_t i: compOrder) {
+                if (!m.ComponentMap.Tag[i].empty()) {
+                    if (relSchByCompId.contains(i)) {
                         TimeState ts = TimeState_GetActiveTimeState(
-                            relSchByCompId[i], r.Time
+                                relSchByCompId[i], r.Time
                         );
-                        if (ts.state)
-                        {
+                        if (ts.state) {
                             out << ",available";
-                        }
-                        else
-                        {
+                        } else {
                             // lookup the failure and fragility modes
                             std::vector<size_t> failModes;
                             failModes.reserve(ts.failureModeCauses.size());
                             std::vector<size_t> fragModes;
                             fragModes.reserve(ts.fragilityModeCauses.size());
-                            for (size_t fm : ts.failureModeCauses)
-                            {
+                            for (size_t fm: ts.failureModeCauses) {
                                 failModes.push_back(fm);
                             }
-                            for (size_t fm : ts.fragilityModeCauses)
-                            {
+                            for (size_t fm: ts.fragilityModeCauses) {
                                 fragModes.push_back(fm);
                             }
                             std::sort(failModes.begin(), failModes.end());
                             std::sort(fragModes.begin(), fragModes.end());
                             std::vector<std::string> fmTags;
                             fmTags.reserve(
-                                ts.failureModeCauses.size()
-                                + ts.fragilityModeCauses.size()
+                                    ts.failureModeCauses.size()
+                                    + ts.fragilityModeCauses.size()
                             );
-                            for (auto const& failModeId : failModes)
-                            {
+                            for (auto const &failModeId: failModes) {
                                 fmTags.push_back(s.FailureModes.Tags[failModeId]
                                 );
                             }
-                            for (auto const& fragModeId : fragModes)
-                            {
+                            for (auto const &fragModeId: fragModes) {
                                 fmTags.push_back(
-                                    s.FragilityModes.Tags[fragModeId]
+                                        s.FragilityModes.Tags[fragModeId]
                                 );
                             }
                             bool first = true;
                             std::ostringstream oss{};
-                            for (std::string const& tag : fmTags)
-                            {
+                            for (std::string const &tag: fmTags) {
                                 oss << (first ? "" : " | ") << tag;
                                 first = false;
                             }
                             out << "," << oss.str();
                         }
-                    }
-                    else
-                    {
+                    } else {
                         out << ",available";
                     }
                 }
@@ -1775,30 +1531,24 @@ namespace erin
 
     Result
     SetLoadsForScenario(
-        std::vector<ScheduleBasedLoad>& loads,
-        LoadDict loadMap,
-        size_t scenarioIdx
-    )
-    {
-        for (size_t sblIdx = 0; sblIdx < loads.size(); ++sblIdx)
-        {
-            if (loads[sblIdx].ScenarioIdToLoadId.contains(scenarioIdx))
-            {
+            std::vector<ScheduleBasedLoad> &loads,
+            LoadDict loadMap,
+            size_t scenarioIdx
+    ) {
+        for (size_t sblIdx = 0; sblIdx < loads.size(); ++sblIdx) {
+            if (loads[sblIdx].ScenarioIdToLoadId.contains(scenarioIdx)) {
                 auto loadId = loads[sblIdx].ScenarioIdToLoadId.at(scenarioIdx);
                 std::vector<TimeAndAmount> schedule{};
                 size_t numEntries = loadMap.Loads[loadId].size();
                 schedule.reserve(numEntries);
-                for (size_t i = 0; i < numEntries; ++i)
-                {
+                for (size_t i = 0; i < numEntries; ++i) {
                     TimeAndAmount tal{};
                     tal.Time_s = loadMap.Loads[loadId][i].Time_s;
                     tal.Amount_W = loadMap.Loads[loadId][i].Amount_W;
                     schedule.push_back(std::move(tal));
                 }
                 loads[sblIdx].TimesAndLoads = std::move(schedule);
-            }
-            else
-            {
+            } else {
                 std::cout << "ERROR:"
                           << "Unhandled scenario id in ScenarioIdToLoadId"
                           << std::endl;
@@ -1810,31 +1560,25 @@ namespace erin
 
     Result
     SetSupplyForScenario(
-        std::vector<ScheduleBasedSource>& loads,
-        LoadDict loadMap,
-        size_t scenarioIdx
-    )
-    {
-        for (size_t sblIdx = 0; sblIdx < loads.size(); ++sblIdx)
-        {
-            if (loads[sblIdx].ScenarioIdToSourceId.contains(scenarioIdx))
-            {
+            std::vector<ScheduleBasedSource> &loads,
+            LoadDict loadMap,
+            size_t scenarioIdx
+    ) {
+        for (size_t sblIdx = 0; sblIdx < loads.size(); ++sblIdx) {
+            if (loads[sblIdx].ScenarioIdToSourceId.contains(scenarioIdx)) {
                 auto loadId =
-                    loads[sblIdx].ScenarioIdToSourceId.at(scenarioIdx);
+                        loads[sblIdx].ScenarioIdToSourceId.at(scenarioIdx);
                 std::vector<TimeAndAmount> schedule{};
                 size_t numEntries = loadMap.Loads[loadId].size();
                 schedule.reserve(numEntries);
-                for (size_t i = 0; i < numEntries; ++i)
-                {
+                for (size_t i = 0; i < numEntries; ++i) {
                     TimeAndAmount tal{};
                     tal.Time_s = loadMap.Loads[loadId][i].Time_s;
                     tal.Amount_W = loadMap.Loads[loadId][i].Amount_W;
                     schedule.push_back(std::move(tal));
                 }
                 loads[sblIdx].TimeAndAvails = std::move(schedule);
-            }
-            else
-            {
+            } else {
                 std::cout << "ERROR:"
                           << "Unhandled scenario id in ScenarioIdToSourceId"
                           << std::endl;
@@ -1846,34 +1590,29 @@ namespace erin
 
     std::vector<double>
     DetermineScenarioOccurrenceTimes(
-        Simulation& s,
-        size_t scenIdx,
-        bool isVerbose
-    )
-    {
+            Simulation &s,
+            size_t scenIdx,
+            bool isVerbose
+    ) {
         std::vector<double> occurrenceTimes_s;
-        auto const& maybeMaxOccurrences = s.ScenarioMap.MaxOccurrences[scenIdx];
+        auto const &maybeMaxOccurrences = s.ScenarioMap.MaxOccurrences[scenIdx];
         size_t maxOccurrence = maybeMaxOccurrences.has_value()
-            ? maybeMaxOccurrences.value()
-            : 1'000;
+                               ? maybeMaxOccurrences.value()
+                               : 1'000;
         auto const distId = s.ScenarioMap.OccurrenceDistributionIds[scenIdx];
         double scenarioStartTime_s = 0.0;
         double maxTime_s = Time_ToSeconds(s.Info.MaxTime, s.Info.TheTimeUnit);
-        for (size_t i = 0; i < maxOccurrence; ++i)
-        {
+        for (size_t i = 0; i < maxOccurrence; ++i) {
             scenarioStartTime_s += s.TheModel.DistSys.next_time_advance(distId);
-            if (scenarioStartTime_s > maxTime_s)
-            {
+            if (scenarioStartTime_s > maxTime_s) {
                 break;
             }
             occurrenceTimes_s.push_back(scenarioStartTime_s);
         }
-        if (isVerbose)
-        {
+        if (isVerbose) {
             std::cout << "Occurrences: " << occurrenceTimes_s.size()
                       << std::endl;
-            for (size_t i = 0; i < occurrenceTimes_s.size(); ++i)
-            {
+            for (size_t i = 0; i < occurrenceTimes_s.size(); ++i) {
                 std::cout << "-- "
                           << SecondsToPrettyString(occurrenceTimes_s[i])
                           << std::endl;
@@ -1883,37 +1622,31 @@ namespace erin
     }
 
     std::map<size_t, double>
-    GetIntensitiesForScenario(Simulation& s, size_t scenIdx)
-    {
+    GetIntensitiesForScenario(Simulation &s, size_t scenIdx) {
         std::map<size_t, double> intensityIdToAmount;
-        for (size_t i = 0; i < s.ScenarioIntensities.ScenarioIds.size(); ++i)
-        {
-            if (s.ScenarioIntensities.ScenarioIds[i] == scenIdx)
-            {
+        for (size_t i = 0; i < s.ScenarioIntensities.ScenarioIds.size(); ++i) {
+            if (s.ScenarioIntensities.ScenarioIds[i] == scenIdx) {
                 auto intensityId = s.ScenarioIntensities.IntensityIds[i];
                 intensityIdToAmount[intensityId] =
-                    s.ScenarioIntensities.IntensityLevels[i];
+                        s.ScenarioIntensities.IntensityLevels[i];
             }
         }
         return intensityIdToAmount;
     }
 
     std::vector<ScheduleBasedReliability>
-    CopyReliabilities(Simulation const& s)
-    {
+    CopyReliabilities(Simulation const &s) {
         std::vector<ScheduleBasedReliability> originalReliabilities;
         originalReliabilities.reserve(s.TheModel.Reliabilities.size());
         for (size_t sbrIdx = 0; sbrIdx < s.TheModel.Reliabilities.size();
-             ++sbrIdx)
-        {
-            ScheduleBasedReliability const& sbrSrc =
-                s.TheModel.Reliabilities[sbrIdx];
+             ++sbrIdx) {
+            ScheduleBasedReliability const &sbrSrc =
+                    s.TheModel.Reliabilities[sbrIdx];
             ScheduleBasedReliability sbrCopy{};
             sbrCopy.ComponentId = sbrSrc.ComponentId;
             sbrCopy.TimeStates.reserve(sbrSrc.TimeStates.size());
-            for (size_t tsIdx = 0; tsIdx < sbrSrc.TimeStates.size(); ++tsIdx)
-            {
-                TimeState const& tsSrc = sbrSrc.TimeStates[tsIdx];
+            for (size_t tsIdx = 0; tsIdx < sbrSrc.TimeStates.size(); ++tsIdx) {
+                TimeState const &tsSrc = sbrSrc.TimeStates[tsIdx];
                 TimeState tsCopy{};
                 tsCopy.time = tsSrc.time;
                 tsCopy.state = tsSrc.state;
@@ -1926,44 +1659,40 @@ namespace erin
 
     std::vector<ScheduleBasedReliability>
     ApplyReliabilitiesAndFragilities(
-        Simulation& s,
-        double startTime_s,
-        double endTime_s,
-        std::map<size_t, double> const& intensityIdToAmount,
-        std::map<size_t, std::vector<TimeState>> const& relSchByCompId,
-        bool verbose
-    )
-    {
+            Simulation &s,
+            double startTime_s,
+            double endTime_s,
+            std::map<size_t, double> const &intensityIdToAmount,
+            std::map<size_t, std::vector<TimeState>> const &relSchByCompId,
+            bool verbose
+    ) {
         std::vector<ScheduleBasedReliability> orig = CopyReliabilities(s);
-        std::set<size_t> reliabilitiesAdded;
+        std::set < size_t > reliabilitiesAdded;
         for (size_t cfmIdx = 0;
              cfmIdx < s.ComponentFailureModes.ComponentIds.size();
-             ++cfmIdx)
-        {
-            auto const& compId = s.ComponentFailureModes.ComponentIds[cfmIdx];
+             ++cfmIdx) {
+            auto const &compId = s.ComponentFailureModes.ComponentIds[cfmIdx];
             // NOTE: there should be a reliability schedule for each entry in
             // ComponentFailureModes. However, since it is possible to have
             // more than one failure mode on one component (and those have
             // already been combined by this point), we need to check if we've
             // already added this reliability schedule
-            if (reliabilitiesAdded.contains(compId))
-            {
+            if (reliabilitiesAdded.contains(compId)) {
                 continue;
             }
-            std::vector<TimeState> const& sch = relSchByCompId.at(compId);
+            std::vector<TimeState> const &sch = relSchByCompId.at(compId);
             double initialAge_s = s.TheModel.ComponentMap.InitialAges_s[compId];
-            if (verbose)
-            {
+            if (verbose) {
                 std::cout << "component: "
                           << s.TheModel.ComponentMap.Tag[compId] << std::endl;
                 std::cout << "initial age (h): "
                           << (initialAge_s / seconds_per_hour) << std::endl;
             }
             std::vector<TimeState> clip = TimeState_Clip(
-                TimeState_Translate(sch, initialAge_s),
-                startTime_s,
-                endTime_s,
-                true
+                    TimeState_Translate(sch, initialAge_s),
+                    startTime_s,
+                    endTime_s,
+                    true
             );
             // NOTE: Reliabilities have not yet been assigned so we can
             // just push_back()
@@ -1973,96 +1702,80 @@ namespace erin
             s.TheModel.Reliabilities.push_back(std::move(sbr));
             reliabilitiesAdded.insert(compId);
         }
-        if (intensityIdToAmount.size() > 0)
-        {
-            if (verbose)
-            {
+        if (intensityIdToAmount.size() > 0) {
+            if (verbose) {
                 std::cout << "... Applying fragilities" << std::endl;
             }
             // NOTE: if there are no components having fragility modes,
             // there is nothing to do.
             for (size_t cfmIdx = 0;
                  cfmIdx < s.ComponentFragilities.ComponentIds.size();
-                 ++cfmIdx)
-            {
+                 ++cfmIdx) {
                 size_t fmId = s.ComponentFragilities.FragilityModeIds[cfmIdx];
                 size_t fcId = s.FragilityModes.FragilityCurveId[fmId];
                 std::optional<size_t> repairId =
-                    s.FragilityModes.RepairDistIds[fmId];
+                        s.FragilityModes.RepairDistIds[fmId];
                 FragilityCurveType curveType =
-                    s.FragilityCurves.CurveTypes[fcId];
+                        s.FragilityCurves.CurveTypes[fcId];
                 size_t fcIdx = s.FragilityCurves.CurveId[fcId];
                 bool isFailed = false;
                 double failureFrac = 0.0;
-                switch (curveType)
-                {
-                    case (FragilityCurveType::Linear):
-                    {
+                switch (curveType) {
+                    case (FragilityCurveType::Linear): {
                         LinearFragilityCurve lfc =
-                            s.LinearFragilityCurves[fcIdx];
+                                s.LinearFragilityCurves[fcIdx];
                         size_t vulnerId = lfc.VulnerabilityId;
-                        if (intensityIdToAmount.contains(vulnerId))
-                        {
+                        if (intensityIdToAmount.contains(vulnerId)) {
                             double level = intensityIdToAmount.at(vulnerId);
                             failureFrac =
-                                LinearFragilityCurve_GetFailureFraction(
-                                    lfc, level
-                                );
+                                    LinearFragilityCurve_GetFailureFraction(
+                                            lfc, level
+                                    );
                         }
                     }
-                    break;
-                    case (FragilityCurveType::Tabular):
-                    {
+                        break;
+                    case (FragilityCurveType::Tabular): {
                         TabularFragilityCurve tfc =
-                            s.TabularFragilityCurves[fcIdx];
+                                s.TabularFragilityCurves[fcIdx];
                         size_t vulnerId = tfc.VulnerabilityId;
-                        if (intensityIdToAmount.contains(vulnerId))
-                        {
+                        if (intensityIdToAmount.contains(vulnerId)) {
                             double level = intensityIdToAmount.at(vulnerId);
                             failureFrac =
-                                TabularFragilityCurve_GetFailureFraction(
-                                    tfc, level
-                                );
+                                    TabularFragilityCurve_GetFailureFraction(
+                                            tfc, level
+                                    );
                         }
                     }
-                    break;
-                    default:
-                    {
+                        break;
+                    default: {
                         WriteErrorMessage(
-                            "fragility_curve", "unhandled fragility curve type"
+                                "fragility_curve", "unhandled fragility curve type"
                         );
                         std::exit(1);
                     }
-                    break;
+                        break;
                 }
-                if (failureFrac == 1.0)
-                {
+                if (failureFrac == 1.0) {
                     isFailed = true;
-                }
-                else if (failureFrac == 0.0)
-                {
+                } else if (failureFrac == 0.0) {
                     isFailed = false;
-                }
-                else
-                {
+                } else {
                     isFailed = s.TheModel.RandFn() <= failureFrac;
                 }
                 // NOTE: if we are not failed, there is nothing to do
-                if (isFailed)
-                {
+                if (isFailed) {
                     // now we have to find the affected component
                     // and assign/update a reliability schedule for it
                     // including any repair distribution if we have
                     // one.
                     size_t compId = s.ComponentFragilities.ComponentIds[cfmIdx];
-                    if (verbose)
-                    {
+                    if (verbose) {
                         std::cout << "... FAILED: "
                                   << s.TheModel.ComponentMap.Tag[compId]
                                   << " (cause: "
                                   << s.FragilityModes
-                                         .Tags[s.ComponentFragilities
-                                                   .FragilityModeIds[cfmIdx]]
+                                          .Tags[s.ComponentFragilities
+                                          .FragilityModeIds[cfmIdx]]
                                   << ")" << std::endl;
                     }
                     // does the component have a reliability signal?
@@ -2070,11 +1783,9 @@ namespace erin
                     size_t reliabilityId = 0;
                     for (size_t rIdx = 0;
                          rIdx < s.TheModel.Reliabilities.size();
-                         ++rIdx)
-                    {
+                         ++rIdx) {
                         if (s.TheModel.Reliabilities[rIdx].ComponentId
-                            == compId)
-                        {
+                            == compId) {
                             hasReliabilityAlready = true;
                             reliabilityId = rIdx;
                             break;
@@ -2086,27 +1797,23 @@ namespace erin
                     ts.time = 0.0;
                     ts.fragilityModeCauses.insert(fmId);
                     newTimeStates.push_back(std::move(ts));
-                    if (repairId.has_value())
-                    {
+                    if (repairId.has_value()) {
                         size_t repId = repairId.value();
                         double repairTime_s =
-                            s.TheModel.DistSys.next_time_advance(repId);
+                                s.TheModel.DistSys.next_time_advance(repId);
                         TimeState repairTime{};
                         repairTime.time = repairTime_s;
                         repairTime.state = true;
                         newTimeStates.push_back(std::move(repairTime));
                     }
-                    if (hasReliabilityAlready)
-                    {
-                        auto const& currentSch =
-                            s.TheModel.Reliabilities[reliabilityId].TimeStates;
+                    if (hasReliabilityAlready) {
+                        auto const &currentSch =
+                                s.TheModel.Reliabilities[reliabilityId].TimeStates;
                         std::vector<TimeState> combined =
-                            TimeState_Combine(currentSch, newTimeStates);
+                                TimeState_Combine(currentSch, newTimeStates);
                         s.TheModel.Reliabilities[reliabilityId].TimeStates =
-                            std::move(combined);
-                    }
-                    else
-                    {
+                                std::move(combined);
+                    } else {
                         ScheduleBasedReliability sbr{};
                         sbr.ComponentId = compId;
                         sbr.TimeStates = newTimeStates;
@@ -2124,18 +1831,16 @@ namespace erin
     // names from data calculations.
     void
     WriteStatisticsToFile(
-        Simulation const& s,
-        std::string const& statsFilePath,
-        std::vector<ScenarioOccurrenceStats> const& occurrenceStats,
-        std::vector<size_t> const& compOrder,
-        std::vector<size_t> const& failOrder,
-        std::vector<size_t> const& fragOrder
-    )
-    {
+            Simulation const &s,
+            std::string const &statsFilePath,
+            std::vector<ScenarioOccurrenceStats> const &occurrenceStats,
+            std::vector<size_t> const &compOrder,
+            std::vector<size_t> const &failOrder,
+            std::vector<size_t> const &fragOrder
+    ) {
         std::ofstream stats;
         stats.open(statsFilePath);
-        if (!stats.good())
-        {
+        if (!stats.good()) {
             std::cout << "Could not open '" << statsFilePath << "' for writing."
                       << std::endl;
             return;
@@ -2149,123 +1854,96 @@ namespace erin
               << "energy availability [EA],"
               << "max single event downtime [MaxSEDT] (h),"
               << "global availability";
-        if (occurrenceStats.size() > 0)
-        {
-            for (auto const& statsByFlow : occurrenceStats[0].FlowTypeStats)
-            {
-                std::string const& flowType =
-                    s.FlowTypeMap.Type[statsByFlow.FlowTypeId];
+        if (occurrenceStats.size() > 0) {
+            for (auto const &statsByFlow: occurrenceStats[0].FlowTypeStats) {
+                std::string const &flowType =
+                        s.FlowTypeMap.Type[statsByFlow.FlowTypeId];
                 stats << ",energy robustness [ER] for " << flowType;
                 stats << ",energy availability [EA] for " << flowType;
             }
-            for (auto const& statsByFlowLoad :
-                 occurrenceStats[0].LoadAndFlowTypeStats)
-            {
-                std::string const& flowType =
-                    s.FlowTypeMap.Type[statsByFlowLoad.Stats.FlowTypeId];
-                std::string const& tag =
-                    s.TheModel.ComponentMap.Tag[statsByFlowLoad.ComponentId];
+            for (auto const &statsByFlowLoad:
+                    occurrenceStats[0].LoadAndFlowTypeStats) {
+                std::string const &flowType =
+                        s.FlowTypeMap.Type[statsByFlowLoad.Stats.FlowTypeId];
+                std::string const &tag =
+                        s.TheModel.ComponentMap.Tag[statsByFlowLoad.ComponentId];
                 stats << ",energy robustness [ER] for " << tag
                       << " [flow: " << flowType << "]";
                 stats << ",energy availability [EA] for " << tag
                       << " [flow: " << flowType << "]";
             }
-            for (auto const& lnsByComp :
-                 occurrenceStats[0].LoadNotServedForComponents)
-            {
-                std::string const& flowType =
-                    s.FlowTypeMap.Type[lnsByComp.FlowTypeId];
-                std::string const& tag =
-                    s.TheModel.ComponentMap.Tag[lnsByComp.ComponentId];
+            for (auto const &lnsByComp:
+                    occurrenceStats[0].LoadNotServedForComponents) {
+                std::string const &flowType =
+                        s.FlowTypeMap.Type[lnsByComp.FlowTypeId];
+                std::string const &tag =
+                        s.TheModel.ComponentMap.Tag[lnsByComp.ComponentId];
                 stats << ",load not served (kJ) for " << tag
                       << " [flow: " << flowType << "]";
             }
         }
-        std::set<size_t> componentsToSkip;
-        for (size_t i : compOrder)
-        {
-            if (s.TheModel.ComponentMap.Tag[i].empty())
-            {
+        std::set < size_t > componentsToSkip;
+        for (size_t i: compOrder) {
+            if (s.TheModel.ComponentMap.Tag[i].empty()) {
                 componentsToSkip.insert(i);
-            }
-            else
-            {
+            } else {
                 stats << ",availability: " << s.TheModel.ComponentMap.Tag[i];
             }
         }
-        for (size_t i : failOrder)
-        {
+        for (size_t i: failOrder) {
             stats << ",global count: " << s.FailureModes.Tags[i];
         }
-        for (size_t i : fragOrder)
-        {
+        for (size_t i: fragOrder) {
             stats << ",global count: " << s.FragilityModes.Tags[i];
         }
-        for (size_t i : failOrder)
-        {
+        for (size_t i: failOrder) {
             stats << ",global time fraction: " << s.FailureModes.Tags[i];
         }
-        for (size_t i : fragOrder)
-        {
+        for (size_t i: fragOrder) {
             stats << ",global time fraction: " << s.FragilityModes.Tags[i];
         }
-        std::map<size_t, std::set<size_t>> failModeIdsByCompId;
-        std::map<size_t, std::set<size_t>> fragModeIdsByCompId;
-        for (size_t compId : compOrder)
-        {
-            failModeIdsByCompId[compId] = std::set<size_t>{};
-            fragModeIdsByCompId[compId] = std::set<size_t>{};
-            for (auto const& occ : occurrenceStats)
-            {
-                if (occ.EventCountByCompIdByFailureModeId.contains(compId))
-                {
-                    for (auto const& p :
-                         occ.EventCountByCompIdByFailureModeId.at(compId))
-                    {
+        std::map < size_t, std::set < size_t >> failModeIdsByCompId;
+        std::map < size_t, std::set < size_t >> fragModeIdsByCompId;
+        for (size_t compId: compOrder) {
+            failModeIdsByCompId[compId] = std::set < size_t > {};
+            fragModeIdsByCompId[compId] = std::set < size_t > {};
+            for (auto const &occ: occurrenceStats) {
+                if (occ.EventCountByCompIdByFailureModeId.contains(compId)) {
+                    for (auto const &p:
+                            occ.EventCountByCompIdByFailureModeId.at(compId)) {
                         failModeIdsByCompId[compId].insert(p.first);
                     }
                 }
-                if (occ.EventCountByCompIdByFragilityModeId.contains(compId))
-                {
-                    for (auto const& p :
-                         occ.EventCountByCompIdByFragilityModeId.at(compId))
-                    {
+                if (occ.EventCountByCompIdByFragilityModeId.contains(compId)) {
+                    for (auto const &p:
+                            occ.EventCountByCompIdByFragilityModeId.at(compId)) {
                         fragModeIdsByCompId[compId].insert(p.first);
                     }
                 }
             }
-            for (size_t failModeId : failOrder)
-            {
-                if (failModeIdsByCompId[compId].contains(failModeId))
-                {
+            for (size_t failModeId: failOrder) {
+                if (failModeIdsByCompId[compId].contains(failModeId)) {
                     stats << ",count: " << s.TheModel.ComponentMap.Tag[compId]
                           << " / " << s.FailureModes.Tags[failModeId];
                 }
             }
-            for (size_t fragModeId : fragOrder)
-            {
-                if (fragModeIdsByCompId[compId].contains(fragModeId))
-                {
+            for (size_t fragModeId: fragOrder) {
+                if (fragModeIdsByCompId[compId].contains(fragModeId)) {
                     stats << ",count: " << s.TheModel.ComponentMap.Tag[compId]
                           << " / " << s.FragilityModes.Tags[fragModeId];
                 }
             }
         }
-        for (size_t compId : compOrder)
-        {
-            for (size_t failModeId : failOrder)
-            {
-                if (failModeIdsByCompId[compId].contains(failModeId))
-                {
+        for (size_t compId: compOrder) {
+            for (size_t failModeId: failOrder) {
+                if (failModeIdsByCompId[compId].contains(failModeId)) {
                     stats << ",time fraction: "
                           << s.TheModel.ComponentMap.Tag[compId] << " / "
                           << s.FailureModes.Tags[failModeId];
                 }
             }
-            for (size_t fragModeId : fragOrder)
-            {
-                if (fragModeIdsByCompId[compId].contains(fragModeId))
-                {
+            for (size_t fragModeId: fragOrder) {
+                if (fragModeIdsByCompId[compId].contains(fragModeId)) {
                     stats << ",time fraction: "
                           << s.TheModel.ComponentMap.Tag[compId] << " / "
                           << s.FragilityModes.Tags[fragModeId];
@@ -2273,20 +1951,19 @@ namespace erin
             }
         }
         stats << std::endl;
-        for (auto const& os : occurrenceStats)
-        {
+        for (auto const &os: occurrenceStats) {
             double stored_kJ = os.StorageCharge_kJ - os.StorageDischarge_kJ;
             double balance = os.Inflow_kJ + os.InFromEnv_kJ
-                - (os.OutflowAchieved_kJ + stored_kJ + os.Wasteflow_kJ);
+                             - (os.OutflowAchieved_kJ + stored_kJ + os.Wasteflow_kJ);
             double efficiency = (os.Inflow_kJ + os.StorageDischarge_kJ) > 0.0
-                ? ((os.OutflowAchieved_kJ + os.StorageCharge_kJ)
-                   / (os.Inflow_kJ + os.StorageDischarge_kJ))
-                : 0.0;
+                                ? ((os.OutflowAchieved_kJ + os.StorageCharge_kJ)
+                                   / (os.Inflow_kJ + os.StorageDischarge_kJ))
+                                : 0.0;
             double ER = os.OutflowRequest_kJ > 0.0
-                ? (os.OutflowAchieved_kJ / os.OutflowRequest_kJ)
-                : 1.0;
+                        ? (os.OutflowAchieved_kJ / os.OutflowRequest_kJ)
+                        : 1.0;
             double EA =
-                os.Duration_s > 0.0 ? (os.Uptime_s / os.Duration_s) : 1.0;
+                    os.Duration_s > 0.0 ? (os.Uptime_s / os.Duration_s) : 1.0;
             stats << s.ScenarioMap.Tags[os.Id];
             stats << "," << os.OccurrenceNumber;
             stats << "," << (os.Duration_s / seconds_per_hour);
@@ -2305,162 +1982,131 @@ namespace erin
             stats << "," << (os.MaxSEDT_s / seconds_per_hour);
             stats << ","
                   << ((os.Duration_s > 0.0)
-                          ? (os.Availability_s / os.Duration_s)
-                          : 0.0);
+                      ? (os.Availability_s / os.Duration_s)
+                      : 0.0);
             // NOTE: written in alphabetical order by flowtype name
-            for (auto const& statsByFlow : os.FlowTypeStats)
-            {
+            for (auto const &statsByFlow: os.FlowTypeStats) {
 
                 double ER_by_flow = statsByFlow.TotalRequest_kJ > 0.0
-                    ? (statsByFlow.TotalAchieved_kJ
-                       / statsByFlow.TotalRequest_kJ)
-                    : 0.0;
+                                    ? (statsByFlow.TotalAchieved_kJ
+                                       / statsByFlow.TotalRequest_kJ)
+                                    : 0.0;
                 double EA_by_flow = os.Duration_s > 0.0
-                    ? (statsByFlow.Uptime_s / os.Duration_s)
-                    : 0.0;
+                                    ? (statsByFlow.Uptime_s / os.Duration_s)
+                                    : 0.0;
                 stats << "," << ER_by_flow;
                 stats << "," << EA_by_flow;
             }
-            for (auto const& statsByFlowLoad : os.LoadAndFlowTypeStats)
-            {
+            for (auto const &statsByFlowLoad: os.LoadAndFlowTypeStats) {
                 double ER_by_load = statsByFlowLoad.Stats.TotalRequest_kJ > 0.0
-                    ? (statsByFlowLoad.Stats.TotalAchieved_kJ
-                       / statsByFlowLoad.Stats.TotalRequest_kJ)
-                    : 0.0;
+                                    ? (statsByFlowLoad.Stats.TotalAchieved_kJ
+                                       / statsByFlowLoad.Stats.TotalRequest_kJ)
+                                    : 0.0;
                 double EA_by_load = os.Duration_s > 0.0
-                    ? (statsByFlowLoad.Stats.Uptime_s / os.Duration_s)
-                    : 0.0;
+                                    ? (statsByFlowLoad.Stats.Uptime_s / os.Duration_s)
+                                    : 0.0;
                 stats << "," << ER_by_load;
                 stats << "," << EA_by_load;
             }
-            for (auto const& lnsByComp : os.LoadNotServedForComponents)
-            {
+            for (auto const &lnsByComp: os.LoadNotServedForComponents) {
                 stats << "," << lnsByComp.LoadNotServed_kJ;
             }
-            for (size_t i : compOrder)
-            {
-                if (!componentsToSkip.contains(i))
-                {
+            for (size_t i: compOrder) {
+                if (!componentsToSkip.contains(i)) {
                     double availability = os.Duration_s > 0.0
-                        ? os.AvailabilityByCompId_s.at(i) / os.Duration_s
-                        : 1.0;
+                                          ? os.AvailabilityByCompId_s.at(i) / os.Duration_s
+                                          : 1.0;
                     stats << "," << availability;
                 }
             }
-            for (size_t i : failOrder)
-            {
+            for (size_t i: failOrder) {
                 size_t eventCount = os.EventCountByFailureModeId.contains(i)
-                    ? os.EventCountByFailureModeId.at(i)
-                    : 0;
+                                    ? os.EventCountByFailureModeId.at(i)
+                                    : 0;
                 stats << "," << eventCount;
             }
-            for (size_t i : fragOrder)
-            {
+            for (size_t i: fragOrder) {
                 size_t eventCount = os.EventCountByFragilityModeId.contains(i)
-                    ? os.EventCountByFragilityModeId.at(i)
-                    : 0;
+                                    ? os.EventCountByFragilityModeId.at(i)
+                                    : 0;
                 stats << "," << eventCount;
             }
-            for (size_t i : failOrder)
-            {
+            for (size_t i: failOrder) {
                 double time_s = os.TimeByFailureModeId_s.contains(i)
-                    ? os.TimeByFailureModeId_s.at(i)
-                    : 0.0;
+                                ? os.TimeByFailureModeId_s.at(i)
+                                : 0.0;
                 stats << ","
                       << (os.Duration_s > 0.0 ? time_s / os.Duration_s : 0.0);
             }
-            for (size_t i : fragOrder)
-            {
+            for (size_t i: fragOrder) {
                 double time_s = os.TimeByFragilityModeId_s.contains(i)
-                    ? os.TimeByFragilityModeId_s.at(i)
-                    : 0.0;
+                                ? os.TimeByFragilityModeId_s.at(i)
+                                : 0.0;
                 stats << ","
                       << (os.Duration_s > 0.0 ? time_s / os.Duration_s : 0.0);
             }
-            for (size_t compId : compOrder)
-            {
-                for (size_t i : failOrder)
-                {
-                    if (failModeIdsByCompId[compId].contains(i))
-                    {
+            for (size_t compId: compOrder) {
+                for (size_t i: failOrder) {
+                    if (failModeIdsByCompId[compId].contains(i)) {
                         if (os.EventCountByCompIdByFailureModeId.contains(compId
-                            )
+                        )
                             && os.EventCountByCompIdByFailureModeId.at(compId)
-                                   .contains(i))
-                        {
+                                    .contains(i)) {
                             stats << ","
                                   << os.EventCountByCompIdByFailureModeId
-                                         .at(compId)
-                                         .at(i);
-                        }
-                        else
-                        {
+                                          .at(compId)
+                                          .at(i);
+                        } else {
                             stats << ",0";
                         }
                     }
                 }
-                for (size_t i : fragOrder)
-                {
-                    if (fragModeIdsByCompId[compId].contains(i))
-                    {
+                for (size_t i: fragOrder) {
+                    if (fragModeIdsByCompId[compId].contains(i)) {
                         if (os.EventCountByCompIdByFragilityModeId.contains(
                                 compId
-                            )
+                        )
                             && os.EventCountByCompIdByFragilityModeId.at(compId)
-                                   .contains(i))
-                        {
+                                    .contains(i)) {
                             stats << ","
                                   << os.EventCountByCompIdByFragilityModeId
-                                         .at(compId)
-                                         .at(i);
-                        }
-                        else
-                        {
+                                          .at(compId)
+                                          .at(i);
+                        } else {
                             stats << ",0";
                         }
                     }
                 }
             }
-            for (size_t compId : compOrder)
-            {
-                for (size_t i : failOrder)
-                {
-                    if (failModeIdsByCompId[compId].contains(i))
-                    {
+            for (size_t compId: compOrder) {
+                for (size_t i: failOrder) {
+                    if (failModeIdsByCompId[compId].contains(i)) {
                         if (os.TimeByCompIdByFailureModeId_s.contains(compId)
                             && os.TimeByCompIdByFailureModeId_s.at(compId)
-                                   .contains(i))
-                        {
+                                    .contains(i)) {
                             double t =
-                                os.TimeByCompIdByFailureModeId_s.at(compId).at(i
-                                );
+                                    os.TimeByCompIdByFailureModeId_s.at(compId).at(i
+                                    );
                             stats << ","
                                   << (os.Duration_s > 0.0 ? t / os.Duration_s
                                                           : 0.0);
-                        }
-                        else
-                        {
+                        } else {
                             stats << ",0";
                         }
                     }
                 }
-                for (size_t i : fragOrder)
-                {
-                    if (fragModeIdsByCompId[compId].contains(i))
-                    {
+                for (size_t i: fragOrder) {
+                    if (fragModeIdsByCompId[compId].contains(i)) {
                         if (os.TimeByCompIdByFragilityModeId_s.contains(compId)
                             && os.TimeByCompIdByFragilityModeId_s.at(compId)
-                                   .contains(i))
-                        {
+                                    .contains(i)) {
                             double t =
-                                os.TimeByCompIdByFragilityModeId_s.at(compId)
-                                    .at(i);
+                                    os.TimeByCompIdByFragilityModeId_s.at(compId)
+                                            .at(i);
                             stats << ","
                                   << (os.Duration_s > 0.0 ? t / os.Duration_s
                                                           : 0.0);
-                        }
-                        else
-                        {
+                        } else {
                             stats << ",0";
                         }
                     }
@@ -2472,85 +2118,113 @@ namespace erin
     }
 
 
-    std::vector<TimeAndFlows> format_results(std::vector<TimeAndFlows> const& results, std::pair<bool, double> const& custom_cadence_h)
-    {
-        if (results.empty() || (!custom_cadence_h.first))
+    std::vector<TimeAndFlows>
+    format_results(std::vector<TimeAndFlows> const &results, std::pair<bool, double> const &custom_cadence_h) {
+        auto num_events = results.size();
+        if ((num_events == 0) || (!custom_cadence_h.first))
             return results;
 
-        auto& taf_eff = results.front();
-        auto num_flows = taf_eff.Flows.size();
+        auto taf = results.front();
+        auto num_flows = taf.Flows.size();
+        auto num_stored = taf.StorageAmounts_J.size();
 
-        std::vector<TimeAndFlows> formatted_results = {taf_eff};
+        std::vector<TimeAndFlows> formatted_results = {taf};
 
-
-        double t_s = 0.0;
-        double dt_report_s = 3600. * custom_cadence_h.second;
-        double tnext_s = t_s + dt_report_s;
-
-        struct time_flow_products
-        {
-            double actual_J, requested_J, available_J;
+        struct time_flow_stats {
+            double sum_actual_prod, sum_requested_prod, sum_available_prod;
         };
-        std::vector<time_flow_products> time_flow_prods(num_flows);
+        std::vector<time_flow_stats> time_flow_prods(num_flows);
 
-        for (auto& taf: results)
-        {
+        double t_prev_report_s = 0.;
+        double T_report_s = 3600. * custom_cadence_h.second;
 
-            while (tnext_s < taf.Time)
-            {
-                double dt_s = (tnext_s < taf.Time) ? (tnext_s - t_s) :
-                {
-                    dt_s = tnext_s - t_s;
+        struct FlowTime {
+            double Requested_J = 0;
+            double Available_J = 0;
+            double Actual_J = 0;
+        };
+        std::vector<FlowTime> flow_times(num_flows, {0., 0., 0.});
+        std::vector<double> storage_totals_J(num_flows, 0.);
+
+        for (std::size_t i_taf = 1; i_taf < num_events; ++i_taf) {
+            auto &next_taf = results[i_taf];
+
+            double t_next_report_s = t_prev_report_s + T_report_s;
+
+            // advance to next event time
+            while (t_next_report_s < next_taf.Time) {
+
+                double dt_s = t_next_report_s - taf.Time;
+                for (std::size_t i = 0; i < num_flows; ++i) {
+                    flow_times[i].Requested_J += static_cast<double>(taf.Flows[i].Requested_W) * dt_s;
+                    flow_times[i].Available_J += static_cast<double>(taf.Flows[i].Available_W) * dt_s;
+                    flow_times[i].Actual_J += static_cast<double>(taf.Flows[i].Actual_W) * dt_s;
+                }
+                double dt_orig_s = next_taf.Time - taf.Time;
+                if (dt_orig_s > 0.) {
+                    double time_frac = dt_s / dt_orig_s;
+                    for (size_t i = 0; i < num_stored; ++i) {
+                        storage_totals_J[i] += time_frac *
+                                               static_cast<double>(taf.StorageAmounts_J[i]);
+                    }
                 }
 
+                // report
+                auto mod_taf = taf;
+                mod_taf.Time = t_next_report_s;
+                for (std::size_t i = 0; i < num_flows; ++i) {
+                    mod_taf.Flows[i].Requested_W = flow_times[i].Requested_J / dt_s;
+                    mod_taf.Flows[i].Available_W = flow_times[i].Available_J / dt_s;
+                    mod_taf.Flows[i].Actual_W = flow_times[i].Actual_J / dt_s;
+                }
+                for (size_t i = 0; i < num_stored; ++i) {
+                    mod_taf.StorageAmounts_J[i] = static_cast<flow_t>(storage_totals_J[i]);
+                }
+                formatted_results.push_back(mod_taf);
 
-                for (size_t i = 0; i < num_flows; ++i)
-                {
-                    auto& time_flow_prod = time_flow_prods[i];
-                    auto& flows = taf.Flows[i];
+                flow_times.assign(num_flows, {0., 0., 0.});
+                storage_totals_J.assign(num_flows, 0.);
 
-                    time_flow_prod.actual_J += flows.Actual_W * dt_s;
+                t_prev_report_s = t_next_report_s;
+                t_next_report_s += T_report_s;
+            }
+
+            if (t_next_report_s >= next_taf.Time) {
+                double dt_s = next_taf.Time - t_prev_report_s;
+                for (std::size_t i = 0; i < num_flows; ++i) {
+                    flow_times[i].Requested_J += static_cast<double>(taf.Flows[i].Requested_W) * dt_s;
+                    flow_times[i].Available_J += static_cast<double>(taf.Flows[i].Available_W) * dt_s;
+                    flow_times[i].Actual_J += static_cast<double>(taf.Flows[i].Actual_W) * dt_s;
+                }
+                double dt_orig_s = next_taf.Time - taf.Time;
+                if (dt_orig_s > 0.) {
+                    double time_frac = dt_s / dt_orig_s;
+                    for (size_t i = 0; i < num_stored; ++i) {
+                        storage_totals_J[i] += time_frac *
+                                               static_cast<double>(taf.StorageAmounts_J[i]);
+                    }
                 }
             }
-
-            std::vector<Flow> tot_flows;
-
-            for (auto& flow: taf.Flows)
-            {
-                tot_flows
-            }
-
-
-            if (taf.Time > tnext_s) {
-                taf.Flows;
-                taf.StorageAmounts_J;
-            }
-            t_s = taf.Time;
+            taf = next_taf;
         }
-
-
         return formatted_results;
     }
 
     void
     Simulation_Run(
-        Simulation& s,
-        std::string const& eventsFilename,
-        std::string const& statsFilename,
-        std::pair<bool, double> custom_cadence_h /*{false, -1.}*/,
-        bool const verbose
-    )
-    {
+            Simulation &s,
+            std::string const &eventsFilename,
+            std::string const &statsFilename,
+            std::pair<bool, double> custom_cadence_h /*{false, -1.}*/,
+            bool const verbose
+    ) {
         // TODO: wrap into input options struct and pass in
         bool const checkNetwork = false;
-        if (checkNetwork)
-        {
+        if (checkNetwork) {
             std::vector<std::string> issues = Model_CheckNetwork(s.TheModel);
-            if (issues.size() > 0)
-            {
+            if (issues.size() > 0) {
                 std::cout << "NETWORK CONNECTION ISSUES:" << std::endl;
-                for (std::string const& issue : issues)
-                {
+                for (std::string const &issue: issues) {
                     std::cout << issue << std::endl;
                 }
             }
@@ -2562,39 +2236,33 @@ namespace erin
         FixedRandom fixedRandom;
         FixedSeries fixedSeries;
         Random fullRandom;
-        switch (s.Info.TypeOfRandom)
-        {
-            case (RandomType::FixedRandom):
-            {
+        switch (s.Info.TypeOfRandom) {
+            case (RandomType::FixedRandom): {
                 fixedRandom.FixedValue = s.Info.FixedValue;
                 s.TheModel.RandFn = fixedRandom;
             }
-            break;
-            case (RandomType::FixedSeries):
-            {
+                break;
+            case (RandomType::FixedSeries): {
                 fixedSeries.Idx = 0;
                 fixedSeries.Series = s.Info.Series;
                 s.TheModel.RandFn = fixedSeries;
             }
-            break;
-            case (RandomType::RandomFromSeed):
-            {
+                break;
+            case (RandomType::RandomFromSeed): {
                 fullRandom = CreateRandomWithSeed(s.Info.Seed);
                 s.TheModel.RandFn = fullRandom;
             }
-            break;
-            case (RandomType::RandomFromClock):
-            {
+                break;
+            case (RandomType::RandomFromClock): {
                 fullRandom = CreateRandom();
                 s.TheModel.RandFn = fullRandom;
             }
-            break;
-            default:
-            {
+                break;
+            default: {
                 WriteErrorMessage("RandomType", "unhandled random type");
                 std::exit(1);
             }
-            break;
+                break;
         }
         // TODO: expose proper options
         // TODO: check the components and network:
@@ -2613,13 +2281,11 @@ namespace erin
         // ... as fragility is "by scenario".
         double maxDuration_s = 0.0;
         for (size_t scenId = 0; scenId < s.ScenarioMap.Durations.size();
-             ++scenId)
-        {
+             ++scenId) {
             double duration_s = Time_ToSeconds(
-                s.ScenarioMap.Durations[scenId], s.ScenarioMap.TimeUnits[scenId]
+                    s.ScenarioMap.Durations[scenId], s.ScenarioMap.TimeUnits[scenId]
             );
-            if (duration_s > maxDuration_s)
-            {
+            if (duration_s > maxDuration_s) {
                 maxDuration_s = duration_s;
             }
         }
@@ -2633,34 +2299,30 @@ namespace erin
         // NOTE: set up reliability manager
         // TODO: remove duplication of data here
         for (size_t fmIdx = 0; fmIdx < s.FailureModes.FailureDistIds.size();
-             ++fmIdx)
-        {
+             ++fmIdx) {
             s.TheModel.Rel.add_failure_mode(
-                s.FailureModes.Tags[fmIdx],
-                s.FailureModes.FailureDistIds[fmIdx],
-                s.FailureModes.RepairDistIds[fmIdx]
+                    s.FailureModes.Tags[fmIdx],
+                    s.FailureModes.FailureDistIds[fmIdx],
+                    s.FailureModes.RepairDistIds[fmIdx]
             );
         }
         for (size_t compFailId = 0;
              compFailId < s.ComponentFailureModes.ComponentIds.size();
-             ++compFailId)
-        {
+             ++compFailId) {
             size_t fmId = s.ComponentFailureModes.FailureModeIds[compFailId];
             s.TheModel.Rel.link_component_with_failure_mode(
-                s.ComponentFailureModes.ComponentIds[compFailId],
-                s.ComponentFailureModes.FailureModeIds[compFailId]
+                    s.ComponentFailureModes.ComponentIds[compFailId],
+                    s.ComponentFailureModes.FailureModeIds[compFailId]
             );
             double maxTime_s =
-                Time_ToSeconds(s.Info.MaxTime, s.Info.TheTimeUnit)
-                + maxDuration_s;
+                    Time_ToSeconds(s.Info.MaxTime, s.Info.TheTimeUnit)
+                    + maxDuration_s;
             std::vector<TimeState> relSch =
-                s.TheModel.Rel.make_schedule_for_link(
-                    fmId, s.TheModel.RandFn, s.TheModel.DistSys, maxTime_s
-                );
-            for (auto& ts : relSch)
-            {
-                if (!ts.state)
-                {
+                    s.TheModel.Rel.make_schedule_for_link(
+                            fmId, s.TheModel.RandFn, s.TheModel.DistSys, maxTime_s
+                    );
+            for (auto &ts: relSch) {
+                if (!ts.state) {
                     ts.failureModeCauses.insert(fmId);
                 }
             }
@@ -2668,18 +2330,14 @@ namespace erin
         }
         // NOTE: combine reliability curves so they are per component
         std::map<size_t, std::vector<TimeState>> relSchByCompId;
-        for (auto const& pair : relSchByCompFailId)
-        {
+        for (auto const &pair: relSchByCompFailId) {
             size_t compId = s.ComponentFailureModes.ComponentIds[pair.first];
-            if (relSchByCompId.contains(compId))
-            {
+            if (relSchByCompId.contains(compId)) {
                 std::vector<TimeState> combined = TimeState_Combine(
-                    pair.second, relSchByCompId.at(pair.first)
+                        pair.second, relSchByCompId.at(pair.first)
                 );
                 relSchByCompId.insert({compId, std::move(combined)});
-            }
-            else
-            {
+            } else {
                 relSchByCompId.insert({compId, pair.second});
             }
         }
@@ -2692,44 +2350,39 @@ namespace erin
         // NOW, we want to do a simulation for each scenario
         std::ofstream out;
         out.open(eventsFilename);
-        if (!out.good())
-        {
+        if (!out.good()) {
             std::cout << "Could not open '" << eventsFilename
                       << "' for writing." << std::endl;
             return;
         }
         WriteEventFileHeader(
-            out,
-            s.TheModel,
-            s.FlowTypeMap,
-            connOrder,
-            storeOrder,
-            compOrder,
-            outputTimeUnit
+                out,
+                s.TheModel,
+                s.FlowTypeMap,
+                connOrder,
+                storeOrder,
+                compOrder,
+                outputTimeUnit
         );
         std::vector<ScenarioOccurrenceStats> occurrenceStats;
-        for (size_t scenIdx : scenarioOrder)
-        {
-            std::string const& scenarioTag = s.ScenarioMap.Tags[scenIdx];
-            if (verbose)
-            {
+        for (size_t scenIdx: scenarioOrder) {
+            std::string const &scenarioTag = s.ScenarioMap.Tags[scenIdx];
+            if (verbose) {
                 std::cout << "Scenario: " << scenarioTag << std::endl;
             }
             // for this scenario, ensure all schedule-based components
             // have the right schedule set for this scenario
             if (SetLoadsForScenario(
                     s.TheModel.ScheduledLoads, s.LoadMap, scenIdx
-                )
-                == Result::Failure)
-            {
+            )
+                == Result::Failure) {
                 std::cout << "Issue setting schedule loads" << std::endl;
                 return;
             }
             if (SetSupplyForScenario(
                     s.TheModel.ScheduledSrcs, s.LoadMap, scenIdx
-                )
-                == Result::Failure)
-            {
+            )
+                == Result::Failure) {
                 std::cout << "Issue setting schedule sources" << std::endl;
                 return;
             }
@@ -2737,33 +2390,30 @@ namespace erin
             // for (size_t sbsIdx = 0; sbsIdx < s.Model.ScheduleSrcs.size();
             // ++sbsIdx) {/* ... */}
             std::vector<double> occurrenceTimes_s =
-                DetermineScenarioOccurrenceTimes(s, scenIdx, verbose);
+                    DetermineScenarioOccurrenceTimes(s, scenIdx, verbose);
             // TODO: initialize total scenario stats (i.e.,
             // over all occurrences)
             std::map<size_t, double> intensityIdToAmount =
-                GetIntensitiesForScenario(s, scenIdx);
-            for (size_t occIdx = 0; occIdx < occurrenceTimes_s.size(); ++occIdx)
-            {
+                    GetIntensitiesForScenario(s, scenIdx);
+            for (size_t occIdx = 0; occIdx < occurrenceTimes_s.size(); ++occIdx) {
                 double t = occurrenceTimes_s[occIdx];
                 double duration_s = Time_ToSeconds(
-                    s.ScenarioMap.Durations[scenIdx],
-                    s.ScenarioMap.TimeUnits[scenIdx]
+                        s.ScenarioMap.Durations[scenIdx],
+                        s.ScenarioMap.TimeUnits[scenIdx]
                 );
                 double tEnd = t + duration_s;
-                if (verbose)
-                {
+                if (verbose) {
                     std::cout << "Occurrence #" << (occIdx + 1) << " at "
                               << SecondsToPrettyString(t) << std::endl;
                 }
                 // TODO: make initial age part of the ComponentMap
                 std::vector<ScheduleBasedReliability> originalReliabilities =
-                    ApplyReliabilitiesAndFragilities(
-                        s, t, tEnd, intensityIdToAmount, relSchByCompId, verbose
-                    );
+                        ApplyReliabilitiesAndFragilities(
+                                s, t, tEnd, intensityIdToAmount, relSchByCompId, verbose
+                        );
                 std::string scenarioStartTimeTag =
-                    TimeToISO8601Period(static_cast<uint64_t>(std::llround(t)));
-                if (verbose)
-                {
+                        TimeToISO8601Period(static_cast<uint64_t>(std::llround(t)));
+                if (verbose) {
                     std::cout << "Running " << s.ScenarioMap.Tags[scenIdx]
                               << " from " << scenarioStartTimeTag << " for "
                               << s.ScenarioMap.Durations[scenIdx] << " "
@@ -2782,25 +2432,24 @@ namespace erin
 
                 // TODO: investigate putting output on another thread
                 WriteResultsToEventFile(
-                    out,
-                    formatted_results,
-                    s,
-                    scenarioTag,
-                    scenarioStartTimeTag,
-                    connOrder,
-                    storeOrder,
-                    compOrder,
-                    outputTimeUnit
+                        out,
+                        formatted_results,
+                        s,
+                        scenarioTag,
+                        scenarioStartTimeTag,
+                        connOrder,
+                        storeOrder,
+                        compOrder,
+                        outputTimeUnit
                 );
                 ScenarioOccurrenceStats sos =
-                    ModelResults_CalculateScenarioOccurrenceStats(
-                        scenIdx, occIdx + 1, s.TheModel, s.FlowTypeMap, results
-                    );
+                        ModelResults_CalculateScenarioOccurrenceStats(
+                                scenIdx, occIdx + 1, s.TheModel, s.FlowTypeMap, results
+                        );
                 occurrenceStats.push_back(std::move(sos));
                 s.TheModel.Reliabilities = originalReliabilities;
             }
-            if (verbose)
-            {
+            if (verbose) {
                 std::cout << "Scenario " << scenarioTag << " finished"
                           << std::endl;
             }
@@ -2809,7 +2458,7 @@ namespace erin
         }
         out.close();
         WriteStatisticsToFile(
-            s, statsFilename, occurrenceStats, compOrder, failOrder, fragOrder
+                s, statsFilename, occurrenceStats, compOrder, failOrder, fragOrder
         );
     }
 } // namespace erin

--- a/test/erin_tests.cpp
+++ b/test/erin_tests.cpp
@@ -1893,30 +1893,35 @@ TEST(Erin, TestApplyUniformTimeStep)
     // SIMULATION INFO and INITIALIZATION
     Model m = {};
     m.RandFn = []() { return 0.4; };
-    m.FinalTime = hours_as_seconds(24.);
+    m.FinalTime = hours_as_seconds(24.0);
 
     // COMPONENTS
     std::vector<TimeAndAmount> ePV_avail{};
     ePV_avail.reserve(5);
-    ePV_avail.push_back(TimeAndAmount{hours_as_seconds(0.), kW_as_W(0.)});
-    ePV_avail.push_back(TimeAndAmount{hours_as_seconds(6.), kW_as_W(1.)});
-    ePV_avail.push_back(TimeAndAmount{hours_as_seconds(9.), kW_as_W(1.5)});
-    ePV_avail.push_back(TimeAndAmount{hours_as_seconds(18.), kW_as_W(1.)});
-    ePV_avail.push_back(TimeAndAmount{hours_as_seconds(21.), kW_as_W(0.)});
+    ePV_avail.push_back(TimeAndAmount{hours_as_seconds(0.0), kW_as_W(0.0)});
+    ePV_avail.push_back(TimeAndAmount{hours_as_seconds(6.0), kW_as_W(1.0)});
+    ePV_avail.push_back(TimeAndAmount{hours_as_seconds(9.0), kW_as_W(1.5)});
+    ePV_avail.push_back(TimeAndAmount{hours_as_seconds(18.0), kW_as_W(1.0)});
+    ePV_avail.push_back(TimeAndAmount{hours_as_seconds(21.0), kW_as_W(0.0)});
 
     // COMPONENTS
     auto ePV = Model_AddScheduleBasedSource(m, ePV_avail);
     auto eBattId = Model_AddStore(
-        m, kWh_as_J(2.), kW_as_W(0.5), kW_as_W(1.), kWh_as_J(0.), kWh_as_J(1.)
+        m,
+        kWh_as_J(2.0),
+        kW_as_W(0.5),
+        kW_as_W(1.0),
+        kWh_as_J(0.0),
+        kWh_as_J(1.0)
     );
 
     // LOADS
     std::vector<TimeAndAmount> eLoad{};
     eLoad.reserve(5);
-    eLoad.push_back(TimeAndAmount{hours_as_seconds(0.), kW_as_W(0.1)});
-    eLoad.push_back(TimeAndAmount{hours_as_seconds(6.), kW_as_W(1.5)});
-    eLoad.push_back(TimeAndAmount{hours_as_seconds(12.), kW_as_W(0.5)});
-    eLoad.push_back(TimeAndAmount{hours_as_seconds(18.), kW_as_W(1.)});
+    eLoad.push_back(TimeAndAmount{hours_as_seconds(0.0), kW_as_W(0.1)});
+    eLoad.push_back(TimeAndAmount{hours_as_seconds(6.0), kW_as_W(1.5)});
+    eLoad.push_back(TimeAndAmount{hours_as_seconds(12.0), kW_as_W(0.5)});
+    eLoad.push_back(TimeAndAmount{hours_as_seconds(18.0), kW_as_W(1.0)});
     eLoad.push_back(TimeAndAmount{hours_as_seconds(21.0), kW_as_W(0.1)});
     auto eLoadId = Model_AddScheduleBasedLoad(m, eLoad);
 
@@ -1928,21 +1933,21 @@ TEST(Erin, TestApplyUniformTimeStep)
     auto results = Simulate(m, false);
 
     // Apply uniform time step
-    auto modified_results = applyUniformTimeStep(results, 1.); // 1-h steps
+    auto modified_results = ApplyUniformTimeStep(results, 1.0); // 1-h steps
 
     EXPECT_EQ(modified_results.size(), 25) << "incorrect number of events";
-    EXPECT_EQ(modified_results[8].Time, hours_as_seconds(8.))
+    EXPECT_EQ(modified_results[8].Time, hours_as_seconds(8.0))
         << "incorrect time of event";
     EXPECT_EQ(modified_results[8].Flows.size(), 3)
         << "incorrect number of flows";
 
     EXPECT_EQ(modified_results[8].Flows[2].Requested_W, kW_as_W(1.5))
         << "incorrect requested-flow value";
-    EXPECT_EQ(modified_results[8].Flows[2].Actual_W, kW_as_W(1.))
+    EXPECT_EQ(modified_results[8].Flows[2].Actual_W, kW_as_W(1.0))
         << "incorrect actual-flow value";
-    EXPECT_EQ(modified_results[8].StorageAmounts_J[0], kWh_as_J(0.))
+    EXPECT_EQ(modified_results[8].StorageAmounts_J[0], kWh_as_J(0.0))
         << "incorrect storage amount";
 
-    EXPECT_EQ(modified_results[14].StorageAmounts_J[0], kWh_as_J(1.))
+    EXPECT_EQ(modified_results[14].StorageAmounts_J[0], kWh_as_J(1.0))
         << "incorrect storage amount";
 }

--- a/test/erin_tests.cpp
+++ b/test/erin_tests.cpp
@@ -23,7 +23,6 @@ static auto kW_as_W = [](double p_kW) -> uint32_t
 { return static_cast<uint32_t>(std::round(p_kW * 1000.0)); };
 static auto hours_as_seconds = [](double h) -> double { return h * 3600.0; };
 static auto kWh_as_J = [](double kWh) -> double { return kWh * 3'600'000.0; };
-static auto J_as_kWh = [](double J) -> double { return J / 3'600'000.0; };
 
 TEST(Erin, Test1)
 {
@@ -1889,7 +1888,8 @@ TEST(Erin, TestParsingComponentsInUse)
     }
 }
 
-TEST(Erin, TestApplyUniformTimeStep) {
+TEST(Erin, TestApplyUniformTimeStep)
+{
     // SIMULATION INFO and INITIALIZATION
     Model m = {};
     m.RandFn = []() { return 0.4; };
@@ -1907,12 +1907,7 @@ TEST(Erin, TestApplyUniformTimeStep) {
     // COMPONENTS
     auto ePV = Model_AddScheduleBasedSource(m, ePV_avail);
     auto eBattId = Model_AddStore(
-            m,
-            kWh_as_J(2.),
-            kW_as_W(0.5),
-            kW_as_W(1.),
-            kWh_as_J(0.),
-            kWh_as_J(1.)
+        m, kWh_as_J(2.), kW_as_W(0.5), kW_as_W(1.), kWh_as_J(0.), kWh_as_J(1.)
     );
 
     // LOADS
@@ -1937,17 +1932,17 @@ TEST(Erin, TestApplyUniformTimeStep) {
 
     EXPECT_EQ(modified_results.size(), 25) << "incorrect number of events";
     EXPECT_EQ(modified_results[8].Time, hours_as_seconds(8.))
-                        << "incorrect time of event";
+        << "incorrect time of event";
     EXPECT_EQ(modified_results[8].Flows.size(), 3)
-                        << "incorrect number of flows";
+        << "incorrect number of flows";
 
     EXPECT_EQ(modified_results[8].Flows[2].Requested_W, kW_as_W(1.5))
-                        << "incorrect requested-flow value";
+        << "incorrect requested-flow value";
     EXPECT_EQ(modified_results[8].Flows[2].Actual_W, kW_as_W(1.))
-                        << "incorrect actual-flow value";
+        << "incorrect actual-flow value";
     EXPECT_EQ(modified_results[8].StorageAmounts_J[0], kWh_as_J(0.))
-                        << "incorrect storage amount";
+        << "incorrect storage amount";
 
     EXPECT_EQ(modified_results[14].StorageAmounts_J[0], kWh_as_J(1.))
-                        << "incorrect storage amount";
+        << "incorrect storage amount";
 }

--- a/test/erin_tests.cpp
+++ b/test/erin_tests.cpp
@@ -1887,8 +1887,10 @@ TEST(Erin, TestParsingComponentsInUse)
     }
 }
 
-TEST(Erin, TestApplyUniformTimeStep) {
-    auto kW_as_W = [](double p_kW) -> uint32_t { return static_cast<uint32_t>(std::round(p_kW * 1000.0)); };
+TEST(Erin, TestApplyUniformTimeStep)
+{
+    auto kW_as_W = [](double p_kW) -> uint32_t
+    { return static_cast<uint32_t>(std::round(p_kW * 1000.0)); };
     auto hours_as_seconds = [](double h) -> double { return h * 3600.0; };
     auto kWh_as_J = [](double kWh) -> double { return kWh * 3'600'000.0; };
 
@@ -1907,19 +1909,11 @@ TEST(Erin, TestApplyUniformTimeStep) {
 
     std::vector<TimeAndAmount> heatLoad{};
     heatLoad.reserve(5);
-    heatLoad.push_back(
-            TimeAndAmount{hours_as_seconds(0.0), kW_as_W(10.00)}
-    );
-    heatLoad.push_back(
-            TimeAndAmount{hours_as_seconds(3.0), kW_as_W(20.00)}
-    );
-    heatLoad.push_back(
-            TimeAndAmount{hours_as_seconds(9.0), kW_as_W(10.00)}
-    );
-    heatLoad.push_back(TimeAndAmount{hours_as_seconds(15.0), kW_as_W(30.00)}
-    );
-    heatLoad.push_back(TimeAndAmount{hours_as_seconds(21.0), kW_as_W(10.00)}
-    );
+    heatLoad.push_back(TimeAndAmount{hours_as_seconds(0.0), kW_as_W(10.00)});
+    heatLoad.push_back(TimeAndAmount{hours_as_seconds(3.0), kW_as_W(20.00)});
+    heatLoad.push_back(TimeAndAmount{hours_as_seconds(9.0), kW_as_W(10.00)});
+    heatLoad.push_back(TimeAndAmount{hours_as_seconds(15.0), kW_as_W(30.00)});
+    heatLoad.push_back(TimeAndAmount{hours_as_seconds(21.0), kW_as_W(10.00)});
 
     std::vector<TimeAndAmount> pvAvail{};
     pvAvail.reserve(4);
@@ -1931,17 +1925,17 @@ TEST(Erin, TestApplyUniformTimeStep) {
     auto pvArrayId = Model_AddScheduleBasedSource(m, pvAvail);
     auto elecUtilId = Model_AddConstantSource(m, kW_as_W(10.0));
     auto batteryId = Model_AddStore(
-            m,
-            kWh_as_J(100.0),
-            kW_as_W(10.0),
-            kW_as_W(1'000.0),
-            kWh_as_J(80.0),
-            kWh_as_J(100.0)
+        m,
+        kWh_as_J(100.0),
+        kW_as_W(10.0),
+        kW_as_W(1'000.0),
+        kWh_as_J(80.0),
+        kWh_as_J(100.0)
     );
     auto elecSourceMuxId = Model_AddMux(m, 2, 1);
     auto elecSupplyMuxId = Model_AddMux(m, 2, 2);
     auto ngUtilId =
-            Model_AddConstantSource(m, std::numeric_limits<uint32_t>::max());
+        Model_AddConstantSource(m, std::numeric_limits<uint32_t>::max());
     auto ngSourceMuxId = Model_AddMux(m, 1, 2);
     auto ngToElecConvId = Model_AddConstantEfficiencyConverter(m, 42, 100);
     auto elecHeatPumpConvId = Model_AddConstantEfficiencyConverter(m, 35, 10);
@@ -1953,37 +1947,37 @@ TEST(Erin, TestApplyUniformTimeStep) {
     // NETWORK / CONNECTIONS
     // - electricity
     auto pvToEmuxConn =
-            Model_AddConnection(m, pvArrayId.Id, 0, elecSourceMuxId, 0);
+        Model_AddConnection(m, pvArrayId.Id, 0, elecSourceMuxId, 0);
     auto eutilToEmuxConn =
-            Model_AddConnection(m, elecUtilId, 0, elecSourceMuxId, 1);
+        Model_AddConnection(m, elecUtilId, 0, elecSourceMuxId, 1);
     auto emuxToBatteryConn =
-            Model_AddConnection(m, elecSourceMuxId, 0, batteryId, 0);
+        Model_AddConnection(m, elecSourceMuxId, 0, batteryId, 0);
     auto batteryToEsupplyConn =
-            Model_AddConnection(m, batteryId, 0, elecSupplyMuxId, 0);
+        Model_AddConnection(m, batteryId, 0, elecSupplyMuxId, 0);
     auto ngGenToEsupplyConn =
-            Model_AddConnection(m, ngToElecConvId.Id, 0, elecSupplyMuxId, 1);
+        Model_AddConnection(m, ngToElecConvId.Id, 0, elecSupplyMuxId, 1);
     auto esupplyToLoadConn =
-            Model_AddConnection(m, elecSupplyMuxId, 0, elecLoadId, 0);
+        Model_AddConnection(m, elecSupplyMuxId, 0, elecLoadId, 0);
     auto esupplyToHeatPumpConn =
-            Model_AddConnection(m, elecSupplyMuxId, 1, elecHeatPumpConvId.Id, 0);
+        Model_AddConnection(m, elecSupplyMuxId, 1, elecHeatPumpConvId.Id, 0);
 
     // - natural gas
     auto ngGridToNgMuxConn =
-            Model_AddConnection(m, ngUtilId, 0, ngSourceMuxId, 0);
+        Model_AddConnection(m, ngUtilId, 0, ngSourceMuxId, 0);
     auto ngMuxToNgGenConn =
-            Model_AddConnection(m, ngSourceMuxId, 0, ngToElecConvId.Id, 0);
+        Model_AddConnection(m, ngSourceMuxId, 0, ngToElecConvId.Id, 0);
     auto ngMuxToNgHeaterConn =
-            Model_AddConnection(m, ngSourceMuxId, 1, ngHeaterConvId.Id, 0);
+        Model_AddConnection(m, ngSourceMuxId, 1, ngHeaterConvId.Id, 0);
 
     // - heating
     auto ngGenLossToHeatMuxConn =
-            Model_AddConnection(m, ngToElecConvId.Id, 1, heatingSupplyMuxId, 0);
+        Model_AddConnection(m, ngToElecConvId.Id, 1, heatingSupplyMuxId, 0);
     auto ngHeaterToHeatMuxConn =
-            Model_AddConnection(m, ngHeaterConvId.Id, 0, heatingSupplyMuxId, 1);
+        Model_AddConnection(m, ngHeaterConvId.Id, 0, heatingSupplyMuxId, 1);
     auto heatPumpToHeatMuxConn =
-            Model_AddConnection(m, elecHeatPumpConvId.Id, 0, heatingSupplyMuxId, 2);
+        Model_AddConnection(m, elecHeatPumpConvId.Id, 0, heatingSupplyMuxId, 2);
     auto heatMuxToLoadConn =
-            Model_AddConnection(m, heatingSupplyMuxId, 0, heatLoadId, 0);
+        Model_AddConnection(m, heatingSupplyMuxId, 0, heatLoadId, 0);
 
     // SIMULATE
     auto results = Simulate(m, false);
@@ -1991,9 +1985,13 @@ TEST(Erin, TestApplyUniformTimeStep) {
     auto modified_results = applyUniformTimeStep(results, 6.);
 
     EXPECT_EQ(modified_results.size(), 5) << "incorrect number of events";
-    EXPECT_EQ(modified_results[1].Time, hours_as_seconds(6.0)) << "incorrect time of event";
-    EXPECT_EQ(modified_results[0].Flows.size(), 18) << "incorrect number of flows";
+    EXPECT_EQ(modified_results[1].Time, hours_as_seconds(6.0))
+        << "incorrect time of event";
+    EXPECT_EQ(modified_results[0].Flows.size(), 18)
+        << "incorrect number of flows";
 
-    EXPECT_EQ(modified_results[2].Flows[3].Actual_W, 205) << "incorrect actual-flow value";
-    EXPECT_EQ(modified_results[2].StorageAmounts_J[0], J_per_kJ * 216000) << "incorrect storage amount";
+    EXPECT_EQ(modified_results[2].Flows[3].Actual_W, 205)
+        << "incorrect actual-flow value";
+    EXPECT_EQ(modified_results[2].StorageAmounts_J[0], J_per_kJ * 216'000)
+        << "incorrect storage amount";
 }

--- a/test/erin_tests.cpp
+++ b/test/erin_tests.cpp
@@ -1886,3 +1886,116 @@ TEST(Erin, TestParsingComponentsInUse)
             << "expected item '" << item << "' not present";
     }
 }
+
+TEST(Erin, TestApplyUniformTimeStep)
+{
+    auto kW_as_W = [](double p_kW) -> uint32_t
+    { return static_cast<uint32_t>(std::round(p_kW * 1000.0)); };
+    auto hours_as_seconds = [](double h) -> double { return h * 3600.0; };
+    auto kWh_as_J = [](double kWh) -> double { return kWh * 3'600'000.0; };
+
+    // SIMULATION INFO and INITIALIZATION
+    Model m = {};
+    m.RandFn = []() { return 0.4; };
+    m.FinalTime = hours_as_seconds(24.0);
+
+    // LOADS
+    std::vector<TimeAndAmount> elecLoad{};
+    elecLoad.reserve(4);
+    elecLoad.push_back(TimeAndAmount{hours_as_seconds(0.0), kW_as_W(100.00)});
+    elecLoad.push_back(TimeAndAmount{hours_as_seconds(6.0), kW_as_W(0.00)});
+    elecLoad.push_back(TimeAndAmount{hours_as_seconds(12.0), kW_as_W(50.0)});
+    elecLoad.push_back(TimeAndAmount{hours_as_seconds(18.0), kW_as_W(0.00)});
+
+    std::vector<TimeAndAmount> heatLoad{};
+    heatLoad.reserve(5);
+    heatLoad.push_back(
+            TimeAndAmount{hours_as_seconds(0.0), kW_as_W(10.00)}
+    );
+    heatLoad.push_back(
+            TimeAndAmount{hours_as_seconds(3.0), kW_as_W(20.00)}
+    );
+    heatLoad.push_back(
+            TimeAndAmount{hours_as_seconds(9.0), kW_as_W(10.00)}
+    );
+    heatLoad.push_back(TimeAndAmount{hours_as_seconds(15.0), kW_as_W(30.00)}
+    );
+    heatLoad.push_back(TimeAndAmount{hours_as_seconds(21.0), kW_as_W(10.00)}
+    );
+
+    std::vector<TimeAndAmount> pvAvail{};
+    pvAvail.reserve(4);
+    pvAvail.push_back(TimeAndAmount{hours_as_seconds(0.0), kW_as_W(0.0)});
+    pvAvail.push_back(TimeAndAmount{hours_as_seconds(6.0), kW_as_W(100.0)});
+    pvAvail.push_back(TimeAndAmount{hours_as_seconds(12.0), kW_as_W(0.0)});
+
+    // COMPONENTS
+    auto pvArrayId = Model_AddScheduleBasedSource(m, pvAvail);
+    auto elecUtilId = Model_AddConstantSource(m, kW_as_W(10.0));
+    auto batteryId = Model_AddStore(
+            m,
+            kWh_as_J(100.0),
+            kW_as_W(10.0),
+            kW_as_W(1'000.0),
+            kWh_as_J(80.0),
+            kWh_as_J(100.0)
+    );
+    auto elecSourceMuxId = Model_AddMux(m, 2, 1);
+    auto elecSupplyMuxId = Model_AddMux(m, 2, 2);
+    auto ngUtilId =
+            Model_AddConstantSource(m, std::numeric_limits<uint32_t>::max());
+    auto ngSourceMuxId = Model_AddMux(m, 1, 2);
+    auto ngToElecConvId = Model_AddConstantEfficiencyConverter(m, 42, 100);
+    auto elecHeatPumpConvId = Model_AddConstantEfficiencyConverter(m, 35, 10);
+    auto ngHeaterConvId = Model_AddConstantEfficiencyConverter(m, 98, 100);
+    auto heatingSupplyMuxId = Model_AddMux(m, 3, 1);
+    auto elecLoadId = Model_AddScheduleBasedLoad(m, elecLoad);
+    auto heatLoadId = Model_AddScheduleBasedLoad(m, heatLoad);
+
+    // NETWORK / CONNECTIONS
+    // - electricity
+    auto pvToEmuxConn =
+            Model_AddConnection(m, pvArrayId.Id, 0, elecSourceMuxId, 0);
+    auto eutilToEmuxConn =
+            Model_AddConnection(m, elecUtilId, 0, elecSourceMuxId, 1);
+    auto emuxToBatteryConn =
+            Model_AddConnection(m, elecSourceMuxId, 0, batteryId, 0);
+    auto batteryToEsupplyConn =
+            Model_AddConnection(m, batteryId, 0, elecSupplyMuxId, 0);
+    auto ngGenToEsupplyConn =
+            Model_AddConnection(m, ngToElecConvId.Id, 0, elecSupplyMuxId, 1);
+    auto esupplyToLoadConn =
+            Model_AddConnection(m, elecSupplyMuxId, 0, elecLoadId, 0);
+    auto esupplyToHeatPumpConn =
+            Model_AddConnection(m, elecSupplyMuxId, 1, elecHeatPumpConvId.Id, 0);
+
+    // - natural gas
+    auto ngGridToNgMuxConn =
+            Model_AddConnection(m, ngUtilId, 0, ngSourceMuxId, 0);
+    auto ngMuxToNgGenConn =
+            Model_AddConnection(m, ngSourceMuxId, 0, ngToElecConvId.Id, 0);
+    auto ngMuxToNgHeaterConn =
+            Model_AddConnection(m, ngSourceMuxId, 1, ngHeaterConvId.Id, 0);
+
+    // - heating
+    auto ngGenLossToHeatMuxConn =
+            Model_AddConnection(m, ngToElecConvId.Id, 1, heatingSupplyMuxId, 0);
+    auto ngHeaterToHeatMuxConn =
+            Model_AddConnection(m, ngHeaterConvId.Id, 0, heatingSupplyMuxId, 1);
+    auto heatPumpToHeatMuxConn =
+            Model_AddConnection(m, elecHeatPumpConvId.Id, 0, heatingSupplyMuxId, 2);
+    auto heatMuxToLoadConn =
+            Model_AddConnection(m, heatingSupplyMuxId, 0, heatLoadId, 0);
+
+    // SIMULATE
+    auto results = Simulate(m, false);
+
+    auto modified_results = applyUniformTimeStep(results, 6.);
+
+    EXPECT_EQ(modified_results.size(), 5) << "incorrect number of events";
+    EXPECT_EQ(modified_results[1].Time, hours_as_seconds(6.0)) << "incorrect time of event";
+    EXPECT_EQ(modified_results[0].Flows.size(), 18) << "incorrect number of flows";
+
+    EXPECT_EQ(modified_results[2].Flows[3].Actual_W, 205) << "incorrect actual-flow value";
+    EXPECT_EQ(modified_results[2].StorageAmounts_J[0], J_per_kJ * 216000) << "incorrect storage amount";
+}

--- a/test/erin_tests.cpp
+++ b/test/erin_tests.cpp
@@ -1887,10 +1887,8 @@ TEST(Erin, TestParsingComponentsInUse)
     }
 }
 
-TEST(Erin, TestApplyUniformTimeStep)
-{
-    auto kW_as_W = [](double p_kW) -> uint32_t
-    { return static_cast<uint32_t>(std::round(p_kW * 1000.0)); };
+TEST(Erin, TestApplyUniformTimeStep) {
+    auto kW_as_W = [](double p_kW) -> uint32_t { return static_cast<uint32_t>(std::round(p_kW * 1000.0)); };
     auto hours_as_seconds = [](double h) -> double { return h * 3600.0; };
     auto kWh_as_J = [](double kWh) -> double { return kWh * 3'600'000.0; };
 

--- a/test/erin_tests.cpp
+++ b/test/erin_tests.cpp
@@ -19,6 +19,12 @@ Round(double n, unsigned int places = 2)
     return std::round(n * mult) / mult;
 }
 
+static auto kW_as_W = [](double p_kW) -> uint32_t
+{ return static_cast<uint32_t>(std::round(p_kW * 1000.0)); };
+static auto hours_as_seconds = [](double h) -> double { return h * 3600.0; };
+static auto kWh_as_J = [](double kWh) -> double { return kWh * 3'600'000.0; };
+
+
 TEST(Erin, Test1)
 {
     Model m = {};
@@ -1095,10 +1101,6 @@ TEST(Erin, Test12)
 
 TEST(Erin, Test13)
 {
-    auto kW_as_W = [](double p_kW) -> uint32_t
-    { return static_cast<uint32_t>(std::round(p_kW * 1000.0)); };
-    auto hours_as_seconds = [](double h) -> double { return h * 3600.0; };
-    auto kWh_as_J = [](double kWh) -> double { return kWh * 3'600'000.0; };
     // SIMULATION INFO and INITIALIZATION
     Model m = {};
     m.RandFn = []() { return 0.4; };
@@ -1889,11 +1891,6 @@ TEST(Erin, TestParsingComponentsInUse)
 
 TEST(Erin, TestApplyUniformTimeStep)
 {
-    auto kW_as_W = [](double p_kW) -> uint32_t
-    { return static_cast<uint32_t>(std::round(p_kW * 1000.0)); };
-    auto hours_as_seconds = [](double h) -> double { return h * 3600.0; };
-    auto kWh_as_J = [](double kWh) -> double { return kWh * 3'600'000.0; };
-
     // SIMULATION INFO and INITIALIZATION
     Model m = {};
     m.RandFn = []() { return 0.4; };
@@ -1982,8 +1979,7 @@ TEST(Erin, TestApplyUniformTimeStep)
     // SIMULATE
     auto results = Simulate(m, false);
 
-    auto modified_results = applyUniformTimeStep(results, 6.);
-
+    auto modified_results = applyUniformTimeStep(results, 6.); // 6-h steps
     EXPECT_EQ(modified_results.size(), 5) << "incorrect number of events";
     EXPECT_EQ(modified_results[1].Time, hours_as_seconds(6.0))
         << "incorrect time of event";


### PR DESCRIPTION
## Allow uniform time step

These changes allow transformation and reporting of results (events) with a user-specified, uniform time step. The time step is specified on the command line with the option `-t` or -`--time_step_h`, followed by a (positive), floating-point value for the time step (in hours) to be applied, e.g.:
``erin run ex03.toml -e ex03_mod-out.csv -t 100.0``

Power values are interpreted as instantaneous, such that the reported values are those of the most recent event. Stored energies are interpreted as cumulative, so linear interpolation is applied between the most recent event and the next event.

A test was added, containing only a series-connected PV system, battery, and load.