### PR TITLE
Fix time algorithm for reliability schedules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,5 @@ RUN mkdir /app
 
 WORKDIR /app
 
-CMD ["clang-format", "-i", "-style=file", "src/*.cpp", "include/**/*.h", "test/*.cpp", "apps/*.cpp"]
+SHELL ["/bin/sh", "-c"]
+CMD clang-format -i --style=file src/*.cpp include/**/*.h test/*.cpp apps/*.cpp

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,4 @@ RUN mkdir /app
 
 WORKDIR /app
 
-CMD clang-format -i -style=file src/*.cpp include/**/*.h test/*.cpp apps/*.cpp
+CMD ["clang-format", "-i", "-style=file", "src/*.cpp", "include/**/*.h", "test/*.cpp", "apps/*.cpp"]

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -57,6 +57,14 @@ tasks:
       # TODO[mok]: have regress.py take the build directory to run against
       - "{{.PYTHON}} regress.py"
 
+  short-test:
+    desc: Run the test suite, skipping long-running tests
+    dir: 'docs/examples'
+    cmds:
+      - "{{.PYTHON}} regress.py"
+    env:
+      ERIN_SHORT_TEST: 1
+
   init-release:
     desc: Initialize a release build
     cmds:

--- a/apps/erin.cpp
+++ b/apps/erin.cpp
@@ -117,6 +117,11 @@ add_run(CLI::App& app)
         "-n,--no-group", no_aggregate_groups, "Suppress group aggregation"
     );
 
+    static bool save_reliability_curves = false;
+    subcommand->add_flag(
+        "-r,--save-reliability", save_reliability_curves, "Save reliability curves"
+    );
+
     auto run = [&]()
     {
         bool aggregate_groups = !no_aggregate_groups;
@@ -129,6 +134,8 @@ add_run(CLI::App& app)
             {
                 std::cout << "time step (h): " << time_step_h << std::endl;
             }
+            std::cout << "save reliability curves: "
+                << (save_reliability_curves ? "true" : "false") << std::endl;
             std::cout << "verbose: " << (verbose ? "true" : "false")
                       << std::endl;
             std::cout << "groups: " << (aggregate_groups ? "true" : "false")
@@ -168,6 +175,7 @@ add_run(CLI::App& app)
             statsFilename,
             time_step_h,
             aggregate_groups,
+            save_reliability_curves,
             verbose
         );
         return EXIT_SUCCESS;

--- a/apps/erin.cpp
+++ b/apps/erin.cpp
@@ -119,7 +119,9 @@ add_run(CLI::App& app)
 
     static bool save_reliability_curves = false;
     subcommand->add_flag(
-        "-r,--save-reliability", save_reliability_curves, "Save reliability curves"
+        "-r,--save-reliability",
+        save_reliability_curves,
+        "Save reliability curves"
     );
 
     auto run = [&]()
@@ -135,7 +137,8 @@ add_run(CLI::App& app)
                 std::cout << "time step (h): " << time_step_h << std::endl;
             }
             std::cout << "save reliability curves: "
-                << (save_reliability_curves ? "true" : "false") << std::endl;
+                      << (save_reliability_curves ? "true" : "false")
+                      << std::endl;
             std::cout << "verbose: " << (verbose ? "true" : "false")
                       << std::endl;
             std::cout << "groups: " << (aggregate_groups ? "true" : "false")

--- a/docs/examples/ex37.toml
+++ b/docs/examples/ex37.toml
@@ -35,18 +35,25 @@ time_unit = "yr"
 type = "uniform"
 lower_bound = 40
 upper_bound = 80
-time_unit = "hours"
+time_unit = "h"
 [dist.repair]
 type = "fixed"
 value = 2
-time_unit = "hours"
+time_unit = "h"
+[dist.extended_repair]
+type = "uniform"
+lower_bound = 20
+upper_bound = 80
+time_unit = "h"
 [failure_mode.fm]
 failure_dist = "break"
 repair_dist = "repair"
 [fragility_mode.vulnerable_to_flooding]
 fragility_curve = "vulnerable_to_flooding_curve"
+repair_dist = "extended_repair"
 [fragility_mode.vulnerable_to_wind]
 fragility_curve = "vulnerable_to_wind_curve"
+repair_dist = "extended_repair"
 [fragility_curve.vulnerable_to_flooding_curve]
 vulnerable_to = "inundation_depth_ft"
 type = "linear"
@@ -63,4 +70,4 @@ occurrence_distribution = "every_10_years"
 duration = 336
 max_occurrences = 10
 intensity.wind_speed_mph = 120
-intensity.inundation_depth_ft = 4
+intensity.inundation_depth_ft = 6

--- a/docs/examples/ex37.toml
+++ b/docs/examples/ex37.toml
@@ -1,0 +1,66 @@
+[simulation_info]
+input_format_version = "0.2"
+rate_unit = "kW"
+quantity_unit = "kJ"
+time_unit = "years"
+max_time = 200
+[loads.building_load]
+time_unit = "h"
+rate_unit = "kW"
+time_rate_pairs = [[0.0,1.0],[336.0,0.0]]
+[components.source]
+type = "source"
+outflow = "natural-gas"
+[components.converter]
+type = "converter"
+constant_efficiency = 0.5
+inflow = "natural-gas"
+outflow = "electricity"
+fragility_modes = ["vulnerable_to_wind", "vulnerable_to_flooding"]
+failure_modes = ["fm"]
+[components.load]
+type = "load"
+inflow = "electricity"
+loads_by_scenario.class_2_hurricane = "building_load"
+[network]
+connections = [
+  ["source:OUT(0)", "converter:IN(0)", "natural-gas"],
+  ["converter:OUT(0)", "load:IN(0)", "electricity"],
+]
+[dist.every_10_years]
+type = "fixed"
+value = 10
+time_unit = "yr"
+[dist.break]
+type = "uniform"
+lower_bound = 40
+upper_bound = 80
+time_unit = "hours"
+[dist.repair]
+type = "fixed"
+value = 2
+time_unit = "hours"
+[failure_mode.fm]
+failure_dist = "break"
+repair_dist = "repair"
+[fragility_mode.vulnerable_to_flooding]
+fragility_curve = "vulnerable_to_flooding_curve"
+[fragility_mode.vulnerable_to_wind]
+fragility_curve = "vulnerable_to_wind_curve"
+[fragility_curve.vulnerable_to_flooding_curve]
+vulnerable_to = "inundation_depth_ft"
+type = "linear"
+lower_bound = 2.0
+upper_bound = 14.0
+[fragility_curve.vulnerable_to_wind_curve]
+vulnerable_to = "wind_speed_mph"
+type = "linear"
+lower_bound = 80.0
+upper_bound = 180.0
+[scenarios.class_2_hurricane]
+time_unit = "h"
+occurrence_distribution = "every_10_years"
+duration = 336
+max_occurrences = 10
+intensity.wind_speed_mph = 120
+intensity.inundation_depth_ft = 4

--- a/docs/examples/regress.py
+++ b/docs/examples/regress.py
@@ -24,20 +24,26 @@ if platform.system() == 'Windows':
         print("Could not find build directory!")
         sys.exit(1)
     BIN_DIR = BIN_DIR.resolve()
-    TEST_EXE = BIN_DIR / 'erin_tests.exe'
-    RAND_TEST_EXE = BIN_DIR / 'erin_next_random_tests.exe'
-    LOOKUP_TABLE_TEST_EXE = BIN_DIR / 'erin_lookup_table_tests.exe'
-    SWITCH_TEST_EXE = BIN_DIR / 'erin_switch_tests.exe'
+    ALL_TESTS = [
+        BIN_DIR / 'erin_tests.exe',
+        BIN_DIR / 'erin_next_random_tests.exe',
+        BIN_DIR / 'erin_lookup_table_tests.exe',
+        BIN_DIR / 'erin_switch_tests.exe',
+        BIN_DIR / 'erin_simulation_tests.exe',
+    ]
     CLI_EXE = BIN_DIR / 'erin.exe'
     PERF01_EXE = BIN_DIR / 'erin_next_stress_test.exe'
 elif platform.system() == 'Darwin' or platform.system() == 'Linux':
     DIFF_PROG = 'diff'
     BIN_DIR = (Path('.') / '..' / '..' / 'build' / 'bin').absolute()
     BIN_DIR = BIN_DIR.resolve()
-    TEST_EXE = BIN_DIR / 'erin_tests'
-    RAND_TEST_EXE = BIN_DIR / 'erin_next_random_tests'
-    LOOKUP_TABLE_TEST_EXE = BIN_DIR / 'erin_lookup_table_tests'
-    SWITCH_TEST_EXE = BIN_DIR / 'erin_switch_tests'
+    ALL_TESTS = [
+        BIN_DIR / 'erin_tests',
+        BIN_DIR / 'erin_next_random_tests',
+        BIN_DIR / 'erin_lookup_table_tests',
+        BIN_DIR / 'erin_switch_tests',
+        BIN_DIR / 'erin_simulation_tests',
+    ]
     CLI_EXE = BIN_DIR / 'erin'
     PERF01_EXE = BIN_DIR / 'erin_next_stress_test'
 else:
@@ -45,20 +51,16 @@ else:
     sys.exit(1)
 BIN_DIR = BIN_DIR.resolve()
 print(f"BINARY DIR: {BIN_DIR}")
-ALL_TESTS = [TEST_EXE, RAND_TEST_EXE, LOOKUP_TABLE_TEST_EXE, SWITCH_TEST_EXE]
 
 
-if not TEST_EXE.exists():
-    print("Cannot find test executable...")
+if len(ALL_TESTS) < 1:
+    print("No test executables defined...")
     sys.exit(1)
 
-if not RAND_TEST_EXE.exists():
-    print("Cannot find random test executable...")
-    sys.exit(1)
-
-if not LOOKUP_TABLE_TEST_EXE.exists():
-    print("Cannot find lookup-table test executable...")
-    sys.exit(1)
+for test_exe in ALL_TESTS:
+    if not test_exe.exists():
+        print(f"Cannot find {test_exe} executable...")
+        sys.exit(1)
 
 if not CLI_EXE.exists():
     print("Cannot find command-line interface executable...")

--- a/docs/examples/regress.py
+++ b/docs/examples/regress.py
@@ -98,6 +98,22 @@ def run_tests():
     print("", flush=True)
 
 
+def run_command(cmd, dir=None):
+    """
+    Run the given command in the given directory.    
+    """
+    cwd = str(Path.cwd().resolve()) if dir is None else dir
+    result = subprocess.run(cmd, capture_output=True, cwd=cwd)
+    if result.returncode != 0:
+        print(f"Error running CLI for {' '.join(cmd)}")
+        print("stdout:\n")
+        print(result.stdout.decode())
+        print("stderr:\n")
+        print(result.stderr.decode())
+        sys.exit(1)
+    return result
+
+
 def smoke_test(example_name, dir=None, timeit=False, print_it=False):
     """
     A smoke test just runs the example and confirms we get a 0 exit code
@@ -386,7 +402,19 @@ if __name__ == "__main__":
     run_cli("34")
     run_cli("35")
     run_cli("36")
+    run_command([CLI_EXE, "run", "ex37.toml", "-r"])
+    files_generated = [f for f in Path.cwd().resolve().glob("class_2_hurricane*.csv")]
+    if len(files_generated) != 10:
+        print("Error on example 37")
+        print(f"Should have created 10 csv files, got {len(files_generated)}")
+        sys.exit(1)
+    for f in files_generated:
+        f.unlink()
     print("\nPassed all regression tests!")
+
+    if os.environ.get("ERIN_SHORT_TEST") is not None:
+        print("Short exit...")
+        sys.exit(0)
 
     # Run original (unpacked) and rename/move output
     orig_name = "ft-illinois"
@@ -414,7 +442,7 @@ if __name__ == "__main__":
     run_perf()
     print("All performance tests run")
 
-    bench_dir = (Path(".")/".."/".."/"benchmark").resolve()
+    bench_dir = (Path(".") / ".." / ".." / "benchmark").resolve()
     if not bench_dir.exists():
         bench_dir.mkdir(parents=True, exist_ok=True)
     benchfile = (bench_dir / "benchmark.txt").resolve()

--- a/include/erin_next/erin_next_reliability.h
+++ b/include/erin_next/erin_next_reliability.h
@@ -55,7 +55,7 @@ namespace erin
             const std::function<double()>& rand_fn,
             const DistributionSystem& cds,
             double final_time
-        );
+        ) const;
 
       private:
         FailureMode fms;

--- a/include/erin_next/erin_next_scenario.h
+++ b/include/erin_next/erin_next_scenario.h
@@ -21,7 +21,7 @@ namespace erin
         // TODO: remove TimeUnits and pre-convert to make Durations in seconds
         std::vector<TimeUnit> TimeUnits;
         std::vector<double> Durations;
-        std::vector<double> TimeOffsetsInHours;
+        std::vector<double> TimeOffsetsInSeconds;
         // NOTE: an entry of none means "no max occurrences"; will take as
         // many as fit in the max time of the simulation (see SimulationInfo)
         std::vector<std::optional<size_t>> MaxOccurrences;
@@ -40,7 +40,8 @@ namespace erin
         size_t occurrenceDistId,
         double duration,
         TimeUnit timeUnit,
-        std::optional<size_t> maxOccurrences
+        std::optional<size_t> maxOccurrences,
+        double timeOffset
     );
 
     std::optional<size_t>

--- a/include/erin_next/erin_next_scenario.h
+++ b/include/erin_next/erin_next_scenario.h
@@ -21,6 +21,7 @@ namespace erin
         // TODO: remove TimeUnits and pre-convert to make Durations in seconds
         std::vector<TimeUnit> TimeUnits;
         std::vector<double> Durations;
+        std::vector<double> TimeOffsetsInHours;
         // NOTE: an entry of none means "no max occurrences"; will take as
         // many as fit in the max time of the simulation (see SimulationInfo)
         std::vector<std::optional<size_t>> MaxOccurrences;

--- a/include/erin_next/erin_next_simulation.h
+++ b/include/erin_next/erin_next_simulation.h
@@ -217,7 +217,20 @@ namespace erin
 
     std::vector<ScheduleBasedReliability>
     ApplyReliabilitiesAndFragilities(
-        Simulation& s,
+        std::function<double ()>& randFn,
+        std::vector<size_t> const& componentFailureModeComponentIds,
+        std::vector<double> const& componentInitialAges_s,
+        std::vector<std::string> const& componentTags,
+        std::vector<size_t> const& componentFragilityComponentIds,
+        std::vector<size_t> const& componentFragilityFragilityModeIds,
+        std::vector<size_t> const& fragilityModeFragilityCurveIds,
+        std::vector<std::optional<size_t>> const& fragilityModeRepairDistIds,
+        std::vector<std::string> const& fragilityModeTags,
+        std::vector<size_t> const& fragilityCurveCurveIds,
+        std::vector<FragilityCurveType> const& fragilityCurveCurveTypes,
+        std::vector<LinearFragilityCurve> linearFragilityCurves,
+        std::vector<TabularFragilityCurve> tabularFragilityCurves,
+        DistributionSystem const& ds,
         double startTime_s,
         double endTime_s,
         std::unordered_map<size_t, double> const& intensityIdToAmount,

--- a/include/erin_next/erin_next_simulation.h
+++ b/include/erin_next/erin_next_simulation.h
@@ -207,7 +207,8 @@ namespace erin
         double startTime_s,
         double endTime_s,
         std::unordered_map<size_t, double> const& intensityIdToAmount,
-        std::unordered_map<size_t, std::vector<TimeState>> const& relSchByCompId,
+        std::unordered_map<size_t, std::vector<TimeState>> const&
+            relSchByCompId,
         bool verbose
     );
 

--- a/include/erin_next/erin_next_simulation.h
+++ b/include/erin_next/erin_next_simulation.h
@@ -4,6 +4,7 @@
 #define ERIN_SIMULATION_H
 
 #include "erin_next/erin_next.h"
+#include "erin_next/erin_next_distribution.h"
 #include "erin_next/erin_next_simulation_info.h"
 #include "erin_next/erin_next_load.h"
 #include "erin_next/erin_next_scenario.h"
@@ -15,6 +16,7 @@
 #include <optional>
 #include <cstdlib>
 #include <unordered_set>
+#include <unordered_map>
 
 namespace erin
 {
@@ -200,6 +202,18 @@ namespace erin
 
     std::vector<ScheduleBasedReliability>
     CopyReliabilities(Simulation const& s);
+
+    std::unordered_map<size_t, std::vector<TimeState>>
+    CreateFailureSchedules(
+        std::vector<size_t> const& componentFailureModeComponentIds,
+        std::vector<size_t> const& componentFailureModeFailureModeIds,
+        std::vector<double> const& componentInitialAges_s,
+        ReliabilityCoordinator const& rc,
+        std::function<double()> const& randFn,
+        DistributionSystem const& ds,
+        double scenarioDuration_s,
+        double scenarioOffset_s
+    );
 
     std::vector<ScheduleBasedReliability>
     ApplyReliabilitiesAndFragilities(

--- a/include/erin_next/erin_next_simulation.h
+++ b/include/erin_next/erin_next_simulation.h
@@ -195,7 +195,7 @@ namespace erin
         bool isVerbose
     );
 
-    std::map<size_t, double>
+    std::unordered_map<size_t, double>
     GetIntensitiesForScenario(Simulation& s, size_t scenIdx);
 
     std::vector<ScheduleBasedReliability>
@@ -206,8 +206,8 @@ namespace erin
         Simulation& s,
         double startTime_s,
         double endTime_s,
-        std::map<size_t, double> const& intensityIdToAmount,
-        std::map<size_t, std::vector<TimeState>> const& relSchByCompId,
+        std::unordered_map<size_t, double> const& intensityIdToAmount,
+        std::unordered_map<size_t, std::vector<TimeState>> const& relSchByCompId,
         bool verbose
     );
 

--- a/include/erin_next/erin_next_simulation.h
+++ b/include/erin_next/erin_next_simulation.h
@@ -217,7 +217,7 @@ namespace erin
 
     std::vector<ScheduleBasedReliability>
     ApplyReliabilitiesAndFragilities(
-        std::function<double ()>& randFn,
+        std::function<double()>& randFn,
         std::vector<size_t> const& componentFailureModeComponentIds,
         std::vector<double> const& componentInitialAges_s,
         std::vector<std::string> const& componentTags,

--- a/include/erin_next/erin_next_simulation.h
+++ b/include/erin_next/erin_next_simulation.h
@@ -224,11 +224,12 @@ namespace erin
     void
     Simulation_Run(
         Simulation& s,
-        const std::string& eventsFilename,
-        const std::string& statsFilename = "stats.csv",
+        std::string const& eventsFilename,
+        std::string const& statsFilename = "stats.csv",
         double time_step_h = -1.0,
         bool aggregateGroups = true,
-        const bool verbose = false
+        bool saveReliabilityCurves = false,
+        bool verbose = false
     );
 
     bool

--- a/include/erin_next/erin_next_timestate.h
+++ b/include/erin_next/erin_next_timestate.h
@@ -69,6 +69,9 @@ namespace erin
         std::map<size_t, double>& timeByFragilityModeId_s
     );
 
+    void
+    TimeState_Print(std::vector<TimeState> const& tss);
+
 } // namespace erin
 
 #endif

--- a/src/erin_next_reliability.cpp
+++ b/src/erin_next_reliability.cpp
@@ -87,7 +87,7 @@ namespace erin
         const std::function<double()>& rand_fn,
         const DistributionSystem& cds,
         double final_time
-    )
+    ) const
     {
         double time = 0.0;
         double dt = -1.0;

--- a/src/erin_next_scenario.cpp
+++ b/src/erin_next_scenario.cpp
@@ -73,7 +73,8 @@ namespace erin
                 sd.Durations[i] = duration;
                 sd.TimeUnits[i] = timeUnit;
                 sd.MaxOccurrences[i] = maxOccurrences;
-                sd.TimeOffsetsInSeconds[i] = Time_ToSeconds(timeOffset, timeUnit);
+                sd.TimeOffsetsInSeconds[i] =
+                    Time_ToSeconds(timeOffset, timeUnit);
                 assert(sd.Durations.size() == sd.MaxOccurrences.size());
                 assert(
                     sd.Durations.size() == sd.OccurrenceDistributionIds.size()
@@ -167,7 +168,8 @@ namespace erin
         {
             if (table.at("time_offset").is_integer())
             {
-                timeOffset = static_cast<double>(table.at("time_offset").as_integer());
+                timeOffset =
+                    static_cast<double>(table.at("time_offset").as_integer());
             }
             else if (table.at("time_offset").is_floating())
             {

--- a/src/erin_next_simulation.cpp
+++ b/src/erin_next_simulation.cpp
@@ -2818,13 +2818,14 @@ namespace erin
         Simulation const& s
     )
     {
-        std::string fname = fmt::format("{}-{:03}.csv", scenarioName, scenarioOccurrence);
+        std::string fname =
+            fmt::format("{}-{:03}.csv", scenarioName, scenarioOccurrence);
         std::ofstream out;
         out.open(fname);
         if (!out.good())
         {
-            std::cout << "Could not open '" << fname
-                      << "' for writing." << std::endl;
+            std::cout << "Could not open '" << fname << "' for writing."
+                      << std::endl;
             return;
         }
         size_t maxRow = 0;
@@ -2840,21 +2841,24 @@ namespace erin
         {
             if (row == 0)
             {
-                for (size_t i=0; i < s.TheModel.Reliabilities.size(); ++i)
+                for (size_t i = 0; i < s.TheModel.Reliabilities.size(); ++i)
                 {
-                    ScheduleBasedReliability const& sbr = s.TheModel.Reliabilities[i];
+                    ScheduleBasedReliability const& sbr =
+                        s.TheModel.Reliabilities[i];
                     if (i > 0)
                     {
                         out << ",";
                     }
-                    std::string const& compTag = s.TheModel.ComponentMap.Tag[sbr.ComponentId];
+                    std::string const& compTag =
+                        s.TheModel.ComponentMap.Tag[sbr.ComponentId];
                     out << "time (s)," << compTag << " state,causes";
                 }
                 out << "\n";
             }
-            for (size_t i=0; i < s.TheModel.Reliabilities.size(); ++i)
+            for (size_t i = 0; i < s.TheModel.Reliabilities.size(); ++i)
             {
-                ScheduleBasedReliability const& sbr = s.TheModel.Reliabilities[i];
+                ScheduleBasedReliability const& sbr =
+                    s.TheModel.Reliabilities[i];
                 if (i > 0)
                 {
                     out << ",";
@@ -2871,15 +2875,16 @@ namespace erin
                 std::string causeStr = "";
                 for (std::string const& cause : causes)
                 {
-                    causeStr += (causeStr.size() == 0) ? cause : fmt::format(" | {}", cause);
+                    causeStr += (causeStr.size() == 0)
+                        ? cause
+                        : fmt::format(" | {}", cause);
                 }
                 if (row < sbr.TimeStates.size())
                 {
-                    out << TimeInSecondsToDesiredUnit(sbr.TimeStates[row].time, TimeUnit::Hour)
-                        << ","
-                        << sbr.TimeStates[row].state
-                        << ","
-                        << causeStr;
+                    out << TimeInSecondsToDesiredUnit(
+                        sbr.TimeStates[row].time, TimeUnit::Hour
+                    ) << ","
+                        << sbr.TimeStates[row].state << "," << causeStr;
                 }
                 else
                 {
@@ -3062,8 +3067,8 @@ namespace erin
             if (verbose)
             {
                 std::cout << "Calculated " << occurrenceTimes_s.size()
-                    << " occurrence times for "
-                    << s.ScenarioMap.Tags[scenIdx] << std::endl;
+                          << " occurrence times for "
+                          << s.ScenarioMap.Tags[scenIdx] << std::endl;
             }
             // TODO: initialize total scenario stats (i.e.,
             // over all occurrences)
@@ -3095,10 +3100,12 @@ namespace erin
                 {
                     if (verbose)
                     {
-                        std::cout << "Writing reliability curves..." << std::endl;
+                        std::cout << "Writing reliability curves..."
+                                  << std::endl;
                     }
                     WriteReliabilityCurves(
-                        s.ScenarioMap.Tags[scenIdx], occIdx, s);
+                        s.ScenarioMap.Tags[scenIdx], occIdx, s
+                    );
                     if (verbose)
                     {
                         std::cout << "Reliability curves written" << std::endl;

--- a/src/erin_next_simulation.cpp
+++ b/src/erin_next_simulation.cpp
@@ -2143,7 +2143,8 @@ namespace erin
         double startTime_s,
         double endTime_s,
         std::unordered_map<size_t, double> const& intensityIdToAmount,
-        std::unordered_map<size_t, std::vector<TimeState>> const& relSchByCompId,
+        std::unordered_map<size_t, std::vector<TimeState>> const&
+            relSchByCompId,
         bool verbose
     )
     {
@@ -2173,10 +2174,7 @@ namespace erin
                           << (initialAge_s / seconds_per_hour) << std::endl;
             }
             std::vector<TimeState> clip = TimeState_Clip(
-                sch,
-                startTime_s + initialAge_s,
-                endTime_s + initialAge_s,
-                true
+                sch, startTime_s + initialAge_s, endTime_s + initialAge_s, true
             );
             // NOTE: Reliabilities have not yet been assigned so we can
             // just push_back()
@@ -2739,7 +2737,6 @@ namespace erin
         return modified_results;
     }
 
-
     std::unordered_map<size_t, std::vector<TimeState>>
     CreateFailureSchedules(
         Simulation& s,
@@ -2750,7 +2747,9 @@ namespace erin
         std::unordered_map<size_t, std::vector<TimeState>> relSchByCompFailId;
         relSchByCompFailId.reserve(s.ComponentFailureModes.ComponentIds.size());
         std::unordered_set<size_t> componentsWithFailures;
-        componentsWithFailures.reserve(s.ComponentFailureModes.ComponentIds.size());
+        componentsWithFailures.reserve(
+            s.ComponentFailureModes.ComponentIds.size()
+        );
         for (size_t compFailId = 0;
              compFailId < s.ComponentFailureModes.ComponentIds.size();
              ++compFailId)
@@ -2947,8 +2946,10 @@ namespace erin
         {
             double scenarioDuration_s = Time_ToSeconds(
                 s.ScenarioMap.Durations[scenIdx],
-                s.ScenarioMap.TimeUnits[scenIdx]);
-            double scenarioOffset_s = s.ScenarioMap.TimeOffsetsInSeconds[scenIdx];
+                s.ScenarioMap.TimeUnits[scenIdx]
+            );
+            double scenarioOffset_s =
+                s.ScenarioMap.TimeOffsetsInSeconds[scenIdx];
             std::string const& scenarioTag = s.ScenarioMap.Tags[scenIdx];
             if (verbose)
             {
@@ -2983,8 +2984,10 @@ namespace erin
                 GetIntensitiesForScenario(s, scenIdx);
             for (size_t occIdx = 0; occIdx < occurrenceTimes_s.size(); ++occIdx)
             {
-                std::unordered_map<size_t, std::vector<TimeState>> relSchByCompId =
-                    CreateFailureSchedules(s, scenarioDuration_s, scenarioOffset_s);
+                std::unordered_map<size_t, std::vector<TimeState>>
+                    relSchByCompId = CreateFailureSchedules(
+                        s, scenarioDuration_s, scenarioOffset_s
+                    );
                 double t = occurrenceTimes_s[occIdx];
                 double tEnd = t + scenarioDuration_s;
                 if (verbose)

--- a/src/erin_next_simulation.cpp
+++ b/src/erin_next_simulation.cpp
@@ -2871,7 +2871,7 @@ namespace erin
                 std::string causeStr = "";
                 for (std::string const& cause : causes)
                 {
-                    causeStr = (causeStr.size() == 0) ? cause : fmt::format("| {}", cause);
+                    causeStr += (causeStr.size() == 0) ? cause : fmt::format(" | {}", cause);
                 }
                 if (row < sbr.TimeStates.size())
                 {

--- a/src/erin_next_simulation.cpp
+++ b/src/erin_next_simulation.cpp
@@ -2851,7 +2851,7 @@ namespace erin
                     }
                     std::string const& compTag =
                         s.TheModel.ComponentMap.Tag[sbr.ComponentId];
-                    out << "time (s)," << compTag << " state,causes";
+                    out << "time (h)," << compTag << " state,causes";
                 }
                 out << "\n";
             }

--- a/src/erin_next_simulation.cpp
+++ b/src/erin_next_simulation.cpp
@@ -2813,6 +2813,10 @@ namespace erin
             double duration_s = Time_ToSeconds(
                 s.ScenarioMap.Durations[scenId], s.ScenarioMap.TimeUnits[scenId]
             );
+            double offset_s = Time_ToSeconds(
+                s.ScenarioMap.TimeOffsetsInHours[scenId], TimeUnit::Hours
+            );
+            duration_s += offset_s;
             if (duration_s > maxDuration_s)
             {
                 maxDuration_s = duration_s;
@@ -2840,6 +2844,24 @@ namespace erin
                 s.ComponentFailureModes.ComponentIds[compFailId],
                 s.ComponentFailureModes.FailureModeIds[compFailId]
             );
+            // NOTE: Fix. ERIN is like the movie Groundhog's Day --
+            // each "year" is repeated over and over again until the
+            // max time limit is reached. As such, if we have
+            // 1,000 years of simulation, we need to generate 1,000
+            // unique 1-year reliability schedules. The exact duration
+            // will be (scenarioStartMonth + scenarioStartDay
+            // + scenarioDuration) - Jan 1 at 00:00:00. We could also
+            // just build out the longest duration needed by any
+            // scenario and just use that for all of them and clip
+            // to the correct time...
+            // BUT s.Info.MaxTime should just set the number of
+            // "Groundhog Days"...
+            // Question: does scenario need start month/day? Could just be
+            // of length duration... is it needed to match up with initial
+            // age? Yes. So what we need for each scenario is a time
+            // offset. So the reliability schedule duration will be
+            // (scenarioOffset + scenarioDuration). Offset will be from
+            // the time the age is assessed.
             double maxTime_s =
                 Time_ToSeconds(s.Info.MaxTime, s.Info.TheTimeUnit)
                 + maxDuration_s;

--- a/src/erin_next_simulation.cpp
+++ b/src/erin_next_simulation.cpp
@@ -2140,12 +2140,12 @@ namespace erin
     void
     PrintReliabilities(std::vector<ScheduleBasedReliability> const& sbrs)
     {
-        std::cout << "ScheduleBasedReliability vector size: " << sbrs.size() << std::endl;
+        std::cout << "ScheduleBasedReliability vector size: " << sbrs.size()
+                  << std::endl;
         for (ScheduleBasedReliability const& sbr : sbrs)
         {
-            std::cout
-                << "- {ComponentId: " << sbr.ComponentId
-                << ",TimeStates=[";
+            std::cout << "- {ComponentId: " << sbr.ComponentId
+                      << ",TimeStates=[";
             bool isFirst = true;
             for (TimeState const& ts : sbr.TimeStates)
             {
@@ -2159,13 +2159,13 @@ namespace erin
                 }
                 std::cout << "{" << ts.time << "," << ts.state << "}";
             }
-            std::cout << "]}" << std::endl; 
+            std::cout << "]}" << std::endl;
         }
     }
 
     std::vector<ScheduleBasedReliability>
     ApplyReliabilitiesAndFragilities(
-        std::function<double ()>& randFn,
+        std::function<double()>& randFn,
         std::vector<size_t> const& componentFailureModeComponentIds,
         std::vector<double> const& componentInitialAges_s,
         std::vector<std::string> const& componentTags,
@@ -2209,8 +2209,8 @@ namespace erin
             double initialAge_s = componentInitialAges_s[compId];
             if (verbose)
             {
-                std::cout << "component: "
-                          << componentTags[compId] << std::endl;
+                std::cout << "component: " << componentTags[compId]
+                          << std::endl;
                 std::cout << "initial age (h): "
                           << (initialAge_s / seconds_per_hour) << std::endl;
             }
@@ -2241,8 +2241,7 @@ namespace erin
                 size_t fcId = fragilityModeFragilityCurveIds[fmId];
                 std::optional<size_t> repairId =
                     fragilityModeRepairDistIds[fmId];
-                FragilityCurveType curveType =
-                    fragilityCurveCurveTypes[fcId];
+                FragilityCurveType curveType = fragilityCurveCurveTypes[fcId];
                 size_t fcIdx = fragilityCurveCurveIds[fcId];
                 bool isFailed = false;
                 double failureFrac = 0.0;
@@ -2250,8 +2249,7 @@ namespace erin
                 {
                     case (FragilityCurveType::Linear):
                     {
-                        LinearFragilityCurve lfc =
-                            linearFragilityCurves[fcIdx];
+                        LinearFragilityCurve lfc = linearFragilityCurves[fcIdx];
                         size_t vulnerId = lfc.VulnerabilityId;
                         if (intensityIdToAmount.contains(vulnerId))
                         {
@@ -2309,18 +2307,14 @@ namespace erin
                     size_t compId = componentFragilityComponentIds[cfmIdx];
                     if (verbose)
                     {
-                        std::cout << "... FAILED: "
-                                  << componentTags[compId]
-                                  << " (cause: "
-                                  << fragilityModeTags[fmId]
+                        std::cout << "... FAILED: " << componentTags[compId]
+                                  << " (cause: " << fragilityModeTags[fmId]
                                   << ")" << std::endl;
                     }
                     // does the component have a reliability signal?
                     bool hasReliabilityAlready = false;
                     size_t reliabilityId = 0;
-                    for (size_t rIdx = 0;
-                         rIdx < result.size();
-                         ++rIdx)
+                    for (size_t rIdx = 0; rIdx < result.size(); ++rIdx)
                     {
                         if (result[rIdx].ComponentId == compId)
                         {
@@ -2341,7 +2335,8 @@ namespace erin
                         double randValue = randFn();
                         if (verbose)
                         {
-                            std::cout << "randValue for next time advance is: " << randValue << "\n";
+                            std::cout << "randValue for next time advance is: "
+                                      << randValue << "\n";
                         }
                         double repairTime_s =
                             ds.next_time_advance(repId, randValue);
@@ -2352,7 +2347,8 @@ namespace erin
                     }
                     if (hasReliabilityAlready)
                     {
-                        auto const& currentSch = result[reliabilityId].TimeStates;
+                        auto const& currentSch =
+                            result[reliabilityId].TimeStates;
                         std::vector<TimeState> combined =
                             TimeState_Combine(currentSch, newTimeStates);
                         result[reliabilityId].TimeStates = std::move(combined);
@@ -3137,31 +3133,31 @@ namespace erin
                               << SecondsToPrettyString(t) << std::endl;
                 }
                 s.TheModel.Reliabilities.clear();
-                s.TheModel.Reliabilities =
-                    ApplyReliabilitiesAndFragilities(
-                        s.TheModel.RandFn,
-                        s.ComponentFailureModes.ComponentIds,
-                        s.TheModel.ComponentMap.InitialAges_s,
-                        s.TheModel.ComponentMap.Tag,
-                        s.ComponentFragilities.ComponentIds,
-                        s.ComponentFragilities.FragilityModeIds,
-                        s.FragilityModes.FragilityCurveId,
-                        s.FragilityModes.RepairDistIds,
-                        s.FragilityModes.Tags,
-                        s.FragilityCurves.CurveId,
-                        s.FragilityCurves.CurveTypes,
-                        s.LinearFragilityCurves,
-                        s.TabularFragilityCurves,
-                        s.TheModel.DistSys,
-                        scenarioOffset_s,
-                        scenarioOffset_s + scenarioDuration_s,
-                        intensityIdToAmount,
-                        relSchByCompId,
-                        verbose
-                    );
+                s.TheModel.Reliabilities = ApplyReliabilitiesAndFragilities(
+                    s.TheModel.RandFn,
+                    s.ComponentFailureModes.ComponentIds,
+                    s.TheModel.ComponentMap.InitialAges_s,
+                    s.TheModel.ComponentMap.Tag,
+                    s.ComponentFragilities.ComponentIds,
+                    s.ComponentFragilities.FragilityModeIds,
+                    s.FragilityModes.FragilityCurveId,
+                    s.FragilityModes.RepairDistIds,
+                    s.FragilityModes.Tags,
+                    s.FragilityCurves.CurveId,
+                    s.FragilityCurves.CurveTypes,
+                    s.LinearFragilityCurves,
+                    s.TabularFragilityCurves,
+                    s.TheModel.DistSys,
+                    scenarioOffset_s,
+                    scenarioOffset_s + scenarioDuration_s,
+                    intensityIdToAmount,
+                    relSchByCompId,
+                    verbose
+                );
                 if (verbose)
                 {
-                    std::cout << "Reliabilities for Scenario: " << scenarioTag << std::endl;
+                    std::cout << "Reliabilities for Scenario: " << scenarioTag
+                              << std::endl;
                     std::cout << "Occurrence #" << (occIdx + 1) << std::endl;
                     PrintReliabilities(s.TheModel.Reliabilities);
                 }

--- a/src/erin_next_timestate.cpp
+++ b/src/erin_next_timestate.cpp
@@ -162,10 +162,10 @@ namespace erin
                 }
             }
             result.push_back({
-                .time=time,
-                .state=state,
-                .failureModeCauses=std::move(failureModes),
-                .fragilityModeCauses=std::move(fragilityModes),
+                .time = time,
+                .state = state,
+                .failureModeCauses = std::move(failureModes),
+                .fragilityModeCauses = std::move(fragilityModes),
             });
             // increment to the lowest time (ta or tb) ahead of t
             bool aCanInc = (aIdx + 1) < a.size();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -58,6 +58,22 @@ target_link_libraries(erin_switch_tests
 	GTest::gtest_main
 )
 
+# ERIN Simulation Tests
+add_executable(erin_simulation_tests
+	erin_simulation_tests.cpp
+)
+
+target_include_directories(erin_simulation_tests
+	PUBLIC
+	${PROJECT_SOURCE_DIR}/include
+	${PROJECT_SOURCE_DIR}/src
+)
+
+target_link_libraries(erin_simulation_tests
+	erin_next
+	GTest::gtest_main
+)
+
 # Google Test
 include(GoogleTest)
 

--- a/test/erin_simulation_tests.cpp
+++ b/test/erin_simulation_tests.cpp
@@ -1,0 +1,11 @@
+/* Copyright (c) 2024 Big Ladder Software LLC. All rights reserved.
+ * See the LICENSE.txt file for additional terms and conditions. */
+#include "erin_next/erin_next_simulation.h"
+#include <gtest/gtest.h>
+
+using namespace erin;
+
+TEST(ErinSim, TestReliabilityAndFragilityCurveGeneration)
+{
+  EXPECT_EQ(1, 1);
+}

