### PR TITLE
Enable Logging System for ERIN and Fix/Clean-up Error Messages

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "vendor/fmt"]
 	path = vendor/fmt
 	url = https://github.com/fmtlib/fmt.git
+[submodule "vendor/courier"]
+	path = vendor/courier
+	url = https://github.com/bigladder/courier.git

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -14,5 +14,6 @@ add_executable(erin erin.cpp compilation_settings.h.in)
 target_include_directories(erin
 	PUBLIC "${PROJECT_SOURCE_DIR}/include"
 	PRIVATE "${PROJECT_SOURCE_DIR}/vendor/toml11"
-	PRIVATE "${PROJECT_SOURCE_DIR}/vendor/CLI11")
+	PRIVATE "${PROJECT_SOURCE_DIR}/vendor/CLI11"
+)
 target_link_libraries(erin erin_next CLI11)

--- a/apps/erin.cpp
+++ b/apps/erin.cpp
@@ -1,4 +1,5 @@
 #include "erin/version.h"
+#include "erin/logging.h"
 #include "erin_next/erin_next_simulation_info.h"
 #include "erin_next/erin_next_load.h"
 #include "erin_next/erin_next_component.h"
@@ -9,6 +10,7 @@
 #include "erin_next/erin_next_toml.h"
 #include "erin_next/erin_next_units.h"
 #include "erin_next/erin_next_result.h"
+#include "erin_next/erin_next_utils.h"
 #include "erin_next/erin_next_validation.h"
 #include "erin_next/erin_next_graph.h"
 #include <cstdlib>
@@ -172,8 +174,24 @@ add_run(CLI::App& app)
             Simulation_Print(s);
             std::cout << "-----------------" << std::endl;
         }
