### PR TITLE
Problem: version doesn't report git sha

### DIFF
--- a/apps/erin.cpp
+++ b/apps/erin.cpp
@@ -55,6 +55,7 @@ add_version(CLI::App& app)
     auto version = [&]()
     {
         std::cout << "Version: " << erin::version::version_string << "\n";
+        std::cout << "(git hash: " << erin::version::git_hash << ")\n";
         std::cout << "Build Type: " << build_type << "\n";
     };
 

--- a/cmake/get-git-hash.cmake
+++ b/cmake/get-git-hash.cmake
@@ -1,0 +1,10 @@
+# Copyright (c) 2020-2024 Big Ladder Software LLC. All rights reserved.
+# See the LICENSE.txt file for additional terms and conditions.
+# Adapted from https://jonathanhamberg.com/post/cmake-embedding-git-hash/
+execute_process(
+    COMMAND git log -1 --format=%h
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    OUTPUT_VARIABLE ERIN_GIT_HASH
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+configure_file(${CMAKE_SOURCE_DIR}/include/erin/version.h.in ${CMAKE_SOURCE_DIR}/include/erin/version.h @ONLY)

--- a/include/erin/version.h.in
+++ b/include/erin/version.h.in
@@ -11,6 +11,7 @@ namespace erin::version
   constexpr int minor_version{@ERIN_VERSION_MINOR@};
   constexpr int release_number{@ERIN_VERSION_PATCH@};
   std::string const version_string{"@ERIN_VERSION@"};
+  std::string const git_hash{"@ERIN_GIT_HASH@"};
 }
 
 #endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,9 +13,7 @@
 #file(GLOB_RECURSE sources "${PROJECT_SOURCE_DIR}/src/[a-zA-Z]*.cpp")
 #file(GLOB_RECURSE public_headers "${PROJECT_SOURCE_DIR}/include/${CMAKE_PROJECT_NAME}/[a-zA-Z]*.h")
 #file(GLOB_RECURSE private_headers "${PROJECT_SOURCE_DIR}/src/[a-zA-Z]*.h")
-configure_file(
-  ${PROJECT_SOURCE_DIR}/include/erin/version.h.in
-  ${PROJECT_SOURCE_DIR}/include/erin/version.h)
+include(../cmake/get-git-hash.cmake)
 
 include_directories(${PROJECT_SOURCE_DIR}/include)
 include_directories(${PROJECT_SOURCE_DIR}/src)

--- a/src/erin_next_simulation.cpp
+++ b/src/erin_next_simulation.cpp
@@ -3326,10 +3326,10 @@ namespace erin
                         )
                     );
                     Log_Info(log, fmt::format("Occurrence #{}", occIdx + 1));
-                    for (std::string const& s :
+                    for (std::string const& reliabilityStrings :
                          ReliabilitiesToStrings(s.TheModel.Reliabilities))
                     {
-                        Log_Info(log, s);
+                        Log_Info(log, reliabilityStrings);
                     }
                 }
                 if (saveReliabilityCurves)


### PR DESCRIPTION
## Description of the Problem this PR will Solve

We don't currently report the git sha when calling for the erin version.

NOTE: this is something of a temporary solution that is *good enough*. The git sha is obtained during cmake configuration time. We intend to integrate with the automatic versioning solution provided by Athenium in the future. This is just a stop gap as it is needed now.