--- a/test/erin_simulation_tests.cpp
+++ b/test/erin_simulation_tests.cpp
@@ -431,7 +431,69 @@ TEST(ErinSim, TestFragility_Reliability_NoRepair_NoOffset_NoAge)
         }
     }
 }
-// TODO:
-// - add reliability
-// - add reliability with offset
-// - add reliability with offset and age
+
+TEST(ErinSim, TestFragility_Reliability_Repair_Offset_Age)
+{
+    double scenarioOffset_s = 250.0;
+    double scenarioDuration_s = 1'000.0;
+    double initialAge_s = 250.0;
+    bool doRepair = false;
+    std::unordered_map<size_t, std::vector<TimeState>> relSchByCompId{};
+    std::vector<TimeState> relSch{};
+    relSch.push_back({
+        .time=510.0,
+        .state=false,
+        .failureModeCauses={0},
+        .fragilityModeCauses={},
+    });
+    relSch.push_back({
+        .time=520.0,
+        .state=true,
+        .failureModeCauses={},
+        .fragilityModeCauses={},
+    });
+    relSchByCompId[0] = std::move(relSch);
+    std::vector<ScheduleBasedReliability> actual =
+        RunApplyReliabilitiesAndFragilities(
+            scenarioOffset_s, scenarioDuration_s, doRepair, initialAge_s,
+            relSchByCompId
+        );
+    EXPECT_EQ(actual.size(), 1);
+    for (ScheduleBasedReliability const& sbr : actual)
+    {
+        EXPECT_EQ(sbr.ComponentId, 0);
+        EXPECT_EQ(sbr.TimeStates.size(), 3);
+        // 1st
+        EXPECT_EQ(sbr.TimeStates[0].time, 0.0);
+        EXPECT_EQ(sbr.TimeStates[0].state, false);
+        EXPECT_EQ(sbr.TimeStates[0].failureModeCauses.size(), 0);
+        EXPECT_EQ(sbr.TimeStates[0].fragilityModeCauses.size(), 1);
+        for (size_t fmId : sbr.TimeStates[0].fragilityModeCauses)
+        {
+            EXPECT_EQ(fmId, 0);
+        }
+        // 2nd
+        EXPECT_EQ(sbr.TimeStates[1].time, 10.0);
+        EXPECT_EQ(sbr.TimeStates[1].state, false);
+        EXPECT_EQ(sbr.TimeStates[1].failureModeCauses.size(), 1);
+        for (size_t fmId : sbr.TimeStates[1].failureModeCauses)
+        {
+            EXPECT_EQ(fmId, 0);
+        }
+        EXPECT_EQ(sbr.TimeStates[1].fragilityModeCauses.size(), 1);
+        for (size_t fmId : sbr.TimeStates[1].fragilityModeCauses)
+        {
+            EXPECT_EQ(fmId, 0);
+        }
+        // 3rd
+        EXPECT_EQ(sbr.TimeStates[2].time, 20.0);
+        EXPECT_EQ(sbr.TimeStates[2].state, false);
+        EXPECT_EQ(sbr.TimeStates[2].failureModeCauses.size(), 0);
+        EXPECT_EQ(sbr.TimeStates[2].fragilityModeCauses.size(), 1);
+        for (size_t fmId : sbr.TimeStates[2].fragilityModeCauses)
+        {
+            EXPECT_EQ(fmId, 0);
+        }
+    }
+}
+