+        Logger logger{};
+        Log log = Log_MakeFromCourier(logger);
+        // NOTE: overriding default error functionality as it throws.
+        //       instead, error conditions and exiting are handled explicitly
+        //       by the library.
+        log.error = [&](std::string const& tag, std::string const& msg) {
+            if (tag.empty())
+            {
+                std::cout << fmt::format("[{}] {}", "ERROR", msg) << std::endl;
+            }
+            else
+            {
+                std::cout << fmt::format("[{}] {}: {}", "ERROR", tag, msg) << std::endl;
+            }
+        };
         Simulation_Run(
             s,
+            log,
             eventsFilename,
             statsFilename,
             time_step_h,

--- a/apps/erin.cpp
+++ b/apps/erin.cpp
@@ -25,10 +25,9 @@
 #include "compilation_settings.h"
 
 erin::Log
-get_standard_log()
+get_standard_log(erin::Logger& logger)
 {
     using namespace erin;
-    Logger logger{};
     Log log = Log_MakeFromCourier(logger);
     // NOTE: overriding default error functionality as it throws.
     //       instead, error conditions and exiting are handled explicitly
@@ -153,7 +152,8 @@ add_run(CLI::App& app)
     auto run = [&]()
     {
         using namespace erin;
-        Log log = get_standard_log();
+        Logger logger{};
+        Log log = get_standard_log(logger);
         bool aggregate_groups = !no_aggregate_groups;
         if (verbose)
         {
@@ -234,7 +234,8 @@ add_graph(CLI::App& app)
     auto graph = [&]()
     {
         using namespace erin;
-        Log log = get_standard_log();
+        Logger logger{};
+        Log log = get_standard_log(logger);
         std::ifstream ifs(tomlFilename, std::ios_base::binary);
         if (!ifs.good())
         {
@@ -290,7 +291,8 @@ add_checkNetwork(CLI::App& app)
     auto checkNetwork = [&]()
     {
         using namespace erin;
-        Log log = get_standard_log();
+        Logger logger{};
+        Log log = get_standard_log(logger);
         std::ifstream ifs(tomlFilename, std::ios_base::binary);
         if (!ifs.good())
         {
@@ -575,7 +577,8 @@ add_packLoads(CLI::App& app)
 
     auto packLoads = [&]()
     {
-        erin::Log log = get_standard_log();
+        erin::Logger logger{};
+        erin::Log log = get_standard_log(logger);
         if (verbose)
         {
             std::cout << "input file: " << tomlFilename << std::endl;

--- a/apps/erin.cpp
+++ b/apps/erin.cpp
@@ -134,14 +134,16 @@ add_run(CLI::App& app)
         // NOTE: overriding default error functionality as it throws.
         //       instead, error conditions and exiting are handled explicitly
         //       by the library.
-        log.error = [&](std::string const& tag, std::string const& msg) {
+        log.error = [&](std::string const& tag, std::string const& msg)
+        {
             if (tag.empty())
             {
                 std::cout << fmt::format("[{}] {}", "ERROR", msg) << std::endl;
             }
             else
             {
-                std::cout << fmt::format("[{}] {}: {}", "ERROR", tag, msg) << std::endl;
+                std::cout << fmt::format("[{}] {}: {}", "ERROR", tag, msg)
+                          << std::endl;
             }
         };
         bool aggregate_groups = !no_aggregate_groups;

--- a/apps/erin.cpp
+++ b/apps/erin.cpp
@@ -575,39 +575,36 @@ add_packLoads(CLI::App& app)
 
     auto packLoads = [&]()
     {
+        erin::Log log = get_standard_log();
         if (verbose)
         {
             std::cout << "input file: " << tomlFilename << std::endl;
             std::cout << "verbose: " << (verbose ? "true" : "false")
                       << std::endl;
         }
-
         std::ifstream ifs(tomlFilename, std::ios_base::binary);
         if (!ifs.good())
         {
-            std::cout << "Could not open input file stream on input file"
-                      << std::endl;
+            erin::Log_Error(
+                log, "Could not open input file stream on input file"
+            );
             return EXIT_FAILURE;
         }
-
         auto tomlFilenameOnly = std::filesystem::path(tomlFilename).filename();
         auto data = toml::parse(ifs, tomlFilenameOnly.string());
         ifs.close();
-
         auto const& loadTable = data.at("loads").as_table();
-
         auto validationInfo = erin::SetupGlobalValidationInfo();
         erin::ValidationInfo explicitValidation =
             validationInfo.Load_01Explicit;
         erin::ValidationInfo fileValidation = validationInfo.Load_02FileBased;
         auto maybeLoads =
-            ParseLoads(loadTable, explicitValidation, fileValidation);
+            ParseLoads(loadTable, explicitValidation, fileValidation, log);
         if (!maybeLoads.has_value())
         {
             return EXIT_FAILURE;
         }
         std::vector<erin::Load> loads = std::move(maybeLoads.value());
-
         return erin::WritePackedLoads(loads, loadsFilename);
     };
 

--- a/apps/erin.cpp
+++ b/apps/erin.cpp
@@ -184,8 +184,9 @@ add_run(CLI::App& app)
         std::unordered_set<std::string> componentTagsInUse =
             TOMLTable_ParseComponentTagsInUse(data);
         auto validationInfo = SetupGlobalValidationInfo();
-        auto maybeSim =
-            Simulation_ReadFromToml(data, validationInfo, componentTagsInUse, log);
+        auto maybeSim = Simulation_ReadFromToml(
+            data, validationInfo, componentTagsInUse, log
+        );
         if (!maybeSim.has_value())
         {
             Log_Error(log, "Simulation returned without value");
@@ -246,8 +247,9 @@ add_graph(CLI::App& app)
         std::unordered_set<std::string> componentTagsInUse =
             TOMLTable_ParseComponentTagsInUse(data);
         auto validation_info = SetupGlobalValidationInfo();
-        auto maybe_sim =
-            Simulation_ReadFromToml(data, validation_info, componentTagsInUse, log);
+        auto maybe_sim = Simulation_ReadFromToml(
+            data, validation_info, componentTagsInUse, log
+        );
         if (!maybe_sim.has_value())
         {
             Log_Error(log, "Could not parse sim data from TOML");
@@ -301,8 +303,9 @@ add_checkNetwork(CLI::App& app)
         std::unordered_set<std::string> componentTagsInUse =
             TOMLTable_ParseComponentTagsInUse(data);
         auto validationInfo = SetupGlobalValidationInfo();
-        auto maybeSim =
-            Simulation_ReadFromToml(data, validationInfo, componentTagsInUse, log);
+        auto maybeSim = Simulation_ReadFromToml(
+            data, validationInfo, componentTagsInUse, log
+        );
         if (!maybeSim.has_value())
         {
             return EXIT_FAILURE;

--- a/docs/examples/regress.py
+++ b/docs/examples/regress.py
@@ -25,11 +25,12 @@ if platform.system() == 'Windows':
         sys.exit(1)
     BIN_DIR = BIN_DIR.resolve()
     ALL_TESTS = [
-        BIN_DIR / 'erin_tests.exe',
-        BIN_DIR / 'erin_next_random_tests.exe',
+        BIN_DIR / 'erin_logging_tests.exe',
         BIN_DIR / 'erin_lookup_table_tests.exe',
-        BIN_DIR / 'erin_switch_tests.exe',
+        BIN_DIR / 'erin_next_random_tests.exe',
         BIN_DIR / 'erin_simulation_tests.exe',
+        BIN_DIR / 'erin_switch_tests.exe',
+        BIN_DIR / 'erin_tests.exe',
     ]
     CLI_EXE = BIN_DIR / 'erin.exe'
     PERF01_EXE = BIN_DIR / 'erin_next_stress_test.exe'
@@ -38,11 +39,12 @@ elif platform.system() == 'Darwin' or platform.system() == 'Linux':
     BIN_DIR = (Path('.') / '..' / '..' / 'build' / 'bin').absolute()
     BIN_DIR = BIN_DIR.resolve()
     ALL_TESTS = [
-        BIN_DIR / 'erin_tests',
-        BIN_DIR / 'erin_next_random_tests',
+        BIN_DIR / 'erin_logging_tests',
         BIN_DIR / 'erin_lookup_table_tests',
-        BIN_DIR / 'erin_switch_tests',
+        BIN_DIR / 'erin_next_random_tests',
         BIN_DIR / 'erin_simulation_tests',
+        BIN_DIR / 'erin_switch_tests',
+        BIN_DIR / 'erin_tests',
     ]
     CLI_EXE = BIN_DIR / 'erin'
     PERF01_EXE = BIN_DIR / 'erin_next_stress_test'

--- a/include/erin/logging.h
+++ b/include/erin/logging.h
@@ -13,89 +13,107 @@
 
 namespace erin
 {
-  enum class LogLevel
-  {
-    Debug = 0,
-    Info,
-    Warning,
-    Error,
-  };
-
-  struct Log
-  {
-    LogLevel LogLevel = LogLevel::Debug;
-    std::optional<std::function<void(std::string const&, std::string const&)>> debug = {};
-    std::optional<std::function<void(std::string const&, std::string const&)>> info = {};
-    std::optional<std::function<void(std::string const&, std::string const&)>> warning = {};
-    std::optional<std::function<void(std::string const&, std::string const&)>> error = {};
-  };
-
-  void
-  Log_General(Log const& log, LogLevel ll, std::string const& msg);
-
-  void
-  Log_General(Log const& log, LogLevel ll, std::string const& tag, std::string const& msg);
-
-  void
-  Log_Debug(Log const& log, std::string const& msg);
-
-  void
-  Log_Debug(Log const& log, std::string const& tag, std::string const& msg);
-
-  void
-  Log_Info(Log const& log, std::string const& msg);
-
-  void
-  Log_Info(Log const& log, std::string const& tag, std::string const& msg);
-
-  void
-  Log_Warning(Log const& log, std::string const& msg);
-
-  void
-  Log_Warning(Log const& log, std::string const& tag, std::string const& msg);
-
-  void
-  Log_Error(Log const& log, std::string const& msg);
-
-  void
-  Log_Error(Log const& log, std::string const& tag, std::string const& msg);
-
-  class Logger final : public Courier::Courier
-  {
-    public:
-
-    void
-    receive_error(const std::string& message) override
+    enum class LogLevel
     {
-        write_message("ERROR", message);
-    }
+        Debug = 0,
+        Info,
+        Warning,
+        Error,
+    };
 
-    void
-    receive_warning(const std::string& message) override {
-      write_message("WARNING", message);
-    }
-
-    void
-    receive_info(const std::string& message) override {
-      write_message("INFO", message);
-    }
-
-    void
-    receive_debug(const std::string& message) override
+    struct Log
     {
-      write_message("DEBUG", message);
-    }
+        LogLevel LogLevel = LogLevel::Debug;
+        std::optional<
+            std::function<void(std::string const&, std::string const&)>>
+            debug = {};
+        std::optional<
+            std::function<void(std::string const&, std::string const&)>>
+            info = {};
+        std::optional<
+            std::function<void(std::string const&, std::string const&)>>
+            warning = {};
+        std::optional<
+            std::function<void(std::string const&, std::string const&)>>
+            error = {};
+    };
 
-    static void
-    write_message(const std::string& message_type, const std::string& message)
+    void
+    Log_General(Log const& log, LogLevel ll, std::string const& msg);
 
+    void
+    Log_General(
+        Log const& log,
+        LogLevel ll,
+        std::string const& tag,
+        std::string const& msg
+    );
+
+    void
+    Log_Debug(Log const& log, std::string const& msg);
+
+    void
+    Log_Debug(Log const& log, std::string const& tag, std::string const& msg);
+
+    void
+    Log_Info(Log const& log, std::string const& msg);
+
+    void
+    Log_Info(Log const& log, std::string const& tag, std::string const& msg);
+
+    void
+    Log_Warning(Log const& log, std::string const& msg);
+
+    void
+    Log_Warning(Log const& log, std::string const& tag, std::string const& msg);
+
+    void
+    Log_Error(Log const& log, std::string const& msg);
+
+    void
+    Log_Error(Log const& log, std::string const& tag, std::string const& msg);
+
+    class Logger final: public Courier::Courier
     {
-        std::cout << fmt::format("[{}] {}", message_type, message) << std::endl;
-    }
-  };
+      public:
+        void
+        receive_error(const std::string& message) override
+        {
+            write_message("ERROR", message);
+        }
 
-  Log
-  Log_MakeFromCourier(Courier::Courier& courier);
+        void
+        receive_warning(const std::string& message) override
+        {
+            write_message("WARNING", message);
+        }
+
+        void
+        receive_info(const std::string& message) override
+        {
+            write_message("INFO", message);
+        }
+
+        void
+        receive_debug(const std::string& message) override
+        {
+            write_message("DEBUG", message);
+        }
+
+        static void
+        write_message(
+            const std::string& message_type,
+            const std::string& message
+        )
+
+        {
+            std::cout << fmt::format("[{}] {}", message_type, message)
+                      << std::endl;
+        }
+    };
+
+    Log
+    Log_MakeFromCourier(Courier::Courier& courier);
 }
 
 #endif

--- a/include/erin/logging.h
+++ b/include/erin/logging.h
@@ -24,10 +24,10 @@ namespace erin
   struct Log
   {
     LogLevel LogLevel = LogLevel::Debug;
-    std::optional<std::function<void(std::string const&, std::string const&)>> debug;
-    std::optional<std::function<void(std::string const&, std::string const&)>> info;
-    std::optional<std::function<void(std::string const&, std::string const&)>> warning;
-    std::optional<std::function<void(std::string const&, std::string const&)>> error;
+    std::optional<std::function<void(std::string const&, std::string const&)>> debug = {};
+    std::optional<std::function<void(std::string const&, std::string const&)>> info = {};
+    std::optional<std::function<void(std::string const&, std::string const&)>> warning = {};
+    std::optional<std::function<void(std::string const&, std::string const&)>> error = {};
   };
 
   void

--- a/include/erin/logging.h
+++ b/include/erin/logging.h
@@ -1,0 +1,101 @@
+/* Copyright (c) 2024 Big Ladder Software LLC. All rights reserved.
+ * See the LICENSE.txt file for additional terms and conditions. */
+#ifndef ERIN_LOGGING_H
+#define ERIN_LOGGING_H
+#include <functional>
+#include <string>
+#include <optional>
+#include <iostream>
+#include <cstdlib>
+#include "../vendor/courier/include/courier/courier.h"
+#include "../vendor/fmt/include/fmt/core.h"
+#include "erin_next/erin_next_utils.h"
+
+namespace erin
+{
+  enum class LogLevel
+  {
+    Debug = 0,
+    Info,
+    Warning,
+    Error,
+  };
+
+  struct Log
+  {
+    LogLevel LogLevel = LogLevel::Debug;
+    std::optional<std::function<void(std::string const&, std::string const&)>> debug;
+    std::optional<std::function<void(std::string const&, std::string const&)>> info;
+    std::optional<std::function<void(std::string const&, std::string const&)>> warning;
+    std::optional<std::function<void(std::string const&, std::string const&)>> error;
+  };
+
+  void
+  Log_General(Log const& log, LogLevel ll, std::string const& msg);
+
+  void
+  Log_General(Log const& log, LogLevel ll, std::string const& tag, std::string const& msg);
+
+  void
+  Log_Debug(Log const& log, std::string const& msg);
+
+  void
+  Log_Debug(Log const& log, std::string const& tag, std::string const& msg);
+
+  void
+  Log_Info(Log const& log, std::string const& msg);
+
+  void
+  Log_Info(Log const& log, std::string const& tag, std::string const& msg);
+
+  void
+  Log_Warning(Log const& log, std::string const& msg);
+
+  void
+  Log_Warning(Log const& log, std::string const& tag, std::string const& msg);
+
+  void
+  Log_Error(Log const& log, std::string const& msg);
+
+  void
+  Log_Error(Log const& log, std::string const& tag, std::string const& msg);
+
+  class Logger final : public Courier::Courier
+  {
+    public:
+
+    void
+    receive_error(const std::string& message) override
+    {
+        write_message("ERROR", message);
+    }
+
+    void
+    receive_warning(const std::string& message) override {
+      write_message("WARNING", message);
+    }
+
+    void
+    receive_info(const std::string& message) override {
+      write_message("INFO", message);
+    }
+
+    void
+    receive_debug(const std::string& message) override
+    {
+      write_message("DEBUG", message);
+    }
+
+    static void
+    write_message(const std::string& message_type, const std::string& message)
+
+    {
+        std::cout << fmt::format("[{}] {}", message_type, message) << std::endl;
+    }
+  };
+
+  Log
+  Log_MakeFromCourier(Courier::Courier& courier);
+}
+
+#endif

--- a/include/erin/logging.h
+++ b/include/erin/logging.h
@@ -23,7 +23,7 @@ namespace erin
 
     struct Log
     {
-        LogLevel LogLevel = LogLevel::Debug;
+        LogLevel log_level = LogLevel::Debug;
         std::optional<
             std::function<void(std::string const&, std::string const&)>>
             debug = {};

--- a/include/erin_next/erin_next.h
+++ b/include/erin_next/erin_next.h
@@ -817,7 +817,12 @@ namespace erin
     FlowsToStrings(Model const& m, SimulationState const& ss, double t);
 
     void
-    LogFlows(Log const& log, Model const& m, SimulationState const& ss, double t);
+    LogFlows(
+        Log const& log,
+        Model const& m,
+        SimulationState const& ss,
+        double t
+    );
 
     void
     PrintFlows(Model const& m, SimulationState const& ss, double t);
@@ -838,7 +843,12 @@ namespace erin
     CopyStorageStates(SimulationState& ss);
 
     std::vector<TimeAndFlows>
-    Simulate(Model& m, bool verbose = true, bool enableSwitchLogic = true, Log const& log = Log{});
+    Simulate(
+        Model& m,
+        bool verbose = true,
+        bool enableSwitchLogic = true,
+        Log const& log = Log{}
+    );
 
     void
     Model_SetComponentToRepaired(

--- a/include/erin_next/erin_next.h
+++ b/include/erin_next/erin_next.h
@@ -11,6 +11,7 @@
 #include "erin_next/erin_next_units.h"
 #include "erin_next/erin_next_result.h"
 #include "erin_next/erin_next_lookup_table.h"
+#include "erin/logging.h"
 #include "../vendor/toml11/toml.hpp"
 #include <iostream>
 #include <limits>
@@ -812,8 +813,14 @@ namespace erin
     std::optional<ComponentType>
     TagToComponentType(std::string const& tag);
 
+    std::vector<std::string>
+    FlowsToStrings(Model const& m, SimulationState const& ss, double t);
+
     void
-    PrintFlows(Model const& m, SimulationState const&, double t);
+    LogFlows(Log const& log, Model const& m, SimulationState const& ss, double t);
+
+    void
+    PrintFlows(Model const& m, SimulationState const& ss, double t);
 
     FlowSummary
     SummarizeFlows(Model const& m, SimulationState const& ss, double t);
@@ -831,7 +838,7 @@ namespace erin
     CopyStorageStates(SimulationState& ss);
 
     std::vector<TimeAndFlows>
-    Simulate(Model& m, bool print = true, bool enableSwitchLogic = true);
+    Simulate(Model& m, bool verbose = true, bool enableSwitchLogic = true, Log const& log = Log{});
 
     void
     Model_SetComponentToRepaired(

--- a/include/erin_next/erin_next_component.h
+++ b/include/erin_next/erin_next_component.h
@@ -17,7 +17,8 @@ namespace erin
         Simulation& s,
         toml::table const& table,
         std::string const& tag,
-        ComponentValidationMap const& compValids
+        ComponentValidationMap const& compValids,
+        Log const& log
     );
 
     Result
@@ -25,7 +26,8 @@ namespace erin
         Simulation& s,
         toml::table const& table,
         ComponentValidationMap const& compValids,
-        std::unordered_set<std::string> const& componentTagsInUse
+        std::unordered_set<std::string> const& componentTagsInUse,
+        Log const& log
     );
 
 } // namespace erin

--- a/include/erin_next/erin_next_distribution.h
+++ b/include/erin_next/erin_next_distribution.h
@@ -5,6 +5,7 @@
 #define ERIN_DISTRIBUTION_H
 #include "erin_next/erin_next_valdata.h"
 #include "erin_next/erin_next_result.h"
+#include "erin/logging.h"
 #include "../vendor/toml11/toml.hpp"
 #include <chrono>
 #include <exception>
@@ -181,7 +182,8 @@ namespace erin
     ParseDistributions(
         DistributionSystem& ds,
         toml::table const& table,
-        DistributionValidationMap const& dvm
+        DistributionValidationMap const& dvm,
+        Log const& log
     );
 
 } // namespace erin

--- a/include/erin_next/erin_next_load.h
+++ b/include/erin_next/erin_next_load.h
@@ -37,7 +37,8 @@ namespace erin
     ParseLoads(
         toml::table const& table,
         ValidationInfo const& explicitValidation,
-        ValidationInfo const& fileValidation
+        ValidationInfo const& fileValidation,
+        Log const& log
     );
 
     std::ostream&

--- a/include/erin_next/erin_next_simulation.h
+++ b/include/erin_next/erin_next_simulation.h
@@ -244,7 +244,8 @@ namespace erin
         std::unordered_map<size_t, double> const& intensityIdToAmount,
         std::unordered_map<size_t, std::vector<TimeState>> const&
             relSchByCompId,
-        bool verbose
+        bool verbose,
+        Log const& log
     );
 
     std::vector<TimeAndFlows>

--- a/include/erin_next/erin_next_simulation.h
+++ b/include/erin_next/erin_next_simulation.h
@@ -175,7 +175,8 @@ namespace erin
     Simulation_ReadFromToml(
         toml::value const& v,
         InputValidationMap const& validationInfo,
-        std::unordered_set<std::string> const& componentTagsInUse
+        std::unordered_set<std::string> const& componentTagsInUse,
+        Log const& log = Log{}
     );
 
     void

--- a/include/erin_next/erin_next_simulation.h
+++ b/include/erin_next/erin_next_simulation.h
@@ -110,7 +110,8 @@ namespace erin
     Simulation_ParseSimulationInfo(
         Simulation& s,
         toml::value const& v,
-        ValidationInfo const& validationInfo
+        ValidationInfo const& validationInfo,
+        Log const& log
     );
 
     Result

--- a/include/erin_next/erin_next_simulation.h
+++ b/include/erin_next/erin_next_simulation.h
@@ -201,8 +201,7 @@ namespace erin
     std::vector<double>
     DetermineScenarioOccurrenceTimes(
         Simulation& s,
-        size_t scenIdx,
-        bool isVerbose
+        size_t scenIdx
     );
 
     std::unordered_map<size_t, double>

--- a/include/erin_next/erin_next_simulation.h
+++ b/include/erin_next/erin_next_simulation.h
@@ -199,10 +199,7 @@ namespace erin
     );
 
     std::vector<double>
-    DetermineScenarioOccurrenceTimes(
-        Simulation& s,
-        size_t scenIdx
-    );
+    DetermineScenarioOccurrenceTimes(Simulation& s, size_t scenIdx);
 
     std::unordered_map<size_t, double>
     GetIntensitiesForScenario(Simulation& s, size_t scenIdx);

--- a/include/erin_next/erin_next_simulation.h
+++ b/include/erin_next/erin_next_simulation.h
@@ -150,27 +150,48 @@ namespace erin
     );
 
     Result
-    Simulation_ParseFragilityCurves(Simulation& s, std::string const& v);
+    Simulation_ParseFragilityCurves(
+        Simulation& s,
+        std::string const& v,
+        Log const& log
+    );
 
     Result
-    Simulation_ParseFragilityModes(Simulation& s, toml::value const& v);
+    Simulation_ParseFragilityModes(
+        Simulation& s,
+        toml::value const& v,
+        Log const& log
+    );
 
     Result
     Simulation_ParseComponents(
         Simulation& s,
         toml::value const& v,
         ComponentValidationMap const& compValidations,
-        std::unordered_set<std::string> const& componentTagsInUse
+        std::unordered_set<std::string> const& componentTagsInUse,
+        Log const& log
     );
 
     Result
-    Simulation_ParseDistributions(Simulation& s, toml::value const& v);
+    Simulation_ParseDistributions(
+        Simulation& s,
+        toml::value const& v,
+        Log const& log
+    );
 
     Result
-    Simulation_ParseNetwork(Simulation& s, toml::value const& v);
+    Simulation_ParseNetwork(
+        Simulation& s,
+        toml::value const& v,
+        Log const& log
+    );
 
     Result
-    Simulation_ParseScenarios(Simulation& s, toml::value const& v);
+    Simulation_ParseScenarios(
+        Simulation& s,
+        toml::value const& v,
+        Log const& log
+    );
 
     std::optional<Simulation>
     Simulation_ReadFromToml(
@@ -280,7 +301,11 @@ namespace erin
     );
 
     Result
-    Simulation_ParseFailureModes(Simulation& s, toml::value const& v);
+    Simulation_ParseFailureModes(
+        Simulation& s,
+        toml::value const& v,
+        Log const& log
+    );
 
     Result
     Simulation_ParseLinearFragilityCurve(

--- a/include/erin_next/erin_next_simulation.h
+++ b/include/erin_next/erin_next_simulation.h
@@ -4,12 +4,14 @@
 #define ERIN_SIMULATION_H
 
 #include "erin_next/erin_next.h"
+#include "erin/logging.h"
 #include "erin_next/erin_next_distribution.h"
 #include "erin_next/erin_next_simulation_info.h"
 #include "erin_next/erin_next_load.h"
 #include "erin_next/erin_next_scenario.h"
 #include "erin_next/erin_next_result.h"
 #include "../vendor/toml11/toml.hpp"
+#include "../vendor/courier/include/courier/courier.h"
 #include "erin_next/erin_next_validation.h"
 #include <string>
 #include <vector>
@@ -257,6 +259,7 @@ namespace erin
     void
     Simulation_Run(
         Simulation& s,
+        Log& log,
         std::string const& eventsFilename,
         std::string const& statsFilename = "stats.csv",
         double time_step_h = -1.0,

--- a/include/erin_next/erin_next_timestate.h
+++ b/include/erin_next/erin_next_timestate.h
@@ -72,6 +72,9 @@ namespace erin
     void
     TimeState_Print(std::vector<TimeState> const& tss);
 
+    std::string
+    TimeState_ToString(TimeState const& ts);
+
 } // namespace erin
 
 #endif

--- a/include/erin_next/erin_next_toml.h
+++ b/include/erin_next/erin_next_toml.h
@@ -4,6 +4,7 @@
 #define ERIN_TOML_H
 #include "erin_next/erin_next_valdata.h"
 #include "erin_next/erin_next_time_and_amount.h"
+#include "erin/logging.h"
 #include "../vendor/toml11/toml.hpp"
 #include <vector>
 #include <unordered_map>
@@ -24,6 +25,7 @@ namespace erin
         std::vector<std::string>& warnings
     );
 
+    // TODO: remove, this function is apparently not used
     // TODO: create struct to hold if tag/name is deprecated
     // struct TagWithDeprecation {string Name; bool IsDeprecated;}
     // TODO: add aliases std::unordered_map<std::string,
@@ -38,7 +40,8 @@ namespace erin
         std::unordered_set<std::string> const& optionalFields,
         std::unordered_map<std::string, std::string> const& defaults,
         std::string const& tableName,
-        bool doPrint = false
+        bool verbose = false,
+        Log const& log = Log{}
     );
 
     std::optional<std::string>

--- a/include/erin_next/erin_next_utils.h
+++ b/include/erin_next/erin_next_utils.h
@@ -119,7 +119,11 @@ namespace erin
     WriteErrorMessage(std::string const& tag, std::string const& message);
 
     std::string
-    WriteTaggedCategoryToString(std::string const& category, std::string const& tag, std::string const& message);
+    WriteTaggedCategoryToString(
+        std::string const& category,
+        std::string const& tag,
+        std::string const& message
+    );
 
     std::string
     WriteWarningToString(std::string const& tag, std::string const& message);

--- a/include/erin_next/erin_next_utils.h
+++ b/include/erin_next/erin_next_utils.h
@@ -106,10 +106,20 @@ namespace erin
     TimeInSecondsToHours(uint64_t time_seconds);
 
     void
+    WriteTaggedCategoryMessage(
+        std::string const& category,
+        std::string const& tag,
+        std::string const& message
+    );
+
+    void
     WriteWarningMessage(std::string const& tag, std::string const& message);
 
     void
     WriteErrorMessage(std::string const& tag, std::string const& message);
+
+    std::string
+    WriteTaggedCategoryToString(std::string const& category, std::string const& tag, std::string const& message);
 
     std::string
     WriteWarningToString(std::string const& tag, std::string const& message);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,6 +27,7 @@ if (${CMAKE_PROJECT_NAME}_COVERAGE)
 endif()
 
 add_library(erin_next
+  erin_logging.cpp
 	erin_next.cpp
 	erin_next_distribution.cpp
 	erin_next_reliability.cpp
@@ -45,6 +46,7 @@ add_library(erin_next
 	erin_next_validation.cpp
 	erin_next_graph.cpp
 	erin_next_lookup_table.cpp
+	"${PROJECT_SOURCE_DIR}/include/erin/logging.h"
 	"${PROJECT_SOURCE_DIR}/include/erin_next/erin_next.h"
 	"${PROJECT_SOURCE_DIR}/include/erin_next/erin_next_valdata.h"
 	"${PROJECT_SOURCE_DIR}/include/erin_next/erin_next_distribution.h"
@@ -67,7 +69,9 @@ add_library(erin_next
 	"${PROJECT_SOURCE_DIR}/include/erin_next/erin_next_lookup_table.h"
 )
 
-target_link_libraries(erin_next PRIVATE fmt)
+target_link_libraries(erin_next
+  PRIVATE courier fmt
+)
 
 # Add Warnings
 if(MSVC)

--- a/src/erin_logging.cpp
+++ b/src/erin_logging.cpp
@@ -1,0 +1,171 @@
+/* Copyright (c) 2024 Big Ladder Software LLC. All rights reserved.
+ * See the LICENSE.txt file for additional terms and conditions. */
+#include "erin/logging.h"
+
+namespace erin
+{
+  unsigned int
+  LogLevel_ToInt(LogLevel ll)
+  {
+    switch (ll)
+    {
+      case LogLevel::Debug:
+        return 0;
+      case LogLevel::Info:
+        return 1;
+      case LogLevel::Warning:
+        return 2;
+      case LogLevel::Error:
+        return 3;
+    }
+    std::cout << "Error: unhandled log level" << std::endl;
+    std::exit(1);
+  }
+
+  bool
+  ContinueLogging(LogLevel incoming, LogLevel reference)
+  {
+    return LogLevel_ToInt(incoming) >= LogLevel_ToInt(reference);
+  }
+  
+  Log
+  Log_MakeFromCourier(Courier::Courier& courier)
+  {
+    return Log {
+      .debug = [&](std::string const& tag, std::string const& msg) {
+        if (!tag.empty())
+        {
+          courier.send_debug(fmt::format("{}: {}", tag, msg));
+        }
+        else
+        {
+          courier.send_debug(msg);
+        }
+      },
+      .info = [&](std::string const& tag, std::string const& msg) {
+        if (!tag.empty())
+        {
+          courier.send_info(fmt::format("{}: {}", tag, msg));
+        }
+        else
+        {
+          courier.send_info(msg);
+        }
+      },
+      .warning = [&](std::string const& tag, std::string const& msg) {
+        if (!tag.empty())
+        {
+          courier.send_warning(fmt::format("{}: {}", tag, msg));
+        }
+        else
+        {
+          courier.send_warning(msg);
+        }
+      },
+      .error = [&](std::string const& tag, std::string const& msg) {
+        if (!tag.empty())
+        {
+          courier.send_error(fmt::format("{}: {}", tag, msg));
+        }
+        else
+        {
+          courier.send_error(msg);
+        }
+      },
+    };
+  }
+
+  void
+  Log_General(Log const& log, LogLevel ll, std::string const& msg)
+  {
+    Log_General(log, ll, "", msg);
+  }
+  
+  void
+  Log_General(Log const& log, LogLevel ll, std::string const& tag, std::string const& msg)
+  {
+    if (!ContinueLogging(ll, log.LogLevel))
+    {
+      return;
+    }
+    std::optional<std::function<void(std::string const&,std::string const&)>>
+      maybeFn = {};
+    switch (ll)
+    {
+      case LogLevel::Debug:
+        {
+          maybeFn = log.debug;
+        } break;
+      case LogLevel::Info:
+        {
+          maybeFn = log.info;
+        } break;
+      case LogLevel::Warning:
+        {
+          maybeFn = log.warning;
+        } break;
+      case LogLevel::Error:
+        {
+          maybeFn = log.error;
+        } break;
+      default:
+        {
+          std::cout << "Unhandled logging level" << std::endl;
+          std::exit(1);
+        }
+    }
+    if (maybeFn.has_value())
+    {
+      std::function<void(std::string const&,std::string const&)> f = maybeFn.value();
+      f(tag, msg);
+    }
+  }
+
+  void
+  Log_Debug(Log const& log, std::string const& msg)
+  {
+    Log_General(log, LogLevel::Debug, msg);
+  }
+
+  void
+  Log_Debug(Log const& log, std::string const& tag, std::string const& msg)
+  {
+    Log_General(log, LogLevel::Debug, tag, msg);
+  }
+
+  void
+  Log_Info(Log const& log, std::string const& msg)
+  {
+    Log_General(log, LogLevel::Info, msg);
+  }
+
+  void
+  Log_Info(Log const& log, std::string const& tag, std::string const& msg)
+  {
+    Log_General(log, LogLevel::Info, tag, msg);
+  }
+
+  void
+  Log_Warning(Log const& log, std::string const& msg)
+  {
+    Log_General(log, LogLevel::Warning, msg);
+  }
+
+  void
+  Log_Warning(Log const& log, std::string const& tag, std::string const& msg)
+  {
+    Log_General(log, LogLevel::Warning, tag, msg);
+  }
+
+  void
+  Log_Error(Log const& log, std::string const& msg)
+  {
+    Log_General(log, LogLevel::Error, msg);
+  }
+
+  void
+  Log_Error(Log const& log, std::string const& tag, std::string const& msg)
+  {
+    Log_General(log, LogLevel::Error, tag, msg);
+  }
+}

--- a/src/erin_logging.cpp
+++ b/src/erin_logging.cpp
@@ -4,168 +4,187 @@
 
 namespace erin
 {
-  unsigned int
-  LogLevel_ToInt(LogLevel ll)
-  {
-    switch (ll)
+    unsigned int
+    LogLevel_ToInt(LogLevel ll)
     {
-      case LogLevel::Debug:
-        return 0;
-      case LogLevel::Info:
-        return 1;
-      case LogLevel::Warning:
-        return 2;
-      case LogLevel::Error:
-        return 3;
+        switch (ll)
+        {
+            case LogLevel::Debug:
+                return 0;
+            case LogLevel::Info:
+                return 1;
+            case LogLevel::Warning:
+                return 2;
+            case LogLevel::Error:
+                return 3;
+        }
+        std::cout << "Error: unhandled log level" << std::endl;
+        std::exit(1);
     }
-    std::cout << "Error: unhandled log level" << std::endl;
-    std::exit(1);
-  }
 
-  bool
-  ContinueLogging(LogLevel incoming, LogLevel reference)
-  {
-    return LogLevel_ToInt(incoming) >= LogLevel_ToInt(reference);
-  }
-  
-  Log
-  Log_MakeFromCourier(Courier::Courier& courier)
-  {
-    return Log {
-      .debug = [&](std::string const& tag, std::string const& msg) {
-        if (!tag.empty())
-        {
-          courier.send_debug(fmt::format("{}: {}", tag, msg));
-        }
-        else
-        {
-          courier.send_debug(msg);
-        }
-      },
-      .info = [&](std::string const& tag, std::string const& msg) {
-        if (!tag.empty())
-        {
-          courier.send_info(fmt::format("{}: {}", tag, msg));
-        }
-        else
-        {
-          courier.send_info(msg);
-        }
-      },
-      .warning = [&](std::string const& tag, std::string const& msg) {
-        if (!tag.empty())
-        {
-          courier.send_warning(fmt::format("{}: {}", tag, msg));
-        }
-        else
-        {
-          courier.send_warning(msg);
-        }
-      },
-      .error = [&](std::string const& tag, std::string const& msg) {
-        if (!tag.empty())
-        {
-          courier.send_error(fmt::format("{}: {}", tag, msg));
-        }
-        else
-        {
-          courier.send_error(msg);
-        }
-      },
-    };
-  }
-
-  void
-  Log_General(Log const& log, LogLevel ll, std::string const& msg)
-  {
-    Log_General(log, ll, "", msg);
-  }
-  
-  void
-  Log_General(Log const& log, LogLevel ll, std::string const& tag, std::string const& msg)
-  {
-    if (!ContinueLogging(ll, log.LogLevel))
+    bool
+    ContinueLogging(LogLevel incoming, LogLevel reference)
     {
-      return;
+        return LogLevel_ToInt(incoming) >= LogLevel_ToInt(reference);
     }
-    std::optional<std::function<void(std::string const&,std::string const&)>>
-      maybeFn = {};
-    switch (ll)
+
+    Log
+    Log_MakeFromCourier(Courier::Courier& courier)
     {
-      case LogLevel::Debug:
+        return Log{
+            .debug =
+                [&](std::string const& tag, std::string const& msg)
+            {
+                if (!tag.empty())
+                {
+                    courier.send_debug(fmt::format("{}: {}", tag, msg));
+                }
+                else
+                {
+                    courier.send_debug(msg);
+                }
+            },
+            .info =
+                [&](std::string const& tag, std::string const& msg)
+            {
+                if (!tag.empty())
+                {
+                    courier.send_info(fmt::format("{}: {}", tag, msg));
+                }
+                else
+                {
+                    courier.send_info(msg);
+                }
+            },
+            .warning =
+                [&](std::string const& tag, std::string const& msg)
+            {
+                if (!tag.empty())
+                {
+                    courier.send_warning(fmt::format("{}: {}", tag, msg));
+                }
+                else
+                {
+                    courier.send_warning(msg);
+                }
+            },
+            .error =
+                [&](std::string const& tag, std::string const& msg)
+            {
+                if (!tag.empty())
+                {
+                    courier.send_error(fmt::format("{}: {}", tag, msg));
+                }
+                else
+                {
+                    courier.send_error(msg);
+                }
+            },
+        };
+    }
+
+    void
+    Log_General(Log const& log, LogLevel ll, std::string const& msg)
+    {
+        Log_General(log, ll, "", msg);
+    }
+
+    void
+    Log_General(
+        Log const& log,
+        LogLevel ll,
+        std::string const& tag,
+        std::string const& msg
+    )
+    {
+        if (!ContinueLogging(ll, log.LogLevel))
         {
-          maybeFn = log.debug;
-        } break;
-      case LogLevel::Info:
+            return;
+        }
+        std::optional<
+            std::function<void(std::string const&, std::string const&)>>
+            maybeFn = {};
+        switch (ll)
         {
-          maybeFn = log.info;
-        } break;
-      case LogLevel::Warning:
+            case LogLevel::Debug:
+            {
+                maybeFn = log.debug;
+            }
+            break;
+            case LogLevel::Info:
+            {
+                maybeFn = log.info;
+            }
+            break;
+            case LogLevel::Warning:
+            {
+                maybeFn = log.warning;
+            }
+            break;
+            case LogLevel::Error:
+            {
+                maybeFn = log.error;
+            }
+            break;
+            default:
+            {
+                std::cout << "Unhandled logging level" << std::endl;
+                std::exit(1);
+            }
+        }
+        if (maybeFn.has_value())
         {
-          maybeFn = log.warning;
-        } break;
-      case LogLevel::Error:
-        {
-          maybeFn = log.error;
-        } break;
-      default:
-        {
-          std::cout << "Unhandled logging level" << std::endl;
-          std::exit(1);
+            std::function<void(std::string const&, std::string const&)> f =
+                maybeFn.value();
+            f(tag, msg);
         }
     }
-    if (maybeFn.has_value())
+
+    void
+    Log_Debug(Log const& log, std::string const& msg)
     {
-      std::function<void(std::string const&,std::string const&)> f = maybeFn.value();
-      f(tag, msg);
+        Log_General(log, LogLevel::Debug, msg);
     }
-  }
 
-  void
-  Log_Debug(Log const& log, std::string const& msg)
-  {
-    Log_General(log, LogLevel::Debug, msg);
-  }
+    void
+    Log_Debug(Log const& log, std::string const& tag, std::string const& msg)
+    {
+        Log_General(log, LogLevel::Debug, tag, msg);
+    }
 
-  void
-  Log_Debug(Log const& log, std::string const& tag, std::string const& msg)
-  {
-    Log_General(log, LogLevel::Debug, tag, msg);
-  }
+    void
+    Log_Info(Log const& log, std::string const& msg)
+    {
+        Log_General(log, LogLevel::Info, msg);
+    }
 
-  void
-  Log_Info(Log const& log, std::string const& msg)
-  {
-    Log_General(log, LogLevel::Info, msg);
-  }
+    void
+    Log_Info(Log const& log, std::string const& tag, std::string const& msg)
+    {
+        Log_General(log, LogLevel::Info, tag, msg);
+    }
 
-  void
-  Log_Info(Log const& log, std::string const& tag, std::string const& msg)
-  {
-    Log_General(log, LogLevel::Info, tag, msg);
-  }
+    void
+    Log_Warning(Log const& log, std::string const& msg)
+    {
+        Log_General(log, LogLevel::Warning, msg);
+    }
 
-  void
-  Log_Warning(Log const& log, std::string const& msg)
-  {
-    Log_General(log, LogLevel::Warning, msg);
-  }
+    void
+    Log_Warning(Log const& log, std::string const& tag, std::string const& msg)
+    {
+        Log_General(log, LogLevel::Warning, tag, msg);
+    }
 
-  void
-  Log_Warning(Log const& log, std::string const& tag, std::string const& msg)
-  {
-    Log_General(log, LogLevel::Warning, tag, msg);
-  }
+    void
+    Log_Error(Log const& log, std::string const& msg)
+    {
+        Log_General(log, LogLevel::Error, msg);
+    }
 
-  void
-  Log_Error(Log const& log, std::string const& msg)
-  {
-    Log_General(log, LogLevel::Error, msg);
-  }
-
-  void
-  Log_Error(Log const& log, std::string const& tag, std::string const& msg)
-  {
-    Log_General(log, LogLevel::Error, tag, msg);
-  }
+    void
+    Log_Error(Log const& log, std::string const& tag, std::string const& msg)
+    {
+        Log_General(log, LogLevel::Error, tag, msg);
+    }
 }

--- a/src/erin_logging.cpp
+++ b/src/erin_logging.cpp
@@ -97,7 +97,7 @@ namespace erin
         std::string const& msg
     )
     {
-        if (!ContinueLogging(ll, log.LogLevel))
+        if (!ContinueLogging(ll, log.log_level))
         {
             return;
         }

--- a/src/erin_next.cpp
+++ b/src/erin_next.cpp
@@ -2972,26 +2972,32 @@ namespace erin
     FlowsToStrings(Model const& m, SimulationState const& ss, double time_s)
     {
         std::vector<std::string> result{};
-        result.push_back(
-            fmt::format("time: {} s, {}, {} h",
-                time_s,
-                TimeToISO8601Period(static_cast<uint64_t>(time_s)),
-                TimeInSecondsToHours(static_cast<uint64_t>(time_s))));
+        result.push_back(fmt::format(
+            "time: {} s, {}, {} h",
+            time_s,
+            TimeToISO8601Period(static_cast<uint64_t>(time_s)),
+            TimeInSecondsToHours(static_cast<uint64_t>(time_s))
+        ));
         for (size_t flowIdx = 0; flowIdx < ss.Flows.size(); ++flowIdx)
         {
-            result.push_back(
-                fmt::format(
-                    "{}: {} (R: {}; A: {})",
-                    ConnectionToString(m.ComponentMap, m.Connections[flowIdx]),
-                    ss.Flows[flowIdx].Actual_W,
-                    ss.Flows[flowIdx].Requested_W,
-                    ss.Flows[flowIdx].Available_W));
+            result.push_back(fmt::format(
+                "{}: {} (R: {}; A: {})",
+                ConnectionToString(m.ComponentMap, m.Connections[flowIdx]),
+                ss.Flows[flowIdx].Actual_W,
+                ss.Flows[flowIdx].Requested_W,
+                ss.Flows[flowIdx].Available_W
+            ));
         }
         return result;
     }
 
     void
-    LogFlows(Log const& log, Model const& m, SimulationState const& ss, double time_s)
+    LogFlows(
+        Log const& log,
+        Model const& m,
+        SimulationState const& ss,
+        double time_s
+    )
     {
         for (std::string const& s : FlowsToStrings(m, ss, time_s))
         {
@@ -3538,10 +3544,15 @@ namespace erin
                         }
                         if (item.second != 0)
                         {
-                            Log_Warning(log,
-                                fmt::format("{} doesn't have a zero sum of all flows: {} W",
+                            Log_Warning(
+                                log,
+                                fmt::format(
+                                    "{} doesn't have a zero sum of all flows: "
+                                    "{} W",
                                     model.ComponentMap.Tag[item.first],
-                                    item.second));
+                                    item.second
+                                )
+                            );
                         }
                     }
                 }

--- a/src/erin_next_distribution.cpp
+++ b/src/erin_next_distribution.cpp
@@ -784,7 +784,7 @@ namespace erin
                     }
                     break;
                 }
-                if (errors.size() > 0)
+                if (!errors.empty())
                 {
                     for (std::string const& err : errors)
                     {

--- a/src/erin_next_distribution.cpp
+++ b/src/erin_next_distribution.cpp
@@ -675,7 +675,8 @@ namespace erin
     ParseDistributions(
         DistributionSystem& ds,
         toml::table const& table,
-        DistributionValidationMap const& dvm
+        DistributionValidationMap const& dvm,
+        Log const& log
     )
     {
         for (auto it = table.cbegin(); it != table.cend(); ++it)
@@ -687,8 +688,8 @@ namespace erin
                 toml::table distTable = it->second.as_table();
                 if (!distTable.contains("type"))
                 {
-                    WriteErrorMessage(
-                        fullTableName, "missing required field 'type'"
+                    Log_Error(
+                        log, fullTableName, "missing required field 'type'"
                     );
                     return Result::Failure;
                 }
@@ -697,7 +698,8 @@ namespace erin
                     tag_to_dist_type(distTypeTag);
                 if (!maybeDistType.has_value())
                 {
-                    WriteErrorMessage(
+                    Log_Error(
+                        log,
                         fullTableName,
                         "unhandled distribution type '" + distTypeTag + "'"
                     );
@@ -779,7 +781,7 @@ namespace erin
                     break;
                     default:
                     {
-                        WriteErrorMessage(fullTableName, "unhandled dist type");
+                        Log_Error(log, fullTableName, "unhandled dist type");
                         return Result::Failure;
                     }
                     break;
@@ -788,13 +790,13 @@ namespace erin
                 {
                     for (std::string const& err : errors)
                     {
-                        WriteErrorMessage("", err);
+                        Log_Error(log, err);
                     }
                     return Result::Failure;
                 }
                 for (std::string const& w : warnings)
                 {
-                    WriteErrorMessage("", w);
+                    Log_Warning(log, w);
                 }
                 // TODO: pull default time from SimulationInfo
                 TimeUnit timeUnit = TimeUnit::Second;
@@ -806,7 +808,8 @@ namespace erin
                         TagToTimeUnit(timeUnitStr);
                     if (!maybeTimeUnit.has_value())
                     {
-                        WriteErrorMessage(
+                        Log_Error(
+                            log,
                             fullTableName,
                             "unhandled time unit '" + timeUnitStr + "'"
                         );
@@ -925,7 +928,8 @@ namespace erin
                             }
                             else
                             {
-                                WriteErrorMessage(
+                                Log_Error(
+                                    log,
                                     fullTableName,
                                     "csv file '" + csvFileName
                                         + "'"
@@ -938,7 +942,8 @@ namespace erin
                         }
                         else
                         {
-                            WriteErrorMessage(
+                            Log_Error(
+                                log,
                                 fullTableName,
                                 "need one of 'variate_time_pairs' or 'csv_file'"
                             );
@@ -982,7 +987,8 @@ namespace erin
                     break;
                     default:
                     {
-                        WriteErrorMessage(
+                        Log_Error(
+                            log,
                             "distribution",
                             "unhandled distribution type: " + distTypeTag
                         );

--- a/src/erin_next_load.cpp
+++ b/src/erin_next_load.cpp
@@ -427,7 +427,8 @@ namespace erin
     ParseLoads(
         toml::table const& table,
         ValidationInfo const& explicitValidation,
-        ValidationInfo const& fileValidation
+        ValidationInfo const& fileValidation,
+        Log const& log
     )
     {
         std::vector<Load> loads{};
@@ -450,14 +451,14 @@ namespace erin
                     maybeLoad = ParseSingleLoadExplicit(explicitLoadTable, tag);
                     if (!maybeLoad.has_value())
                     {
-                        WriteErrorMessage(tableName, "unable to load");
+                        Log_Error(log, tableName, "unable to load");
                         return {};
                     }
                     if (warnings01.size() > 0)
                     {
                         for (auto const& w : warnings01)
                         {
-                            WriteErrorMessage(tableName, w);
+                            Log_Warning(log, tableName, w);
                         }
                     }
                     if (maybeLoad.has_value())
@@ -488,8 +489,10 @@ namespace erin
                             }
                             else
                             {
-                                WriteErrorMessage(
-                                    tableName, "single load did not have value"
+                                Log_Error(
+                                    log,
+                                    tableName,
+                                    "single load did not have value"
                                 );
                                 return {};
                             }
@@ -508,7 +511,8 @@ namespace erin
                                 }
                                 else
                                 {
-                                    WriteErrorMessage(
+                                    Log_Error(
+                                        log,
                                         tableName,
                                         "multi-part load did not have value"
                                     );
@@ -521,7 +525,7 @@ namespace erin
             }
             else
             {
-                WriteErrorMessage(tableName, "is not a table");
+                Log_Error(log, tableName, "not a table");
                 return {};
             }
         }

--- a/src/erin_next_simulation.cpp
+++ b/src/erin_next_simulation.cpp
@@ -1347,7 +1347,8 @@ namespace erin
     Simulation_ReadFromToml(
         toml::value const& v,
         InputValidationMap const& validationInfo,
-        std::unordered_set<std::string> const& componentTagsInUse
+        std::unordered_set<std::string> const& componentTagsInUse,
+        Log const& log
     )
     {
         Simulation s = {};
@@ -1356,7 +1357,7 @@ namespace erin
             Simulation_ParseSimulationInfo(s, v, validationInfo.SimulationInfo);
         if (simInfoResult == Result::Failure)
         {
-            WriteErrorMessage("simulation_info", "problem parsing...");
+            Log_Error(log, "simulation_info", "problem parsing...");
             return {};
         }
         auto loadsResult = Simulation_ParseLoads(
@@ -1367,7 +1368,7 @@ namespace erin
         );
         if (loadsResult == Result::Failure)
         {
-            WriteErrorMessage("loads", "problem parsing...");
+            Log_Error(log, "loads", "problem parsing...");
             return {};
         }
         auto compResult = Simulation_ParseComponents(
@@ -1375,39 +1376,39 @@ namespace erin
         );
         if (compResult == Result::Failure)
         {
-            WriteErrorMessage("components", "problem parsing...");
+            Log_Error(log, "components", "problem parsing...");
             return {};
         }
         auto distResult =
             Simulation_ParseDistributions(s, v, validationInfo.Dist);
         if (distResult == Result::Failure)
         {
-            WriteErrorMessage("dist", "problem parsing...");
+            Log_Error(log, "dist", "problem parsing...");
             return {};
         }
         if (Simulation_ParseFailureModes(s, v) == Result::Failure)
         {
-            WriteErrorMessage("failure_mode", "problem parsing...");
+            Log_Error(log, "failure_mode", "problem parsing...");
             return {};
         }
         if (Simulation_ParseFragilityModes(s, v) == Result::Failure)
         {
-            WriteErrorMessage("fragility_mode", "problem parsing...");
+            Log_Error(log, "fragility_mode", "problem parsing...");
             return {};
         }
         if (Simulation_ParseNetwork(s, v) == Result::Failure)
         {
-            WriteErrorMessage("network", "problem parsing...");
+            Log_Error(log, "network", "problem parsing...");
             return {};
         }
         if (Simulation_ParseScenarios(s, v) == Result::Failure)
         {
-            WriteErrorMessage("scenarios", "problem parsing...");
+            Log_Error(log, "scenarios", "problem parsing...");
             return {};
         }
         if (Simulation_ParseFragilityCurves(s, v) == Result::Failure)
         {
-            WriteErrorMessage("fragility_curve", "problem parsing...");
+            Log_Error(log, "fragility_curve", "problem parsing...");
             return {};
         }
         return s;

--- a/src/erin_next_simulation.cpp
+++ b/src/erin_next_simulation.cpp
@@ -666,12 +666,14 @@ namespace erin
     Simulation_ParseSimulationInfo(
         Simulation& s,
         toml::value const& v,
-        ValidationInfo const& validationInfo
+        ValidationInfo const& validationInfo,
+        Log const& log
     )
     {
         if (!v.contains("simulation_info"))
         {
-            WriteErrorMessage(
+            Log_Error(
+                log,
                 "simulation_info",
                 "Required section [simulation_info] not found"
             );
@@ -680,7 +682,8 @@ namespace erin
         toml::value const& simInfoValue = v.at("simulation_info");
         if (!simInfoValue.is_table())
         {
-            WriteErrorMessage(
+            Log_Error(
+                log,
                 "simulation_info",
                 "Required section [simulation_info] is not a table"
             );
@@ -697,20 +700,18 @@ namespace erin
                 errors,
                 warnings
             );
-        if (warnings.size() > 0)
+        if (!warnings.empty())
         {
-            std::cout << "WARNINGS:" << std::endl;
             for (auto const& w : warnings)
             {
-                std::cerr << w << std::endl;
+                Log_Warning(log, w);
             }
         }
-        if (errors.size() > 0)
+        if (!errors.empty())
         {
-            std::cout << "ERRORS:" << std::endl;
             for (auto const& err : errors)
             {
-                std::cerr << err << std::endl;
+                Log_Error(log, err);
             }
             return Result::Failure;
         }
@@ -1353,8 +1354,9 @@ namespace erin
     {
         Simulation s = {};
         Simulation_Init(s);
-        auto simInfoResult =
-            Simulation_ParseSimulationInfo(s, v, validationInfo.SimulationInfo);
+        auto simInfoResult = Simulation_ParseSimulationInfo(
+            s, v, validationInfo.SimulationInfo, log
+        );
         if (simInfoResult == Result::Failure)
         {
             Log_Error(log, "simulation_info", "problem parsing...");

--- a/src/erin_next_simulation.cpp
+++ b/src/erin_next_simulation.cpp
@@ -1274,7 +1274,7 @@ namespace erin
         {
             // TODO: have ParseDistributions return a Result
             return ParseDistributions(
-                s.TheModel.DistSys, v.at("dist").as_table(), dvm
+                s.TheModel.DistSys, v.at("dist").as_table(), dvm, log
             );
         }
         Log_Error(log, "required field 'dist' not found");

--- a/src/erin_next_simulation.cpp
+++ b/src/erin_next_simulation.cpp
@@ -2090,8 +2090,7 @@ namespace erin
     std::vector<double>
     DetermineScenarioOccurrenceTimes(
         Simulation& s,
-        size_t scenIdx,
-        bool isVerbose
+        size_t scenIdx
     )
     {
         std::vector<double> occurrenceTimes_s;
@@ -2110,17 +2109,6 @@ namespace erin
                 break;
             }
             occurrenceTimes_s.push_back(scenarioStartTime_s);
-        }
-        if (isVerbose)
-        {
-            std::cout << "Occurrences: " << occurrenceTimes_s.size()
-                      << std::endl;
-            for (size_t i = 0; i < occurrenceTimes_s.size(); ++i)
-            {
-                std::cout << "-- "
-                          << SecondsToPrettyString(occurrenceTimes_s[i])
-                          << std::endl;
-            }
         }
         return occurrenceTimes_s;
     }
@@ -3152,7 +3140,7 @@ namespace erin
             // for (size_t sbsIdx = 0; sbsIdx < s.Model.ScheduleSrcs.size();
             // ++sbsIdx) {/* ... */}
             std::vector<double> occurrenceTimes_s =
-                DetermineScenarioOccurrenceTimes(s, scenIdx, verbose);
+                DetermineScenarioOccurrenceTimes(s, scenIdx);
             if (verbose)
             {
                 Log_Debug(
@@ -3281,7 +3269,7 @@ namespace erin
                 // TODO: add an optional verbosity flag to SimInfo
                 // -- use that to set things like the print flag below
 
-                auto results = Simulate(s.TheModel, verbose);
+                auto results = Simulate(s.TheModel, verbose, true, log);
                 {
                     auto* output_results = &results;
                     std::vector<TimeAndFlows> modified_results0 = {};

--- a/src/erin_next_simulation.cpp
+++ b/src/erin_next_simulation.cpp
@@ -2088,10 +2088,7 @@ namespace erin
     }
 
     std::vector<double>
-    DetermineScenarioOccurrenceTimes(
-        Simulation& s,
-        size_t scenIdx
-    )
+    DetermineScenarioOccurrenceTimes(Simulation& s, size_t scenIdx)
     {
         std::vector<double> occurrenceTimes_s;
         auto const& maybeMaxOccurrences = s.ScenarioMap.MaxOccurrences[scenIdx];
@@ -2173,8 +2170,8 @@ namespace erin
     {
         std::vector<std::string> result{};
         result.push_back(
-            fmt::format("ScheduleBasedReliability vector size: {}",
-                        sbrs.size()));
+            fmt::format("ScheduleBasedReliability vector size: {}", sbrs.size())
+        );
         for (ScheduleBasedReliability const& sbr : sbrs)
         {
             std::ostringstream oss{};
@@ -2191,9 +2188,11 @@ namespace erin
                 }
                 oss << "{" << ts.time << "," << ts.state << "}";
             }
-            result.push_back(
-                fmt::format("- {{ComponentId: {},TimeStates=[{}]}}",
-                            sbr.ComponentId, oss.str()));
+            result.push_back(fmt::format(
+                "- {{ComponentId: {},TimeStates=[{}]}}",
+                sbr.ComponentId,
+                oss.str()
+            ));
         }
         return result;
     }
@@ -2254,8 +2253,15 @@ namespace erin
             double initialAge_s = componentInitialAges_s[compId];
             if (verbose)
             {
-                Log_Info(log, fmt::format("component: {}", componentTags[compId]));
-                Log_Info(log, fmt::format("initial age (h): {}", (initialAge_s / seconds_per_hour)));
+                Log_Info(
+                    log, fmt::format("component: {}", componentTags[compId])
+                );
+                Log_Info(
+                    log,
+                    fmt::format(
+                        "initial age (h): {}", (initialAge_s / seconds_per_hour)
+                    )
+                );
             }
             std::vector<TimeState> clip = TimeState_Clip(
                 sch, startTime_s + initialAge_s, endTime_s + initialAge_s, true
@@ -2321,7 +2327,11 @@ namespace erin
                     break;
                     default:
                     {
-                        Log_Error(log, "fragility_curve", "unhandled fragility curve type");
+                        Log_Error(
+                            log,
+                            "fragility_curve",
+                            "unhandled fragility curve type"
+                        );
                         std::exit(1);
                     }
                     break;
@@ -2348,8 +2358,15 @@ namespace erin
                     size_t compId = componentFragilityComponentIds[cfmIdx];
                     if (verbose)
                     {
-                        Log_Debug(log, "fragility_curve",
-                                  fmt::format("component failed: {}; cause: {}", componentTags[compId], fragilityModeTags[fmId]));
+                        Log_Debug(
+                            log,
+                            "fragility_curve",
+                            fmt::format(
+                                "component failed: {}; cause: {}",
+                                componentTags[compId],
+                                fragilityModeTags[fmId]
+                            )
+                        );
                     }
                     // does the component have a reliability signal?
                     bool hasReliabilityAlready = false;
@@ -2375,7 +2392,13 @@ namespace erin
                         double randValue = randFn();
                         if (verbose)
                         {
-                            Log_Info(log, fmt::format("randValue for next time advance is: {}", randValue));
+                            Log_Info(
+                                log,
+                                fmt::format(
+                                    "randValue for next time advance is: {}",
+                                    randValue
+                                )
+                            );
                         }
                         double repairTime_s =
                             ds.next_time_advance(repId, randValue);
@@ -3078,7 +3101,11 @@ namespace erin
         out.open(eventsFilename);
         if (!out.good())
         {
-            Log_Warning(log, "file I/O", fmt::format("Could not open '{}' for writing", eventsFilename));
+            Log_Warning(
+                log,
+                "file I/O",
+                fmt::format("Could not open '{}' for writing", eventsFilename)
+            );
             return;
         }
 
@@ -3145,9 +3172,12 @@ namespace erin
             {
                 Log_Debug(
                     log,
-                    fmt::format("Calculated {} occurrence times for {}",
+                    fmt::format(
+                        "Calculated {} occurrence times for {}",
                         occurrenceTimes_s.size(),
-                        s.ScenarioMap.Tags[scenIdx]));
+                        s.ScenarioMap.Tags[scenIdx]
+                    )
+                );
             }
             // TODO: initialize total scenario stats (i.e.,
             // over all occurrences)
@@ -3177,10 +3207,15 @@ namespace erin
                     {
                         std::string const& tag =
                             s.TheModel.ComponentMap.Tag[pair.first];
-                        Log_Info(log, fmt::format("Schedule for {}[{}]", tag, pair.first));
+                        Log_Info(
+                            log,
+                            fmt::format("Schedule for {}[{}]", tag, pair.first)
+                        );
                         for (auto const& ts : pair.second)
                         {
-                            Log_Debug(log, fmt::format("- {}", TimeState_ToString(ts)));
+                            Log_Debug(
+                                log, fmt::format("- {}", TimeState_ToString(ts))
+                            );
                         }
                     }
                 }
@@ -3188,21 +3223,33 @@ namespace erin
                 double tEnd = t + scenarioDuration_s;
                 if (verbose)
                 {
-                    Log_Info(log, fmt::format("Occurrence #{} at {}",
-                                                 occIdx + 1,
-                                                 SecondsToPrettyString(t)));
-                    Log_Info(log,
-                                fmt::format(
-                                    "Scenario start time: {} h",
-                                    TimeInSecondsToHours(
-                                        static_cast<uint64_t>(scenarioOffset_s)
-                                    )));
-                    Log_Info(log,
-                                fmt::format("Scenario end time: {} h",
-                                    TimeInSecondsToHours(
-                                        static_cast<uint64_t>(scenarioOffset_s)
-                                        + static_cast<uint64_t>(scenarioDuration_s)
-                                    )));
+                    Log_Info(
+                        log,
+                        fmt::format(
+                            "Occurrence #{} at {}",
+                            occIdx + 1,
+                            SecondsToPrettyString(t)
+                        )
+                    );
+                    Log_Info(
+                        log,
+                        fmt::format(
+                            "Scenario start time: {} h",
+                            TimeInSecondsToHours(
+                                static_cast<uint64_t>(scenarioOffset_s)
+                            )
+                        )
+                    );
+                    Log_Info(
+                        log,
+                        fmt::format(
+                            "Scenario end time: {} h",
+                            TimeInSecondsToHours(
+                                static_cast<uint64_t>(scenarioOffset_s)
+                                + static_cast<uint64_t>(scenarioDuration_s)
+                            )
+                        )
+                    );
                 }
                 s.TheModel.Reliabilities.clear();
                 s.TheModel.Reliabilities = ApplyReliabilitiesAndFragilities(
@@ -3229,9 +3276,15 @@ namespace erin
                 );
                 if (verbose)
                 {
-                    Log_Info(log, fmt::format("Reliabilities for Scenario: {}", scenarioTag));
+                    Log_Info(
+                        log,
+                        fmt::format(
+                            "Reliabilities for Scenario: {}", scenarioTag
+                        )
+                    );
                     Log_Info(log, fmt::format("Occurrence #{}", occIdx + 1));
-                    for (std::string const& s : ReliabilitiesToStrings(s.TheModel.Reliabilities))
+                    for (std::string const& s :
+                         ReliabilitiesToStrings(s.TheModel.Reliabilities))
                     {
                         Log_Info(log, s);
                     }
@@ -3254,16 +3307,24 @@ namespace erin
                     TimeToISO8601Period(static_cast<uint64_t>(std::llround(t)));
                 if (verbose)
                 {
-                    Log_Info(log,
-                        fmt::format("Running {} from {} for {} {}",
+                    Log_Info(
+                        log,
+                        fmt::format(
+                            "Running {} from {} for {} {}",
                             s.ScenarioMap.Tags[scenIdx],
                             scenarioStartTimeTag,
                             s.ScenarioMap.Durations[scenIdx],
-                            TimeUnitToTag(s.ScenarioMap.TimeUnits[scenIdx])));
-                    Log_Info(log,
-                        fmt::format("time: {} to {}",
+                            TimeUnitToTag(s.ScenarioMap.TimeUnits[scenIdx])
+                        )
+                    );
+                    Log_Info(
+                        log,
+                        fmt::format(
+                            "time: {} to {}",
                             SecondsToPrettyString(t),
-                            SecondsToPrettyString(tEnd)));
+                            SecondsToPrettyString(tEnd)
+                        )
+                    );
                 }
                 s.TheModel.FinalTime = scenarioDuration_s;
                 // TODO: add an optional verbosity flag to SimInfo

--- a/src/erin_next_simulation.cpp
+++ b/src/erin_next_simulation.cpp
@@ -729,12 +729,13 @@ namespace erin
         Simulation& s,
         toml::value const& v,
         ValidationInfo const& explicitValidation,
-        ValidationInfo const& fileValidation
+        ValidationInfo const& fileValidation,
+        Log const& log
     )
     {
         toml::value const& loadTable = v.at("loads");
         auto maybeLoads = ParseLoads(
-            loadTable.as_table(), explicitValidation, fileValidation
+            loadTable.as_table(), explicitValidation, fileValidation, log
         );
         if (!maybeLoads.has_value())
         {
@@ -1366,7 +1367,8 @@ namespace erin
             s,
             v,
             validationInfo.Load_01Explicit,
-            validationInfo.Load_02FileBased
+            validationInfo.Load_02FileBased,
+            log
         );
         if (loadsResult == Result::Failure)
         {

--- a/src/erin_next_timestate.cpp
+++ b/src/erin_next_timestate.cpp
@@ -3,6 +3,7 @@
 #include "erin_next/erin_next_timestate.h"
 #include "erin_next/erin_next_utils.h"
 #include <assert.h>
+#include <sstream>
 
 namespace erin
 {
@@ -453,6 +454,14 @@ namespace erin
         {
             std::cout << "- " << ts << std::endl;
         }
+    }
+
+    std::string
+    TimeState_ToString(TimeState const& ts)
+    {
+        std::ostringstream oss;
+        oss << ts;
+        return oss.str();
     }
 
 } // namespace erin

--- a/src/erin_next_toml.cpp
+++ b/src/erin_next_toml.cpp
@@ -2,6 +2,7 @@
 #include "erin/logging.h"
 #include "erin_next/erin_next_utils.h"
 #include "erin_next/erin_next_validation.h"
+#include "fmt/format.h"
 #include <iostream>
 #include <sstream>
 #include <unordered_map>
@@ -35,7 +36,8 @@ namespace erin
                     std::ostringstream oss;
                     oss << "Duplicate field found '" << it->first << "' (for "
                         << key << ")";
-                    errors.push_back(WriteErrorToString(tableName, oss.str()));
+                    errors.push_back(fmt::format("{}: {}", tableName, oss.str())
+                    );
                     return out;
                 }
                 fieldsFound.insert(key);
@@ -59,7 +61,7 @@ namespace erin
                                 oss << "Duplicate field found '" << it->first
                                     << "' (for " << key << ")";
                                 errors.push_back(
-                                    WriteErrorToString(tableName, oss.str())
+                                    fmt::format("{}: {}", tableName, oss.str())
                                 );
                                 return out;
                             }
@@ -67,7 +69,7 @@ namespace erin
                             if (aliasValue.IsDeprecated)
                             {
                                 std::ostringstream oss{};
-                                oss << "WARNING! field '" << aliasValue.Tag
+                                oss << "field '" << aliasValue.Tag
                                     << "' is deprecated and will be removed "
                                     << "in a future version; use '"
                                     << alias.first << "' instead (value = ";
@@ -85,7 +87,7 @@ namespace erin
                                 }
                                 oss << ")";
                                 warnings.push_back(
-                                    WriteErrorToString(tableName, oss.str())
+                                    fmt::format("{}: {}", tableName, oss.str())
                                 );
                             }
                             break;
@@ -99,10 +101,9 @@ namespace erin
                 if (!found)
                 {
                     std::ostringstream oss{};
-                    oss << "WARNING! unhandled field '" << key
-                        << "' will be ignored";
+                    oss << "unhandled field '" << key << "' will be ignored";
                     warnings.push_back(
-                        WriteWarningToString(tableName, oss.str())
+                        fmt::format("{}: {}", tableName, oss.str())
                     );
                     continue;
                 }
@@ -128,7 +129,7 @@ namespace erin
                         oss << "Expected type string for field '" << it->first
                             << "'";
                         errors.push_back(
-                            WriteErrorToString(tableName, oss.str())
+                            fmt::format("{}: {}", tableName, oss.str())
                         );
                         return out;
                     }
@@ -141,7 +142,7 @@ namespace erin
                             oss << "Could not find enumerations for field '"
                                 << it->first << "'";
                             errors.push_back(
-                                WriteErrorToString(tableName, oss.str())
+                                fmt::format("{}: {}", tableName, oss.str())
                             );
                             return out;
                         }
@@ -157,7 +158,7 @@ namespace erin
                                 oss << "- " << item << std::endl;
                             }
                             errors.push_back(
-                                WriteErrorToString(tableName, oss.str())
+                                fmt::format("{}: {}", tableName, oss.str())
                             );
                             return out;
                         }
@@ -173,7 +174,7 @@ namespace erin
                         oss << "Expected type array for field '" << it->first
                             << "'";
                         errors.push_back(
-                            WriteErrorToString(tableName, oss.str())
+                            fmt::format("{}: {}", tableName, oss.str())
                         );
                         return out;
                     }
@@ -190,7 +191,7 @@ namespace erin
                                 << it->first << "' to be a number at "
                                 << "index " << i;
                             errors.push_back(
-                                WriteErrorToString(tableName, oss.str())
+                                fmt::format("{}: {}", tableName, oss.str())
                             );
                             return out;
                         }
@@ -202,7 +203,7 @@ namespace erin
                                 << it->first << "' to be a number at "
                                 << "index " << i;
                             errors.push_back(
-                                WriteErrorToString(tableName, oss.str())
+                                fmt::format("{}: {}", tableName, oss.str())
                             );
                             return out;
                         }
@@ -219,7 +220,7 @@ namespace erin
                         oss << "Expected type array for field '" << it->first
                             << "'";
                         errors.push_back(
-                            WriteErrorToString(tableName, oss.str())
+                            fmt::format("{}: {}", tableName, oss.str())
                         );
                         return out;
                     }
@@ -235,7 +236,7 @@ namespace erin
                                 << " for field '" << it->first
                                 << "' to be an array of number of length 2 (a)";
                             errors.push_back(
-                                WriteErrorToString(tableName, oss.str())
+                                fmt::format("{}: {}", tableName, oss.str())
                             );
                             return out;
                         }
@@ -247,7 +248,7 @@ namespace erin
                                 << " for field '" << it->first
                                 << "' to be an array of number of length 2 (b)";
                             errors.push_back(
-                                WriteErrorToString(tableName, oss.str())
+                                fmt::format("{}: {}", tableName, oss.str())
                             );
                             return out;
                         }
@@ -261,7 +262,7 @@ namespace erin
                                 << " for field '" << it->first
                                 << "' to be an array of number of length 2 (c)";
                             errors.push_back(
-                                WriteErrorToString(tableName, oss.str())
+                                fmt::format("{}: {}", tableName, oss.str())
                             );
                             return out;
                         }
@@ -274,7 +275,7 @@ namespace erin
                                 << " for field '" << it->first
                                 << "' to be an array of number of length 2 (c)";
                             errors.push_back(
-                                WriteErrorToString(tableName, oss.str())
+                                fmt::format("{}: {}", tableName, oss.str())
                             );
                             return out;
                         }
@@ -295,7 +296,7 @@ namespace erin
                         oss << "Expected type array for field '" << it->first
                             << "'";
                         errors.push_back(
-                            WriteErrorToString(tableName, oss.str())
+                            fmt::format("{}: {}", tableName, oss.str())
                         );
                         return out;
                     }
@@ -311,7 +312,7 @@ namespace erin
                                 << " for field '" << it->first
                                 << "' to be an array of string of length >= 3";
                             errors.push_back(
-                                WriteErrorToString(tableName, oss.str())
+                                fmt::format("{}: {}", tableName, oss.str())
                             );
                             return out;
                         }
@@ -323,7 +324,7 @@ namespace erin
                                 << " for field '" << it->first
                                 << "' to be an array of string of length >= 3";
                             errors.push_back(
-                                WriteErrorToString(tableName, oss.str())
+                                fmt::format("{}: {}", tableName, oss.str())
                             );
                             return out;
                         }
@@ -340,7 +341,7 @@ namespace erin
                                     << "' to be an array of string of length "
                                        ">= 3";
                                 errors.push_back(
-                                    WriteErrorToString(tableName, oss.str())
+                                    fmt::format("{}: {}", tableName, oss.str())
                                 );
                                 return out;
                             }
@@ -368,7 +369,7 @@ namespace erin
                                 << " integer part: " << integerPart
                                 << "; fraction part: " << fracPart;
                             errors.push_back(
-                                WriteErrorToString(tableName, oss.str())
+                                fmt::format("{}: {}", tableName, oss.str())
                             );
                             return out;
                         }
@@ -380,7 +381,7 @@ namespace erin
                         oss << "Expected field '" << it->first
                             << "' to be convertable to an integer";
                         errors.push_back(
-                            WriteErrorToString(tableName, oss.str())
+                            fmt::format("{}: {}", tableName, oss.str())
                         );
                         return out;
                     }
