### PR TITLE
Fix/clarify max occurrences input

### DIFF
--- a/src/erin_next_scenario.cpp
+++ b/src/erin_next_scenario.cpp
@@ -136,11 +136,11 @@ namespace erin
                 }
                 if (maxOccurrencesString.value() != "unlimited")
                 {
-                    std::cout << "[" << fullName << "] max_occurrences must "
-                              << "be a non-zero positive number or the string "
-                              << "'unlimited' or the value -1 (unlimited); got '"
-                              << maxOccurrencesString.value() << "'"
-                              << std::endl;
+                    std::cout
+                        << "[" << fullName << "] max_occurrences must "
+                        << "be a non-zero positive number or the string "
+                        << "'unlimited' or the value -1 (unlimited); got '"
+                        << maxOccurrencesString.value() << "'" << std::endl;
                     return {};
                 }
             }
@@ -154,7 +154,8 @@ namespace erin
                 }
                 if (maxOccurrenceValue.value() == -1)
                 {
-                    // nothing to do; this means there is no maximum number of occurrences.
+                    // nothing to do; this means there is no maximum number of
+                    // occurrences.
                 }
                 else if (maxOccurrenceValue.value() > 0)
                 {

--- a/src/erin_next_scenario.cpp
+++ b/src/erin_next_scenario.cpp
@@ -138,7 +138,7 @@ namespace erin
                 {
                     std::cout << "[" << fullName << "] max_occurrences must "
                               << "be a non-zero positive number or the string "
-                              << "'unlimited'; got '"
+                              << "'unlimited' or the value -1 (unlimited); got '"
                               << maxOccurrencesString.value() << "'"
                               << std::endl;
                     return {};
@@ -152,7 +152,11 @@ namespace erin
                 {
                     return {};
                 }
-                if (maxOccurrenceValue.value() > 0)
+                if (maxOccurrenceValue.value() == -1)
+                {
+                    // nothing to do; this means there is no maximum number of occurrences.
+                }
+                else if (maxOccurrenceValue.value() > 0)
                 {
                     maxOccurrences = maxOccurrenceValue;
                 }


### PR DESCRIPTION
## Description of the Problem this PR will Solve

In previous versions of ERIN, one could specify `max_occurrences = -1` to indicate the same as `max_occurrences = "unlimited"`. This clarifies the program structures to re-enable usage of -1.