--- a/test/erin_simulation_tests.cpp
+++ b/test/erin_simulation_tests.cpp
@@ -3,6 +3,7 @@
 #include "erin_next/erin_next_distribution.h"
 #include "erin_next/erin_next_reliability.h"
 #include "erin_next/erin_next_simulation.h"
+#include "erin_next/erin_next_timestate.h"
 #include <gtest/gtest.h>
 
 using namespace erin;
@@ -37,4 +38,13 @@ TEST(ErinSim, TestCreateFailureSchedules)
             scenarioOffset_s
         );
     EXPECT_EQ(actual.size(), 1);
+    for (auto const& it : actual)
+    {
+        std::vector<TimeState> const& tss = it.second;
+        EXPECT_EQ(tss.size(), 24);
+        EXPECT_EQ(tss[0].time, 10.0) << tss[0];
+        EXPECT_EQ(tss[0].state, false) << tss[0];
+        EXPECT_EQ(tss[23].time, 144.0) << tss[23];
+        EXPECT_EQ(tss[23].state, true) << tss[23];
+    }
 }

--- a/test/erin_simulation_tests.cpp
+++ b/test/erin_simulation_tests.cpp
@@ -48,3 +48,44 @@ TEST(ErinSim, TestCreateFailureSchedules)
         EXPECT_EQ(tss[23].state, true) << tss[23];
     }
 }