@@ -395,7 +396,7 @@ namespace erin
                         oss << "Expected field '" << it->first
                             << "' to be convertable to a real number";
                         errors.push_back(
-                            WriteErrorToString(tableName, oss.str())
+                            fmt::format("{}: {}", tableName, oss.str())
                         );
                         return out;
                     }
@@ -406,7 +407,7 @@ namespace erin
                         oss << "Expected field '" << it->first
                             << "' to be convertable to a real number";
                         errors.push_back(
-                            WriteErrorToString(tableName, oss.str())
+                            fmt::format("{}: {}", tableName, oss.str())
                         );
                         return out;
                     }
@@ -422,7 +423,7 @@ namespace erin
                         oss << "Expected field '" << it->first
                             << "' to be an array of string";
                         errors.push_back(
-                            WriteErrorToString(tableName, oss.str())
+                            fmt::format("{}: {}", tableName, oss.str())
                         );
                         return out;
                     }
@@ -436,7 +437,7 @@ namespace erin
                             oss << "Expected field '" << it->first << "' at "
                                 << i << " to be a string";
                             errors.push_back(
-                                WriteErrorToString(tableName, oss.str())
+                                fmt::format("{}: {}", tableName, oss.str())
                             );
                             return out;
                         }
@@ -454,7 +455,7 @@ namespace erin
                         oss << "expected field '" << it->first
                             << "' to be a map from string to string";
                         errors.push_back(
-                            WriteErrorToString(tableName, oss.str())
+                            fmt::format("{}: {}", tableName, oss.str())
                         );
                         return out;
                     }
