### PR TITLE
Add feature to show random seed after run.

### DIFF
--- a/app/erin.cpp
+++ b/app/erin.cpp
@@ -106,6 +106,9 @@ CLI::App* add_run(CLI::App& app)
     static bool verbose = false;
     subcommand->add_flag("-v,--verbose", verbose, "Verbose output");
 
+    static bool show_seed = false;
+    subcommand->add_flag("-k,--show_seed", show_seed, "Show random seed used for simulation");
+
     static bool no_aggregate_groups = false;
     subcommand->add_flag("-n,--no-group", no_aggregate_groups, "Suppress group aggregation");
 
@@ -164,7 +167,8 @@ CLI::App* add_run(CLI::App& app)
             time_step_h,
             aggregate_groups,
             save_reliability_curves,
-            verbose);
+            verbose,
+            show_seed);
         return EXIT_SUCCESS;
     };
 

--- a/docs/examples/ft-illinois/exft-illinois.toml
+++ b/docs/examples/ft-illinois/exft-illinois.toml
@@ -6,6 +6,7 @@ rate_unit = "kW"
 quantity_unit = "kJ"
 time_unit = "hours"
 max_time = 8760
+random_seed = 17
 
 # Distributions
 [dist.immediately]

--- a/docs/examples/ft-illinois_packed/exft-illinois_packed.toml
+++ b/docs/examples/ft-illinois_packed/exft-illinois_packed.toml
@@ -6,6 +6,7 @@ rate_unit = "kW"
 quantity_unit = "kJ"
 time_unit = "hours"
 max_time = 8760
+random_seed = 17
 
 # Distributions
 [dist.immediately]

--- a/include/erin/simulation.h
+++ b/include/erin/simulation.h
@@ -194,7 +194,8 @@ void run(Simulation& s,
          double time_step_h = -1.0,
          bool aggregate_groups = true,
          bool save_reliability_curves = false,
-         bool verbose = false);
+         bool verbose = false,
+         bool show_seed = false);
 
 bool is_failure_name_unique(Simulation& s, std::string const& name);
 

--- a/src/erin-simulation.cpp
+++ b/src/erin-simulation.cpp
@@ -2763,7 +2763,8 @@ void run(Simulation& s,
          double time_step_h /*-1.0*/,
          bool aggregateGroups,
          bool saveReliabilityCurves,
-         bool verbose)
+         bool verbose,
+         bool show_seed)
 {
     // TODO: wrap into input options struct and pass in
     bool const checkNetwork = false;
@@ -2793,6 +2794,11 @@ void run(Simulation& s,
     {
         fixedRandom.fixed_value = s.info.fixed_value;
         s.the_model.random_function = fixedRandom;
+        if (show_seed)
+        {
+            std::cout << std::endl << "RANDOM_TYPE: fixed" << std::endl;
+            std::cout << "RANDOM_SEED: " << s.info.fixed_value << "\n";
+        }
     }
     break;
     case (RandomType::fixed_series):
@@ -2800,18 +2806,47 @@ void run(Simulation& s,
         fixedSeries.index = 0;
         fixedSeries.series = s.info.series;
         s.the_model.random_function = fixedSeries;
+        if (show_seed)
+        {
+            std::cout << std::endl << "RANDOM_TYPE: fixed_series" << std::endl;
+            std::cout << "RANDOM_SEED: ";
+            bool is_first = true;
+            for (auto fixed_series_value : s.info.series)
+            {
+                if (is_first)
+                {
+                    is_first = false;
+                }
+                else
+                {
+                    std::cout << ", ";
+                }
+                std::cout << fixed_series_value;
+            }
+            std::cout << std::endl;
+        }
     }
     break;
     case (RandomType::random_from_seed):
     {
         fullRandom = create_random_with_seed(s.info.seed);
         s.the_model.random_function = fullRandom;
+        if (show_seed)
+        {
+            std::cout << std::endl << "RANDOM_TYPE: random_from_seed" << std::endl;
+            std::cout << "RANDOM_SEED: " << s.info.seed << std::endl;
+        }
     }
     break;
     case (RandomType::random_from_clock):
     {
         fullRandom = create_random();
         s.the_model.random_function = fullRandom;
+        if (show_seed)
+        {
+            std::cout << std::endl << "RANDOM_TYPE: random_from_clock" << std::endl;
+            std::cout << "RANDOM_SEED: " << fullRandom.seed << std::endl;
+        }
     }
     break;
     default:

--- a/src/erin-validation.cpp
+++ b/src/erin-validation.cpp
@@ -406,7 +406,7 @@ InputValidationMap setup_global_validation_info()
             .input_type = InputType::integer,
             .is_required = false,
             .inform_if_missing = false,
-            .default_value = "17",
+            .default_value = "",
             .enum_values = valid_time_units,
             .aliases = {},
             .sections =


### PR DESCRIPTION
## Description

When the random seed is calculated via clock, it is important to be able to see it should we want to reseed the
random number generator with the same values. This enables that capability.

NOTE: we also print out the random settings for all types of random (fixed, fixed, series, explicitly seeded, or randomly seeded via the clock).

This PR also fixes an issue where, by default, we were always using a default random seed specified as 17 if we didn't specify the type of random process. Instead, we should have been calculating the random seed from the clock. After this fix, we did have to fix the random seed to be 17 in order for some regression tests to still pass.