+
+TEST(ErinSim, TestCreateFailureSchedulesWithOffset)
+{
+    size_t compId = 0;
+    double initialAge_s = 0.0;
+    DistributionSystem ds{};
+    ReliabilityCoordinator rc{};
+    size_t breakDistId = ds.add_fixed("break", 10.0);
+    size_t fixDistId = ds.add_fixed("fix", 2.0);
+    size_t fmId = rc.add_failure_mode("fm", breakDistId, fixDistId);
+    size_t compFmId = rc.link_component_with_failure_mode(compId, fmId);
+    std::vector<size_t> componentFailureModeComponentIds{};
+    componentFailureModeComponentIds.push_back(compId);
+    std::vector<size_t> componentFailureModeFailureModeIds{};
+    componentFailureModeFailureModeIds.push_back(fmId);
+    std::vector<double> componentInitialAges_s{};
+    componentInitialAges_s.push_back(initialAge_s);
+    double scenarioDuration_s = 144.0;
+    double scenarioOffset_s = 24.0;
+    std::unordered_map<size_t, std::vector<TimeState>> actual =
+        erin::CreateFailureSchedules(
+            componentFailureModeComponentIds,
+            componentFailureModeFailureModeIds,
+            componentInitialAges_s,
+            rc,
+            []() { return 0.5; },
+            ds,
+            scenarioDuration_s,
+            scenarioOffset_s
+        );
+    EXPECT_EQ(actual.size(), 1);
+    for (auto const& it : actual)
+    {
+        std::vector<TimeState> const& tss = it.second;
+        EXPECT_EQ(tss.size(), 28);
+        EXPECT_EQ(tss[0].time, 10.0) << tss[0];
+        EXPECT_EQ(tss[0].state, false) << tss[0];
+        EXPECT_EQ(tss[27].time, 168.0) << tss[27];
+        EXPECT_EQ(tss[27].state, true) << tss[27];
+    }
+}