@@ -467,7 +468,7 @@ namespace erin
                                 << "' at key '" << item.first
                                 << "' to be a string";
                             errors.push_back(
-                                WriteErrorToString(tableName, oss.str())
+                                fmt::format("{}: {}", tableName, oss.str())
                             );
                             return out;
                         }
@@ -496,7 +497,7 @@ namespace erin
                 std::string message = fieldsToInform
                     + " not found; default value of '"
                     + validationInfo.Defaults.at(fieldsToInform) + "' assumed";
-                warnings.push_back(WriteWarningToString(tableName, message));
+                warnings.push_back(fmt::format("{}: {}", tableName, message));
             }
         }
         // insert defaults if not defined
@@ -544,7 +545,7 @@ namespace erin
             {
                 std::ostringstream oss;
                 oss << "missing required field '" << field << "'";
-                errors.push_back(WriteErrorToString(tableName, oss.str()));
+                errors.push_back(fmt::format("{}: {}", tableName, oss.str()));
             }
         }
         return out;

--- a/src/erin_next_toml.cpp
+++ b/src/erin_next_toml.cpp
@@ -1,4 +1,5 @@
 #include "erin_next/erin_next_toml.h"
+#include "erin/logging.h"
 #include "erin_next/erin_next_utils.h"
 #include "erin_next/erin_next_validation.h"
 #include <iostream>