--- a/test/erin_simulation_tests.cpp
+++ b/test/erin_simulation_tests.cpp
@@ -69,3 +69,19 @@ TEST(ErinSim, TestCreateFailureSchedulesWithOffset)
         EXPECT_EQ(tss[27].state, true) << tss[27];
     }
 }
+
+TEST(ErinSim, TestCreateFailureSchedulesWithInitialAge)
+{
+    std::unordered_map<size_t, std::vector<TimeState>> actual =
+        RunCreateFailureSchedules(24.0, 0.0);
+    EXPECT_EQ(actual.size(), 1);
+    for (auto const& it : actual)
+    {
+        std::vector<TimeState> const& tss = it.second;
+        EXPECT_EQ(tss.size(), 28);
+        EXPECT_EQ(tss[0].time, 10.0) << tss[0];
+        EXPECT_EQ(tss[0].state, false) << tss[0];
+        EXPECT_EQ(tss[27].time, 168.0) << tss[27];
+        EXPECT_EQ(tss[27].state, true) << tss[27];
+    }
+}

--- a/test/erin_simulation_tests.cpp
+++ b/test/erin_simulation_tests.cpp
@@ -5,13 +5,14 @@
 #include "erin_next/erin_next_simulation.h"
 #include "erin_next/erin_next_timestate.h"
 #include <gtest/gtest.h>
+#include <unordered_map>
 
 using namespace erin;
 