@@ -559,7 +560,8 @@ namespace erin
         std::unordered_set<std::string> const& optionalFields,
         std::unordered_map<std::string, std::string> const& defaults,
         std::string const& tableName,
-        bool doPrint
+        bool verbose,
+        Log const& log
     )
     {
         for (auto it = table.cbegin(); it != table.cend(); ++it)
@@ -568,11 +570,9 @@ namespace erin
                 && !optionalFields.contains(it->first)
                 && !defaults.contains(it->first))
             {
-                if (doPrint)
+                if (verbose)
                 {
-                    std::cout << "[" << tableName << "] "
-                              << "Unrecognized key '" << it->first << "'"
-                              << std::endl;
+                    Log_Warning(log, tableName, fmt::format("Unrecognized key '{}'", it->first));
                 }
                 return false;
             }
@@ -582,11 +582,9 @@ namespace erin
         {
             if (!table.contains(*it))
             {
-                if (doPrint)
+                if (verbose)
                 {
-                    std::cout << "[" << tableName << "] "
-                              << "Missing required key '" << *it << "'"
-                              << std::endl;
+                    Log_Error(log, tableName, fmt::format("Missing required key '{}'", *it));
                 }
                 return false;
             }

--- a/src/erin_next_toml.cpp
+++ b/src/erin_next_toml.cpp
@@ -572,7 +572,11 @@ namespace erin
             {
                 if (verbose)
                 {
-                    Log_Warning(log, tableName, fmt::format("Unrecognized key '{}'", it->first));
+                    Log_Warning(
+                        log,
+                        tableName,
+                        fmt::format("Unrecognized key '{}'", it->first)
+                    );
                 }
                 return false;
             }
@@ -584,7 +588,11 @@ namespace erin
             {
                 if (verbose)
                 {
-                    Log_Error(log, tableName, fmt::format("Missing required key '{}'", *it));
+                    Log_Error(
+                        log,
+                        tableName,
+                        fmt::format("Missing required key '{}'", *it)
+                    );
                 }
                 return false;
             }

--- a/src/erin_next_utils.cpp
+++ b/src/erin_next_utils.cpp
@@ -75,6 +75,16 @@ namespace erin
     }
 
     void