-TEST(ErinSim, TestCreateFailureSchedules)
+std::unordered_map<size_t, std::vector<TimeState>>
+RunCreateFailureSchedules(double initialAge_s, double scenarioOffset_s)
 {
     size_t compId = 0;
-    double initialAge_s = 0.0;
     DistributionSystem ds{};
     ReliabilityCoordinator rc{};
     size_t breakDistId = ds.add_fixed("break", 10.0);
@@ -25,9 +26,7 @@ TEST(ErinSim, TestCreateFailureSchedules)
     std::vector<double> componentInitialAges_s{};
     componentInitialAges_s.push_back(initialAge_s);
     double scenarioDuration_s = 144.0;
-    double scenarioOffset_s = 0.0;
-    std::unordered_map<size_t, std::vector<TimeState>> actual =
-        erin::CreateFailureSchedules(
+    return erin::CreateFailureSchedules(
             componentFailureModeComponentIds,
             componentFailureModeFailureModeIds,
             componentInitialAges_s,
@@ -37,6 +36,12 @@ TEST(ErinSim, TestCreateFailureSchedules)
             scenarioDuration_s,
             scenarioOffset_s
         );
+}
+
+TEST(ErinSim, TestCreateFailureSchedules)
+{
+    std::unordered_map<size_t, std::vector<TimeState>> actual =
+        RunCreateFailureSchedules(0.0, 0.0);
     EXPECT_EQ(actual.size(), 1);
     for (auto const& it : actual)
     {
@@ -51,33 +56,8 @@ TEST(ErinSim, TestCreateFailureSchedules)
 
 TEST(ErinSim, TestCreateFailureSchedulesWithOffset)
 {
-    size_t compId = 0;
-    double initialAge_s = 0.0;
-    DistributionSystem ds{};
-    ReliabilityCoordinator rc{};
-    size_t breakDistId = ds.add_fixed("break", 10.0);
-    size_t fixDistId = ds.add_fixed("fix", 2.0);
-    size_t fmId = rc.add_failure_mode("fm", breakDistId, fixDistId);
-    size_t compFmId = rc.link_component_with_failure_mode(compId, fmId);
-    std::vector<size_t> componentFailureModeComponentIds{};
-    componentFailureModeComponentIds.push_back(compId);
-    std::vector<size_t> componentFailureModeFailureModeIds{};
-    componentFailureModeFailureModeIds.push_back(fmId);
-    std::vector<double> componentInitialAges_s{};
-    componentInitialAges_s.push_back(initialAge_s);
-    double scenarioDuration_s = 144.0;
-    double scenarioOffset_s = 24.0;
     std::unordered_map<size_t, std::vector<TimeState>> actual =
-        erin::CreateFailureSchedules(
-            componentFailureModeComponentIds,
-            componentFailureModeFailureModeIds,
-            componentInitialAges_s,
-            rc,
-            []() { return 0.5; },
-            ds,
-            scenarioDuration_s,
-            scenarioOffset_s
-        );
+        RunCreateFailureSchedules(0.0, 24.0);
     EXPECT_EQ(actual.size(), 1);
     for (auto const& it : actual)
     {

--- a/test/erin_simulation_tests.cpp
+++ b/test/erin_simulation_tests.cpp
@@ -1,11 +1,40 @@
 /* Copyright (c) 2024 Big Ladder Software LLC. All rights reserved.
  * See the LICENSE.txt file for additional terms and conditions. */
+#include "erin_next/erin_next_distribution.h"
+#include "erin_next/erin_next_reliability.h"
 #include "erin_next/erin_next_simulation.h"
 #include <gtest/gtest.h>
 
 using namespace erin;
 
-TEST(ErinSim, TestReliabilityAndFragilityCurveGeneration)
+TEST(ErinSim, TestCreateFailureSchedules)
 {
-  EXPECT_EQ(1, 1);
+    size_t compId = 0;
+    double initialAge_s = 0.0;
+    DistributionSystem ds{};
+    ReliabilityCoordinator rc{};
+    size_t breakDistId = ds.add_fixed("break", 10.0);
+    size_t fixDistId = ds.add_fixed("fix", 2.0);
+    size_t fmId = rc.add_failure_mode("fm", breakDistId, fixDistId);
+    size_t compFmId = rc.link_component_with_failure_mode(compId, fmId);
+    std::vector<size_t> componentFailureModeComponentIds{};
+    componentFailureModeComponentIds.push_back(compId);
+    std::vector<size_t> componentFailureModeFailureModeIds{};
+    componentFailureModeFailureModeIds.push_back(fmId);
+    std::vector<double> componentInitialAges_s{};
+    componentInitialAges_s.push_back(initialAge_s);
+    double scenarioDuration_s = 144.0;
+    double scenarioOffset_s = 0.0;
+    std::unordered_map<size_t, std::vector<TimeState>> actual =
+        erin::CreateFailureSchedules(
+            componentFailureModeComponentIds,
+            componentFailureModeFailureModeIds,
+            componentInitialAges_s,
+            rc,
+            []() { return 0.5; },
+            ds,
+            scenarioDuration_s,
+            scenarioOffset_s
+        );
+    EXPECT_EQ(actual.size(), 1);
 }

--- a/test/erin_simulation_tests.cpp
+++ b/test/erin_simulation_tests.cpp
@@ -27,15 +27,15 @@ RunCreateFailureSchedules(double initialAge_s, double scenarioOffset_s)
     componentInitialAges_s.push_back(initialAge_s);
     double scenarioDuration_s = 144.0;
     return erin::CreateFailureSchedules(
-            componentFailureModeComponentIds,
-            componentFailureModeFailureModeIds,
-            componentInitialAges_s,
-            rc,
-            []() { return 0.5; },
-            ds,
-            scenarioDuration_s,
-            scenarioOffset_s
-        );
+        componentFailureModeComponentIds,
+        componentFailureModeFailureModeIds,
+        componentInitialAges_s,
+        rc,
+        []() { return 0.5; },
+        ds,
+        scenarioDuration_s,
+        scenarioOffset_s
+    );
 }
 
 TEST(ErinSim, TestCreateFailureSchedules)

--- a/test/erin_simulation_tests.cpp
+++ b/test/erin_simulation_tests.cpp
@@ -113,7 +113,7 @@ RunApplyReliabilitiesAndFragilities(
 {
     // NOTE: our network is one source feeding electricity
     // into one load. That is, S -> L
-    std::function<double()> randFn = []{ return 0.5; };
+    std::function<double()> randFn = [] { return 0.5; };
     std::vector<size_t> componentFailureModeComponentIds{};
     std::vector<double> componentInitialAges_s = {0.0, 0.0};
     std::vector<std::string> componentTags = {"S", "L"};
@@ -123,51 +123,55 @@ RunApplyReliabilitiesAndFragilities(
     std::vector<std::optional<size_t>> fragilityModeRepairDistIds = {{}};
     std::vector<std::string> fragilityModeTags = {"vulnerable_to_wind"};
     std::vector<size_t> fragilityCurveCurveIds = {0};
-    std::vector<FragilityCurveType> fragilityCurveCurveTypes = {FragilityCurveType::Linear};
+    std::vector<FragilityCurveType> fragilityCurveCurveTypes = {
+        FragilityCurveType::Linear
+    };
     std::vector<LinearFragilityCurve> linearFragilityCurves = {
-        {.VulnerabilityId=0, .LowerBound=80.0, .UpperBound=140.0}
+        {.VulnerabilityId = 0, .LowerBound = 80.0, .UpperBound = 140.0}
     };
     std::vector<TabularFragilityCurve> tabularFragilityCurves = {};
     DistributionSystem ds{};
     std::unordered_map<size_t, double> intensityIdToAmount = {
-        { 0, 160.0 },
+        {0, 160.0},
     };
     std::unordered_map<size_t, std::vector<TimeState>> relSchByCompId{};
     bool verbose = false;
 
     return ApplyReliabilitiesAndFragilities(
-            randFn,
-            componentFailureModeComponentIds,
-            componentInitialAges_s,
-            componentTags,
-            componentFragilityComponentIds,
-            componentFragilityFragilityModeIds,
-            fragilityModeFragilityCurveId,
-            fragilityModeRepairDistIds,
-            fragilityModeTags,
-            fragilityCurveCurveIds,
-            fragilityCurveCurveTypes,
-            linearFragilityCurves,
-            tabularFragilityCurves,
-            ds,
-            scenarioOffset_s,
-            scenarioOffset_s + scenarioDuration_s,
-            intensityIdToAmount,
-            relSchByCompId,
-            verbose
-        );
+        randFn,
+        componentFailureModeComponentIds,
+        componentInitialAges_s,
+        componentTags,
+        componentFragilityComponentIds,
+        componentFragilityFragilityModeIds,
+        fragilityModeFragilityCurveId,
+        fragilityModeRepairDistIds,
+        fragilityModeTags,
+        fragilityCurveCurveIds,
+        fragilityCurveCurveTypes,
+        linearFragilityCurves,
+        tabularFragilityCurves,
+        ds,
+        scenarioOffset_s,
+        scenarioOffset_s + scenarioDuration_s,
+        intensityIdToAmount,
+        relSchByCompId,
+        verbose
+    );
 }
 
 TEST(ErinSim, TestFragility_NoReliability_NoRepair_NoOffset_NoAge)
 {
     double scenarioOffset_s = 0.0;
     double scenarioDuration_s = 1'000.0;
-    //std::unordered_map<size_t, double> intensityIdToAmount = {
-    //    { 0, 160.0 },
-    //};
-    //std::unordered_map<size_t, std::vector<TimeState>> relSchByCompId{};
+    // std::unordered_map<size_t, double> intensityIdToAmount = {
+    //     { 0, 160.0 },
+    // };
+    // std::unordered_map<size_t, std::vector<TimeState>> relSchByCompId{};
     std::vector<ScheduleBasedReliability> actual =
-        RunApplyReliabilitiesAndFragilities(scenarioOffset_s, scenarioDuration_s);    
+        RunApplyReliabilitiesAndFragilities(
+            scenarioOffset_s, scenarioDuration_s
+        );
     EXPECT_EQ(actual.size(), 1);
     for (ScheduleBasedReliability const& sbr : actual)
     {

--- a/test/erin_simulation_tests.cpp
+++ b/test/erin_simulation_tests.cpp
@@ -184,7 +184,10 @@ TEST(ErinSim, TestFragility_NoReliability_NoRepair_NoOffset_NoAge)
     std::unordered_map<size_t, std::vector<TimeState>> relSchByCompId{};
     std::vector<ScheduleBasedReliability> actual =
         RunApplyReliabilitiesAndFragilities(
-            scenarioOffset_s, scenarioDuration_s, doRepair, initialAge_s,
+            scenarioOffset_s,
+            scenarioDuration_s,
+            doRepair,
+            initialAge_s,
             relSchByCompId
         );
     EXPECT_EQ(actual.size(), 1);
@@ -212,7 +215,10 @@ TEST(ErinSim, TestFragility_NoReliability_Repair_NoOffset_NoAge)
     std::unordered_map<size_t, std::vector<TimeState>> relSchByCompId{};
     std::vector<ScheduleBasedReliability> actual =
         RunApplyReliabilitiesAndFragilities(
-            scenarioOffset_s, scenarioDuration_s, doRepair, initialAge_s,
+            scenarioOffset_s,
+            scenarioDuration_s,
+            doRepair,
+            initialAge_s,
             relSchByCompId
         );
     EXPECT_EQ(actual.size(), 1);
@@ -244,7 +250,10 @@ TEST(ErinSim, TestFragility_NoReliability_NoRepair_Offset_NoAge)
     std::unordered_map<size_t, std::vector<TimeState>> relSchByCompId{};
     std::vector<ScheduleBasedReliability> actual =
         RunApplyReliabilitiesAndFragilities(
-            scenarioOffset_s, scenarioDuration_s, doRepair, initialAge_s,
+            scenarioOffset_s,
+            scenarioDuration_s,
+            doRepair,
+            initialAge_s,
             relSchByCompId
         );
     EXPECT_EQ(actual.size(), 1);
@@ -272,7 +281,10 @@ TEST(ErinSim, TestFragility_NoReliability_NoRepair_NoOffset_Age)
     std::unordered_map<size_t, std::vector<TimeState>> relSchByCompId{};
     std::vector<ScheduleBasedReliability> actual =
         RunApplyReliabilitiesAndFragilities(
-            scenarioOffset_s, scenarioDuration_s, doRepair, initialAge_s,
+            scenarioOffset_s,
+            scenarioDuration_s,
+            doRepair,
+            initialAge_s,
             relSchByCompId
         );
     EXPECT_EQ(actual.size(), 1);
@@ -300,7 +312,10 @@ TEST(ErinSim, TestFragility_NoReliability_NoRepair_Offset_Age)
     std::unordered_map<size_t, std::vector<TimeState>> relSchByCompId{};
     std::vector<ScheduleBasedReliability> actual =
         RunApplyReliabilitiesAndFragilities(
-            scenarioOffset_s, scenarioDuration_s, doRepair, initialAge_s,
+            scenarioOffset_s,
+            scenarioDuration_s,
+            doRepair,
+            initialAge_s,
             relSchByCompId
         );
     EXPECT_EQ(actual.size(), 1);
@@ -323,44 +338,44 @@ TEST(TimeState, TestTimeStateCombine)
 {
     std::vector<TimeState> A = {
         {
-            .time=10.0,
-            .state=false,
-            .failureModeCauses={0},
-            .fragilityModeCauses={},
+            .time = 10.0,
+            .state = false,
+            .failureModeCauses = {0},
+            .fragilityModeCauses = {},
         },
         {
-            .time=20.0,
-            .state=true,
-            .failureModeCauses={},
-            .fragilityModeCauses={},
+            .time = 20.0,
+            .state = true,
+            .failureModeCauses = {},
+            .fragilityModeCauses = {},
         },
     };
     std::vector<TimeState> B = {
         {
-            .time=0.0,
-            .state=false,
-            .failureModeCauses={},
-            .fragilityModeCauses={0},
+            .time = 0.0,
+            .state = false,
+            .failureModeCauses = {},
+            .fragilityModeCauses = {0},
         },
     };
     std::vector<TimeState> expected = {
         {
-            .time=0.0,
-            .state=false,
-            .failureModeCauses={},
-            .fragilityModeCauses={0},
+            .time = 0.0,
+            .state = false,
+            .failureModeCauses = {},
+            .fragilityModeCauses = {0},
         },
         {
-            .time=10.0,
-            .state=false,
-            .failureModeCauses={0},
-            .fragilityModeCauses={0},
+            .time = 10.0,
+            .state = false,
+            .failureModeCauses = {0},
+            .fragilityModeCauses = {0},
         },
         {
-            .time=20.0,
-            .state=false,
-            .failureModeCauses={},
-            .fragilityModeCauses={0},
+            .time = 20.0,
+            .state = false,
+            .failureModeCauses = {},
+            .fragilityModeCauses = {0},
         },
     };
     std::vector<TimeState> actual = TimeState_Combine(A, B);
@@ -376,21 +391,24 @@ TEST(ErinSim, TestFragility_Reliability_NoRepair_NoOffset_NoAge)
     std::unordered_map<size_t, std::vector<TimeState>> relSchByCompId{};
     std::vector<TimeState> relSch{};
     relSch.push_back({
-        .time=10.0,
-        .state=false,
-        .failureModeCauses={0},
-        .fragilityModeCauses={},
+        .time = 10.0,
+        .state = false,
+        .failureModeCauses = {0},
+        .fragilityModeCauses = {},
     });
     relSch.push_back({
-        .time=20.0,
-        .state=true,
-        .failureModeCauses={},
-        .fragilityModeCauses={},
+        .time = 20.0,
+        .state = true,
+        .failureModeCauses = {},
+        .fragilityModeCauses = {},
     });
     relSchByCompId[0] = std::move(relSch);
     std::vector<ScheduleBasedReliability> actual =
         RunApplyReliabilitiesAndFragilities(
-            scenarioOffset_s, scenarioDuration_s, doRepair, initialAge_s,
+            scenarioOffset_s,
+            scenarioDuration_s,
+            doRepair,
+            initialAge_s,
             relSchByCompId
         );
     EXPECT_EQ(actual.size(), 1);
@@ -441,21 +459,24 @@ TEST(ErinSim, TestFragility_Reliability_Repair_Offset_Age)
     std::unordered_map<size_t, std::vector<TimeState>> relSchByCompId{};
     std::vector<TimeState> relSch{};
     relSch.push_back({
-        .time=510.0,
-        .state=false,
-        .failureModeCauses={0},
-        .fragilityModeCauses={},
+        .time = 510.0,
+        .state = false,
+        .failureModeCauses = {0},
+        .fragilityModeCauses = {},
     });
     relSch.push_back({
-        .time=520.0,
-        .state=true,
-        .failureModeCauses={},
-        .fragilityModeCauses={},
+        .time = 520.0,
+        .state = true,
+        .failureModeCauses = {},
+        .fragilityModeCauses = {},
     });
     relSchByCompId[0] = std::move(relSch);
     std::vector<ScheduleBasedReliability> actual =
         RunApplyReliabilitiesAndFragilities(
-            scenarioOffset_s, scenarioDuration_s, doRepair, initialAge_s,
+            scenarioOffset_s,
+            scenarioDuration_s,
+            doRepair,
+            initialAge_s,
             relSchByCompId
         );
     EXPECT_EQ(actual.size(), 1);
@@ -496,4 +517,3 @@ TEST(ErinSim, TestFragility_Reliability_Repair_Offset_Age)
         }
     }
 }
-

--- a/test/erin_simulation_tests.cpp
+++ b/test/erin_simulation_tests.cpp
@@ -1,10 +1,13 @@
 /* Copyright (c) 2024 Big Ladder Software LLC. All rights reserved.
  * See the LICENSE.txt file for additional terms and conditions. */
+#include "erin_next/erin_next.h"
 #include "erin_next/erin_next_distribution.h"
 #include "erin_next/erin_next_reliability.h"
 #include "erin_next/erin_next_simulation.h"
 #include "erin_next/erin_next_timestate.h"
+#include "gtest/gtest.h"
 #include <gtest/gtest.h>
+#include <optional>
 #include <unordered_map>
 
 using namespace erin;
@@ -99,5 +102,84 @@ TEST(ErinSim, TestCreateFailureSchedulesWithInitialAgeAndOffset)
         EXPECT_EQ(tss[0].state, false) << tss[0];
         EXPECT_EQ(tss[27].time, 168.0) << tss[27];
         EXPECT_EQ(tss[27].state, true) << tss[27];
+    }
+}
+
+std::vector<ScheduleBasedReliability>
+RunApplyReliabilitiesAndFragilities(
+    double scenarioOffset_s,
+    double scenarioDuration_s
+)
+{
+    // NOTE: our network is one source feeding electricity
+    // into one load. That is, S -> L
+    std::function<double()> randFn = []{ return 0.5; };
+    std::vector<size_t> componentFailureModeComponentIds{};
+    std::vector<double> componentInitialAges_s = {0.0, 0.0};
+    std::vector<std::string> componentTags = {"S", "L"};
+    std::vector<size_t> componentFragilityComponentIds = {0};
+    std::vector<size_t> componentFragilityFragilityModeIds = {0};
+    std::vector<size_t> fragilityModeFragilityCurveId = {0};
+    std::vector<std::optional<size_t>> fragilityModeRepairDistIds = {{}};
+    std::vector<std::string> fragilityModeTags = {"vulnerable_to_wind"};
+    std::vector<size_t> fragilityCurveCurveIds = {0};
+    std::vector<FragilityCurveType> fragilityCurveCurveTypes = {FragilityCurveType::Linear};
+    std::vector<LinearFragilityCurve> linearFragilityCurves = {
+        {.VulnerabilityId=0, .LowerBound=80.0, .UpperBound=140.0}
+    };
+    std::vector<TabularFragilityCurve> tabularFragilityCurves = {};
+    DistributionSystem ds{};
+    std::unordered_map<size_t, double> intensityIdToAmount = {
+        { 0, 160.0 },
+    };
+    std::unordered_map<size_t, std::vector<TimeState>> relSchByCompId{};
+    bool verbose = false;
+
+    return ApplyReliabilitiesAndFragilities(
+            randFn,
+            componentFailureModeComponentIds,
+            componentInitialAges_s,
+            componentTags,
+            componentFragilityComponentIds,
+            componentFragilityFragilityModeIds,
+            fragilityModeFragilityCurveId,
+            fragilityModeRepairDistIds,
+            fragilityModeTags,
+            fragilityCurveCurveIds,
+            fragilityCurveCurveTypes,
+            linearFragilityCurves,
+            tabularFragilityCurves,
+            ds,
+            scenarioOffset_s,
+            scenarioOffset_s + scenarioDuration_s,
+            intensityIdToAmount,
+            relSchByCompId,
+            verbose
+        );
+}
+
+TEST(ErinSim, TestFragility_NoReliability_NoRepair_NoOffset_NoAge)
+{
+    double scenarioOffset_s = 0.0;
+    double scenarioDuration_s = 1'000.0;
+    //std::unordered_map<size_t, double> intensityIdToAmount = {
+    //    { 0, 160.0 },
+    //};
+    //std::unordered_map<size_t, std::vector<TimeState>> relSchByCompId{};
+    std::vector<ScheduleBasedReliability> actual =
+        RunApplyReliabilitiesAndFragilities(scenarioOffset_s, scenarioDuration_s);    
+    EXPECT_EQ(actual.size(), 1);
+    for (ScheduleBasedReliability const& sbr : actual)
+    {
+        EXPECT_EQ(sbr.ComponentId, 0);
+        EXPECT_EQ(sbr.TimeStates.size(), 1);
+        EXPECT_EQ(sbr.TimeStates[0].time, 0.0);
+        EXPECT_EQ(sbr.TimeStates[0].state, false);
+        EXPECT_EQ(sbr.TimeStates[0].failureModeCauses.size(), 0);
+        EXPECT_EQ(sbr.TimeStates[0].fragilityModeCauses.size(), 1);
+        for (size_t fmId : sbr.TimeStates[0].fragilityModeCauses)
+        {
+            EXPECT_EQ(fmId, 0);
+        }
     }
 }

--- a/test/erin_simulation_tests.cpp
+++ b/test/erin_simulation_tests.cpp
@@ -85,3 +85,19 @@ TEST(ErinSim, TestCreateFailureSchedulesWithInitialAge)
         EXPECT_EQ(tss[27].state, true) << tss[27];
     }
 }