+    WriteTaggedCategoryMessage(
+        std::string const& category,
+        std::string const& tag,
+        std::string const& message
+    )
+    {
+        std::cerr << WriteTaggedCategoryToString(category, tag, message) << std::endl;
+    }
+
+    void
     WriteWarningMessage(std::string const& tag, std::string const& message)
     {
         std::cerr << WriteWarningToString(tag, message) << std::endl;
@@ -87,35 +97,36 @@ namespace erin
     }
 
     std::string
-    WriteWarningToString(std::string const& tag, std::string const& message)
+    WriteTaggedCategoryToString(
+        std::string const& category,
+        std::string const& tag,
+        std::string const& message)
     {
         std::ostringstream oss;
         if (!tag.empty())
         {
-            oss << "[WARNING: " << tag << "] ";
+            oss << "[" << category << ": " << tag << "] ";
         }
         else
         {
-            oss << "[WARNING] ";
+            oss << "[" << category << "] ";
         }
         oss << message << std::endl;
         return oss.str();
     }
 
     std::string
+    WriteWarningToString(std::string const& tag, std::string const& message)
+    {
+        return WriteTaggedCategoryToString(
+            "WARNING", tag, message);
+    }
+
+    std::string
     WriteErrorToString(std::string const& tag, std::string const& message)
     {
-        std::ostringstream oss;
-        if (!tag.empty())
-        {
-            oss << "[ERROR: " << tag << "] ";
-        }
-        else
-        {
-            oss << "[ERROR] ";
-        }
-        oss << message << std::endl;
-        return oss.str();
+        return WriteTaggedCategoryToString(
+            "ERROR", tag, message);
     }
 
 } // namespace erin