+
+TEST(ErinSim, TestCreateFailureSchedulesWithInitialAgeAndOffset)
+{
+    std::unordered_map<size_t, std::vector<TimeState>> actual =
+        RunCreateFailureSchedules(12.0, 12.0);
+    EXPECT_EQ(actual.size(), 1);
+    for (auto const& it : actual)
+    {
+        std::vector<TimeState> const& tss = it.second;
+        EXPECT_EQ(tss.size(), 28);
+        EXPECT_EQ(tss[0].time, 10.0) << tss[0];
+        EXPECT_EQ(tss[0].state, false) << tss[0];
+        EXPECT_EQ(tss[27].time, 168.0) << tss[27];
+        EXPECT_EQ(tss[27].state, true) << tss[27];
+    }
+}

--- a/test/erin_simulation_tests.cpp
+++ b/test/erin_simulation_tests.cpp
@@ -367,52 +367,70 @@ TEST(TimeState, TestTimeStateCombine)
     EXPECT_EQ(actual.size(), expected.size());
 }
 
-// TODO: re-enable
-//TEST(ErinSim, TestFragility_Reliability_NoRepair_NoOffset_NoAge)
-//{
-//    double scenarioOffset_s = 0.0;
-//    double scenarioDuration_s = 1'000.0;
-//    double initialAge_s = 0.0;
-//    bool doRepair = false;
-//    std::unordered_map<size_t, std::vector<TimeState>> relSchByCompId{};
-//    std::vector<TimeState> relSch{};
-//    relSch.push_back({
-//        .time=10.0,
-//        .state=false,
-//        .failureModeCauses={0},
-//        .fragilityModeCauses={},
-//    });
-//    relSch.push_back({
-//        .time=20.0,
-//        .state=true,
-//        .failureModeCauses={},
-//        .fragilityModeCauses={},
-//    });
-//    relSchByCompId[0] = std::move(relSch);
-//    std::vector<ScheduleBasedReliability> actual =
-//        RunApplyReliabilitiesAndFragilities(
-//            scenarioOffset_s, scenarioDuration_s, doRepair, initialAge_s,
-//            relSchByCompId
-//        );
-//    EXPECT_EQ(actual.size(), 1);
-//    for (ScheduleBasedReliability const& sbr : actual)
-//    {
-//        EXPECT_EQ(sbr.ComponentId, 0);
-//        for (TimeState const& ts : sbr.TimeStates)
-//        {
-//            std::cout << ts << std::endl;
-//        }
-//        EXPECT_EQ(sbr.TimeStates.size(), 3);
-//        EXPECT_EQ(sbr.TimeStates[0].time, 0.0);
-//        EXPECT_EQ(sbr.TimeStates[0].state, false);
-//        EXPECT_EQ(sbr.TimeStates[0].failureModeCauses.size(), 0);
-//        EXPECT_EQ(sbr.TimeStates[0].fragilityModeCauses.size(), 1);
-//        for (size_t fmId : sbr.TimeStates[0].fragilityModeCauses)
-//        {
-//            EXPECT_EQ(fmId, 0);
-//        }
-//    }
-//}
+TEST(ErinSim, TestFragility_Reliability_NoRepair_NoOffset_NoAge)
+{
+    double scenarioOffset_s = 0.0;
+    double scenarioDuration_s = 1'000.0;
+    double initialAge_s = 0.0;
+    bool doRepair = false;
+    std::unordered_map<size_t, std::vector<TimeState>> relSchByCompId{};
+    std::vector<TimeState> relSch{};
+    relSch.push_back({
+        .time=10.0,
+        .state=false,
+        .failureModeCauses={0},
+        .fragilityModeCauses={},
+    });
+    relSch.push_back({
+        .time=20.0,
+        .state=true,
+        .failureModeCauses={},
+        .fragilityModeCauses={},
+    });
+    relSchByCompId[0] = std::move(relSch);
+    std::vector<ScheduleBasedReliability> actual =
+        RunApplyReliabilitiesAndFragilities(
+            scenarioOffset_s, scenarioDuration_s, doRepair, initialAge_s,
+            relSchByCompId
+        );
+    EXPECT_EQ(actual.size(), 1);
+    for (ScheduleBasedReliability const& sbr : actual)
+    {
+        EXPECT_EQ(sbr.ComponentId, 0);
+        EXPECT_EQ(sbr.TimeStates.size(), 3);
+        // 1st
+        EXPECT_EQ(sbr.TimeStates[0].time, 0.0);
+        EXPECT_EQ(sbr.TimeStates[0].state, false);
+        EXPECT_EQ(sbr.TimeStates[0].failureModeCauses.size(), 0);
+        EXPECT_EQ(sbr.TimeStates[0].fragilityModeCauses.size(), 1);
+        for (size_t fmId : sbr.TimeStates[0].fragilityModeCauses)
+        {
+            EXPECT_EQ(fmId, 0);
+        }
+        // 2nd
+        EXPECT_EQ(sbr.TimeStates[1].time, 10.0);
+        EXPECT_EQ(sbr.TimeStates[1].state, false);
+        EXPECT_EQ(sbr.TimeStates[1].failureModeCauses.size(), 1);
+        for (size_t fmId : sbr.TimeStates[1].failureModeCauses)
+        {
+            EXPECT_EQ(fmId, 0);
+        }
+        EXPECT_EQ(sbr.TimeStates[1].fragilityModeCauses.size(), 1);
+        for (size_t fmId : sbr.TimeStates[1].fragilityModeCauses)
+        {
+            EXPECT_EQ(fmId, 0);
+        }
+        // 3rd
+        EXPECT_EQ(sbr.TimeStates[2].time, 20.0);
+        EXPECT_EQ(sbr.TimeStates[2].state, false);
+        EXPECT_EQ(sbr.TimeStates[2].failureModeCauses.size(), 0);
+        EXPECT_EQ(sbr.TimeStates[2].fragilityModeCauses.size(), 1);
+        for (size_t fmId : sbr.TimeStates[2].fragilityModeCauses)
+        {
+            EXPECT_EQ(fmId, 0);
+        }
+    }
+}
 // TODO:
 // - add reliability
 // - add reliability with offset


### PR DESCRIPTION
## Description of the Problem this PR will Solve

Fixes #90 

This PR reworks the time algorithm for the reliability schedule generator. Reliability schedules are now only created per each scenario's occurrence and they always progress from "time zero" (the time when age is assessed and the scenario offset is measured from) -- this is normally presumed to be January 1 of the given year. Age of each of the components and scenario offset is taken into account. However, a separate PR will fully wire up and test the new scenario offset feature (ability to specify that a scenario starts on March 25, for example).