--- a/src/erin_next_utils.cpp
+++ b/src/erin_next_utils.cpp
@@ -81,7 +81,8 @@ namespace erin
         std::string const& message
     )
     {
-        std::cerr << WriteTaggedCategoryToString(category, tag, message) << std::endl;
+        std::cerr << WriteTaggedCategoryToString(category, tag, message)
+                  << std::endl;
     }
 
     void
@@ -100,7 +101,8 @@ namespace erin
     WriteTaggedCategoryToString(
         std::string const& category,
         std::string const& tag,
-        std::string const& message)
+        std::string const& message
+    )
     {
         std::ostringstream oss;
         if (!tag.empty())
@@ -118,15 +120,13 @@ namespace erin
     std::string
     WriteWarningToString(std::string const& tag, std::string const& message)
     {
-        return WriteTaggedCategoryToString(
-            "WARNING", tag, message);
+        return WriteTaggedCategoryToString("WARNING", tag, message);
     }
 
     std::string
     WriteErrorToString(std::string const& tag, std::string const& message)
     {
-        return WriteTaggedCategoryToString(
-            "ERROR", tag, message);
+        return WriteTaggedCategoryToString("ERROR", tag, message);
     }
 
 } // namespace erin

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -74,6 +74,17 @@ target_link_libraries(erin_simulation_tests
 	GTest::gtest_main
 )
 
+# erin_logging_test
+add_executable(erin_logging_tests
+	erin_logging_tests.cpp)
+
+target_include_directories(erin_logging_tests
+	PUBLIC ${PROJECT_SOURCE_DIR}/include)
+
+target_link_libraries(erin_logging_tests
+	erin_next
+	GTest::gtest_main)
+
 # Google Test
 include(GoogleTest)
 

--- a/test/erin_logging_tests.cpp
+++ b/test/erin_logging_tests.cpp
@@ -1,0 +1,19 @@
+/* Copyright (c) 2024 Big Ladder Software LLC. All rights reserved.
+ * See the LICENSE.txt file for additional terms and conditions. */
+#include "erin/logging.h"
+#include <exception>
+#include <gtest/gtest.h>
+
+using namespace erin;
+
+TEST(Logging, TestWeCanLog)
+{
+  Logger logger{};
+  Log log = Log_MakeFromCourier(logger);
+  Log_Debug(log, "this is a debug statement");
+  Log_Info(log, "this is an info statement");
+  Log_Warning(log, "this is a warning statement");
+  EXPECT_THROW(
+    Log_Error(log, "this is an error -- using courier, it throws..."),
+    std::exception);
+}

--- a/test/erin_logging_tests.cpp
+++ b/test/erin_logging_tests.cpp
@@ -8,12 +8,13 @@ using namespace erin;
 
 TEST(Logging, TestWeCanLog)
 {
-  Logger logger{};
-  Log log = Log_MakeFromCourier(logger);
-  Log_Debug(log, "this is a debug statement");
-  Log_Info(log, "this is an info statement");
-  Log_Warning(log, "this is a warning statement");
-  EXPECT_THROW(
-    Log_Error(log, "this is an error -- using courier, it throws..."),
-    std::exception);
+    Logger logger{};
+    Log log = Log_MakeFromCourier(logger);
+    Log_Debug(log, "this is a debug statement");
+    Log_Info(log, "this is an info statement");
+    Log_Warning(log, "this is a warning statement");
+    EXPECT_THROW(
+        Log_Error(log, "this is an error -- using courier, it throws..."),
+        std::exception
+    );
 }

--- a/test/erin_simulation_tests.cpp
+++ b/test/erin_simulation_tests.cpp
@@ -151,6 +151,7 @@ RunApplyReliabilitiesAndFragilities(
         {0, 160.0},
     };
     bool verbose = false;
+    Log log{};
 
     return ApplyReliabilitiesAndFragilities(
         randFn,
@@ -171,7 +172,8 @@ RunApplyReliabilitiesAndFragilities(
         scenarioOffset_s + scenarioDuration_s,
         intensityIdToAmount,
         relSchByCompId,
-        verbose
+        verbose,
+        log
     );
 }
 

--- a/vendor/CMakeLists.txt
+++ b/vendor/CMakeLists.txt
@@ -27,3 +27,7 @@ endif()
 if (NOT TARGET CLI11)
   add_subdirectory(CLI11)
 endif()
+
+if (NOT TARGET courier)
+  add_subdirectory(courier)
+endif()


### PR DESCRIPTION
## Description of the Problem this PR will Solve

ERIN's error and warning (and debug/info) logging system has been a bit ad-hoc. This release cleans up a lot of the major issues and rolls out the new logging system. The logging system is backed by [Big Ladder's Courier](https://github.com/bigladder/courier) system.

Note: an adaptor is created to bridge from Courier's mechanism (which assumes objects) to ERIN's (which is just functions and data). Additionally, a work-around is put in place to disable Courier's current functionality which throws when an error is logged as ERIN will search input files and find and report on (possibly multiple) error issues prior to exiting.
