### PR TITLE
Add check to ensure network is a directed acyclical graph

### DIFF
--- a/app/erin.cpp
+++ b/app/erin.cpp
@@ -14,6 +14,8 @@
 #include "erin/all.h"
 #include "compilation_settings.h"
 
+int exit_code = EXIT_SUCCESS;
+
 erin::Log get_standard_log(erin::Logger& logger)
 {
     using namespace erin;
@@ -140,7 +142,8 @@ CLI::App* add_run(CLI::App& app)
         if (!ifs.good())
         {
             Log_error(log, "Could not open input file stream on input file");
-            return EXIT_FAILURE;
+            exit_code = EXIT_FAILURE;
+            return;
         }
         auto name_only = std::filesystem::path(toml_filename).filename();
         toml::value data = toml::parse(ifs, name_only.string());
@@ -152,7 +155,8 @@ CLI::App* add_run(CLI::App& app)
         if (!maybe_sim.has_value())
         {
             Log_error(log, "Simulation returned without value");
-            return EXIT_FAILURE;
+            exit_code = EXIT_FAILURE;
+            return;
         }
         Simulation s = std::move(maybe_sim.value());
         if (verbose)
@@ -169,7 +173,6 @@ CLI::App* add_run(CLI::App& app)
             save_reliability_curves,
             verbose,
             show_seed);
-        return EXIT_SUCCESS;
     };
 
     subcommand->callback([&]() { run_it(); });
@@ -199,7 +202,8 @@ CLI::App* add_graph(CLI::App& app)
         if (!ifs.good())
         {
             Log_error(log, "Could not open input file stream on input file");
-            return EXIT_FAILURE;
+            exit_code = EXIT_FAILURE;
+            return;
         }
         auto name_only = std::filesystem::path(toml_filename).filename();
         auto data = toml::parse(ifs, name_only.string());
@@ -211,7 +215,8 @@ CLI::App* add_graph(CLI::App& app)
         if (!maybe_sim.has_value())
         {
             Log_error(log, "Could not parse sim data from TOML");
-            return EXIT_FAILURE;
+            exit_code = EXIT_FAILURE;
+            return;
         }
         Simulation s = std::move(maybe_sim.value());
         std::string dot_data =
@@ -221,11 +226,11 @@ CLI::App* add_graph(CLI::App& app)
         if (!ofs.good())
         {
             std::cout << "Could not open output file stream on output file" << std::endl;
-            return EXIT_FAILURE;
+            exit_code = EXIT_FAILURE;
+            return;
         }
         ofs << dot_data << std::endl;
         ofs.close();
-        return EXIT_SUCCESS;
     };
 
     subcommand->callback([&]() { graph(); });
@@ -249,7 +254,8 @@ CLI::App* add_check_network(CLI::App& app)
         if (!ifs.good())
         {
             Log_error(log, "Could not open input file stream on input file");
-            return EXIT_FAILURE;
+            exit_code = EXIT_FAILURE;
+            return;
         }
         auto name_only = std::filesystem::path(toml_filename).filename();
         auto data = toml::parse(ifs, name_only.string());
@@ -260,7 +266,8 @@ CLI::App* add_check_network(CLI::App& app)
         auto maybe_sim = read_from_toml(data, validationInfo, component_tags_in_use, log);
         if (!maybe_sim.has_value())
         {
-            return EXIT_FAILURE;
+            exit_code = EXIT_FAILURE;
+            return;
         }
         Simulation s = std::move(maybe_sim.value());
         std::vector<std::string> issues = erin::check_network(s.the_model);
@@ -271,10 +278,10 @@ CLI::App* add_check_network(CLI::App& app)
             {
                 std::cout << issue << std::endl;
             }
-            return EXIT_FAILURE;
+            exit_code = EXIT_FAILURE;
+            return;
         }
         std::cout << "No issues found with network." << std::endl;
-        return EXIT_SUCCESS;
     };
 
     subcommand->callback([&]() { check_network(); });
@@ -302,7 +309,8 @@ CLI::App* add_update(CLI::App& app)
         if (!ifs.good())
         {
             std::cout << "Could not open input file stream on input file" << std::endl;
-            return EXIT_FAILURE;
+            exit_code = EXIT_FAILURE;
+            return;
         }
         using namespace erin;
         auto name_only = std::filesystem::path(input_filename).filename();
@@ -472,11 +480,11 @@ CLI::App* add_update(CLI::App& app)
         if (!ofs.good())
         {
             std::cout << "Could not open ouptut file stream for output file" << std::endl;
-            return EXIT_FAILURE;
+            exit_code = EXIT_FAILURE;
+            return;
         }
         ofs << data;
         ofs.close();
-        return EXIT_SUCCESS;
     };
 
     subcommand->callback([&]() { update(); });
@@ -511,7 +519,8 @@ CLI::App* add_pack_loads(CLI::App& app)
         if (!ifs.good())
         {
             erin::Log_error(log, "Could not open input file stream on input file");
-            return EXIT_FAILURE;
+            exit_code = EXIT_FAILURE;
+            return;
         }
         auto toml_filename_only = std::filesystem::path(toml_filename).filename();
         auto data = toml::parse(ifs, toml_filename_only.string());
@@ -523,10 +532,11 @@ CLI::App* add_pack_loads(CLI::App& app)
         auto maybeLoads = parse_loads(load_table, explicit_validation, file_validation, log);
         if (!maybeLoads.has_value())
         {
-            return EXIT_FAILURE;
+            exit_code = EXIT_FAILURE;
+            return;
         }
         std::vector<erin::Load> loads = std::move(maybeLoads.value());
-        return erin::write_packed_loads(loads, loads_filename);
+        exit_code = erin::write_packed_loads(loads, loads_filename);
     };
 
     subcommand->callback([&]() { pack_loads(); });
@@ -536,10 +546,8 @@ CLI::App* add_pack_loads(CLI::App& app)
 
 int main(int argc, char** argv)
 {
-    int result = EXIT_SUCCESS;
-
     CLI::App app {"erin"};
-    app.require_subcommand(0);
+    app.require_subcommand(0, 1);
 
     add_version(app);
     add_limits(app);
@@ -560,5 +568,5 @@ int main(int argc, char** argv)
         std::cout << app.help() << std::endl;
     }
 
-    return result;
+    return exit_code;
 }

--- a/app/erin.cpp
+++ b/app/erin.cpp
@@ -233,7 +233,7 @@ CLI::App* add_graph(CLI::App& app)
     return subcommand;
 }
 
-CLI::App* add_checkNetwork(CLI::App& app)
+CLI::App* add_check_network(CLI::App& app)
 {
     auto subcommand = app.add_subcommand("check", "Check network for issues");
 
@@ -545,7 +545,7 @@ int main(int argc, char** argv)
     add_limits(app);
     add_run(app);
     add_graph(app);
-    add_checkNetwork(app);
+    add_check_network(app);
     add_update(app);
     add_pack_loads(app);
 

--- a/docs/examples/ex_bad_network.toml
+++ b/docs/examples/ex_bad_network.toml
@@ -1,0 +1,55 @@
+[simulation_info]
+input_format_version = "0.2"
+rate_unit = "kW"
+quantity_unit = "kJ"
+time_unit = "hours"
+max_time = 4
+############################################################
+[loads.building_electrical]
+time_unit = "hours"
+rate_unit = "kW"
+time_rate_pairs = [
+  [0.0, 1.0],
+  [1.0, 10.0],
+  [3.0, 1.0],
+  [4.0, 0.0],
+]
+############################################################
+[components.electric_utility]
+type = "source"
+outflow = "electricity"
+[components.electric_bus]
+type = "mux"
+num_inflows = 2
+num_outflows = 1
+flow = "electricity"
+[components.transformer]
+type = "converter"
+constant_efficiency = 0.98
+inflow = "electricity"
+outflow = "electricity"
+lossflow = "electricity"
+[components.cluster_01_electric]
+type = "load"
+inflow = "electricity"
+loads_by_scenario.blue_sky = "building_electrical"
+############################################################
+[network]
+connections = [
+  ["electric_utility:OUT(0)", "electric_bus:IN(0)", "electricity"],
+  ["electric_bus:OUT(0)", "transformer:IN(0)", "electricity"],
+  ["transformer:OUT(0)", "cluster_01_electric:IN(0)", "electricity"],
+  ["transformer:OUT(1)", "electric_bus:IN(1)", "electricity"],
+]
+############################################################
+[dist.immediately]
+type = "fixed"
+value = 0
+time_unit = "hours"
+############################################################
+[scenarios.blue_sky]
+time_unit = "hours"
+occurrence_distribution = "immediately"
+duration = 4
+max_occurrences = 1
+

--- a/docs/examples/regress.py
+++ b/docs/examples/regress.py
@@ -9,35 +9,36 @@ import datetime
 
 
 print("Platform: " + platform.system())
-if platform.system() == 'Windows':
+if platform.system() == "Windows":
     from shutil import which
-    DIFF_PROG = 'fc' if which('fc') is not None else 'diff'
-    ROOT_DIR = (Path('.') / '..' / '..').absolute()
-    BIN_DIR = ROOT_DIR / 'build' / 'bin' / 'Release'
+
+    DIFF_PROG = "fc" if which("fc") is not None else "diff"
+    ROOT_DIR = (Path(".") / ".." / "..").absolute()
+    BIN_DIR = ROOT_DIR / "build" / "bin" / "Release"
     if not BIN_DIR.exists():
-        BIN_DIR = ROOT_DIR / 'build' / 'bin' / 'Debug'
+        BIN_DIR = ROOT_DIR / "build" / "bin" / "Debug"
     if not BIN_DIR.exists():
-        BIN_DIR = ROOT_DIR / 'out' / 'build' / 'x64-Debug' / 'bin'
+        BIN_DIR = ROOT_DIR / "out" / "build" / "x64-Debug" / "bin"
     if not BIN_DIR.exists():
-        BIN_DIR = ROOT_DIR / 'out' / 'build' / 'x64-Release' / 'bin'
+        BIN_DIR = ROOT_DIR / "out" / "build" / "x64-Release" / "bin"
     if not BIN_DIR.exists():
         print("Could not find build directory!")
         sys.exit(1)
     BIN_DIR = BIN_DIR.resolve()
     ALL_TESTS = [
-        BIN_DIR / 'erin_tests.exe',
+        BIN_DIR / "erin_tests.exe",
     ]
-    CLI_EXE = BIN_DIR / 'erin.exe'
-    PERF01_EXE = BIN_DIR / 'erin_stress_test.exe'
-elif platform.system() == 'Darwin' or platform.system() == 'Linux':
-    DIFF_PROG = 'diff'
-    BIN_DIR = (Path('.') / '..' / '..' / 'build' / 'bin').absolute()
+    CLI_EXE = BIN_DIR / "erin.exe"
+    PERF01_EXE = BIN_DIR / "erin_stress_test.exe"
+elif platform.system() == "Darwin" or platform.system() == "Linux":
+    DIFF_PROG = "diff"
+    BIN_DIR = (Path(".") / ".." / ".." / "build" / "bin").absolute()
     BIN_DIR = BIN_DIR.resolve()
     ALL_TESTS = [
-        BIN_DIR / 'erin_tests',
+        BIN_DIR / "erin_tests",
     ]
-    CLI_EXE = BIN_DIR / 'erin'
-    PERF01_EXE = BIN_DIR / 'erin_stress_test'
+    CLI_EXE = BIN_DIR / "erin"
+    PERF01_EXE = BIN_DIR / "erin_stress_test"
 else:
     print(f"Unhandled platform, '{platform.system()}'")
     sys.exit(1)
@@ -90,13 +91,13 @@ def run_tests():
     print("", flush=True)
 
 
-def run_command(cmd, dir=None):
+def run_command(cmd, dir=None, check_return_code=True):
     """
     Run the given command in the given directory.
     """
     cwd = str(Path.cwd().resolve()) if dir is None else dir
     result = subprocess.run(cmd, capture_output=True, cwd=cwd)
-    if result.returncode != 0:
+    if check_return_code and result.returncode != 0:
         print(f"Error running CLI for {' '.join(cmd)}")
         print("stdout:\n")
         print(result.stdout.decode())
@@ -112,8 +113,8 @@ def smoke_test(example_name, dir=None, timeit=False, print_it=False):
     """
     cwd = str(Path.cwd().resolve()) if dir is None else dir
 
-    out_name = 'out.csv'
-    stats_name = 'stats.csv'
+    out_name = "out.csv"
+    stats_name = "stats.csv"
 
     Path(out_name).unlink(missing_ok=True)
     Path(stats_name).unlink(missing_ok=True)
@@ -145,30 +146,28 @@ def run_bench(bench_file, example_name, dir=None):
     Run a benchmark test.
     """
     git_sha = "<no-git-sha-detected>"
-    git_sha_result = subprocess.run(
-        ["git", "rev-parse", "HEAD"],
-        capture_output=True)
-    prog_info = subprocess.run(
-        [CLI_EXE, "version"],
-        capture_output=True,
-        text=True)
+    git_sha_result = subprocess.run(["git", "rev-parse", "HEAD"], capture_output=True)
+    prog_info = subprocess.run([CLI_EXE, "version"], capture_output=True, text=True)
     is_debug = "Build Type: Debug" in prog_info.stdout
     if git_sha_result.returncode == 0:
         git_sha = git_sha_result.stdout.decode("utf-8").strip()
     now = datetime.datetime.now().isoformat()
     result = smoke_test(example_name, dir)
-    with open(bench_file, 'a') as f:
+    with open(bench_file, "a") as f:
         time_s = result.time_ns / 1_000_000_000.0
         debug_flag = "true" if is_debug else "false"
-        print(f"{{\"time\": \"{now}\", \"commit\": \"{git_sha}\", " +
-              f"\"debug\": {debug_flag}, \"name\": \"{example_name}\", " +
-              f"\"time-s\": {time_s}}}", file=f)
+        print(
+            f'{{"time": "{now}", "commit": "{git_sha}", '
+            + f'"debug": {debug_flag}, "name": "{example_name}", '
+            + f'"time-s": {time_s}}}',
+            file=f,
+        )
 
 
 def read_csv(path):
     header = None
     data = {}
-    with open(path, newline='') as csvfile:
+    with open(path, newline="") as csvfile:
         rdr = csv.reader(csvfile)
         for row in rdr:
             if header is None:
@@ -194,8 +193,8 @@ def compare_csv(original_csv_path, proposed_csv_path):
         print("header lengths NOT equal")
         print(f"-- len(original['header']): {len(orig['header'])}")
         print(f"-- len(proposed['header']): {len(prop['header'])}")
-    orig_set = set(orig['header'])
-    prop_set = set(prop['header'])
+    orig_set = set(orig["header"])
+    prop_set = set(prop["header"])
     if orig_set != prop_set:
         in_orig_only = orig_set.difference(prop_set)
         in_prop_only = prop_set.difference(orig_set)
@@ -203,17 +202,17 @@ def compare_csv(original_csv_path, proposed_csv_path):
         print(f"- {','.join(sorted(in_orig_only))}")
         print("in proposed but not original: ")
         print(f"- {','.join(sorted(in_prop_only))}")
-    col0_key = orig['header'][0] if len(orig['header']) > 0 else ""
-    col1_key = orig['header'][1] if len(orig['header']) > 1 else ""
+    col0_key = orig["header"][0] if len(orig["header"]) > 0 else ""
+    col1_key = orig["header"][1] if len(orig["header"]) > 1 else ""
 
     def prefix_for(idx):
         items = []
-        if col0_key in orig['data'] and col0_key in prop['data']:
-            test_a = len(orig['data'][col0_key]) > idx
-            test_b = len(prop['data'][col0_key]) > idx
+        if col0_key in orig["data"] and col0_key in prop["data"]:
+            test_a = len(orig["data"][col0_key]) > idx
+            test_b = len(prop["data"][col0_key]) > idx
             if test_a and test_b:
-                vorig = orig['data'][col0_key][idx]
-                vprop = prop['data'][col0_key][idx]
+                vorig = orig["data"][col0_key][idx]
+                vprop = prop["data"][col0_key][idx]
                 if vorig == vprop:
                     items.append(vorig)
                 else:
@@ -222,12 +221,12 @@ def compare_csv(original_csv_path, proposed_csv_path):
                 return ""
         else:
             return ""
-        if col1_key in orig['data'] and col1_key in prop['data']:
-            test_a = len(orig['data'][col1_key]) > idx
-            test_b = len(prop['data'][col1_key]) > idx
+        if col1_key in orig["data"] and col1_key in prop["data"]:
+            test_a = len(orig["data"][col1_key]) > idx
+            test_b = len(prop["data"][col1_key]) > idx
             if test_a and test_b:
-                vorig = orig['data'][col1_key][idx]
-                vprop = prop['data'][col1_key][idx]
+                vorig = orig["data"][col1_key][idx]
+                vprop = prop["data"][col1_key][idx]
                 if vorig == vprop:
                     items.append(vorig)
                 else:
@@ -237,6 +236,7 @@ def compare_csv(original_csv_path, proposed_csv_path):
         else:
             return ""
         return ":".join(items)
+
     for key in orig["header"]:
         if key not in prop["data"]:
             continue
@@ -262,11 +262,9 @@ def full_compare_csv(file1_name, file2_name, dir1=None, dir2=None):
     file1_name = os.path.join(cwd1, file1_name)
     file2_name = os.path.join(cwd2, file2_name)
 
-    result = subprocess.run(
-        [DIFF_PROG, file1_name, file2_name],
-        capture_output=True)
+    result = subprocess.run([DIFF_PROG, file1_name, file2_name], capture_output=True)
     if result.returncode != 0:
-        print(f'diff did not compare clean for {file1_name} for {file2_name}')
+        print(f"diff did not compare clean for {file1_name} for {file2_name}")
         print("stdout:\n")
         print(result.stdout.decode())
         print("stderr:\n")
@@ -283,11 +281,11 @@ def run_cli(example_name, dir=None, timeit=False, print_it=False):
     """
     _ = smoke_test(example_name, dir, timeit, print_it)
 
-    ref_out_name = f'ex{example_name}-out.csv'
-    ref_stats_name = f'ex{example_name}-stats.csv'
+    ref_out_name = f"ex{example_name}-out.csv"
+    ref_stats_name = f"ex{example_name}-stats.csv"
 
-    out_name = 'out.csv'
-    stats_name = 'stats.csv'
+    out_name = "out.csv"
+    stats_name = "stats.csv"
 
     full_compare_csv(out_name, ref_out_name, dir1=dir, dir2=dir)
     full_compare_csv(stats_name, ref_stats_name, dir1=dir, dir2=dir)
@@ -299,16 +297,14 @@ def run_perf():
     """
     Run performance tests and report timing
     """
-    result = subprocess.run(
-        [PERF01_EXE],
-        capture_output=True)
+    result = subprocess.run([PERF01_EXE], capture_output=True)
     if result.returncode != 0:
         print(f"error running performance test {PERF01_EXE}")
         print("stdout:\n")
         print(result.stdout.decode())
         print("stderr:\n")
         print(result.stderr.decode())
-    print(result.stdout.decode(), end='')
+    print(result.stdout.decode(), end="")
 
 
 def pack_csv_cli(example_name, dir=None, timeit=False, print_it=False):
@@ -317,14 +313,14 @@ def pack_csv_cli(example_name, dir=None, timeit=False, print_it=False):
     """
     cwd = str(Path.cwd().resolve()) if dir is None else dir
 
-    packed_loads_name = 'packed-loads.csv'
+    packed_loads_name = "packed-loads.csv"
     Path(packed_loads_name).unlink(missing_ok=True)
 
     in_name = f"ex{example_name}.toml"
     start_time = time.perf_counter_ns()
     result = subprocess.run(
-        [CLI_EXE, "pack-loads", f"{in_name}", "-o", f"{packed_loads_name}"],
-        cwd=cwd)
+        [CLI_EXE, "pack-loads", f"{in_name}", "-o", f"{packed_loads_name}"], cwd=cwd
+    )
     end_time = time.perf_counter_ns()
     time_ns = end_time - start_time
     if result.returncode != 0:
@@ -395,9 +391,7 @@ if __name__ == "__main__":
     run_cli("35")
     run_cli("36")
     run_command([CLI_EXE, "run", "ex37.toml", "-r"])
-    files_generated = [f
-                       for f in Path.cwd().resolve().glob(
-                           "class_2_hurricane*.csv")]
+    files_generated = [f for f in Path.cwd().resolve().glob("class_2_hurricane*.csv")]
     if len(files_generated) != 10:
         print("Error on example 37")
         print(f"Should have created 10 csv files, got {len(files_generated)}")
@@ -410,6 +404,15 @@ if __name__ == "__main__":
     run_cli("41")
     run_cli("42")
     run_cli("43")
+    # Ensure check detects cycles in network
+    cwd = str(Path.cwd().resolve())
+    cmd = [CLI_EXE, "check", "ex_bad_network.toml"]
+    result = run_command(cmd, dir=cwd, check_return_code=False)
+    if result.returncode == 0:
+        # NOTE: we should have a non-zero exit code if checks don't pass
+        sys.exit(1)
+    else:
+        print(".", end="", sep="", flush=True)
     print("\nPassed all regression tests!")
 
     if os.environ.get("ERIN_SHORT_TEST") is not None:
@@ -419,24 +422,31 @@ if __name__ == "__main__":
     # Run original (unpacked) and rename/move output
     orig_name = "ft-illinois"
     smoke_test(orig_name, dir=orig_name, print_it=True)
-    rename_file("out.csv", f"ex{orig_name}-out.csv",
-                dir1=orig_name, dir2=orig_name)
+    rename_file("out.csv", f"ex{orig_name}-out.csv", dir1=orig_name, dir2=orig_name)
 
     # Pack and rename packed loads
     packed_name = orig_name + "_packed"
     pack_csv_cli(orig_name, dir=orig_name, timeit=False, print_it=False)
-    rename_file("packed-loads.csv", f"ex{packed_name}-loads.csv",
-                dir1=orig_name, dir2=packed_name)
+    rename_file(
+        "packed-loads.csv",
+        f"ex{packed_name}-loads.csv",
+        dir1=orig_name,
+        dir2=packed_name,
+    )
 
     # Run packed and rename output
     smoke_test(packed_name, dir=packed_name, print_it=True)
-    rename_file("out.csv", f"ex{packed_name}-out.csv",
-                dir1=packed_name, dir2=packed_name)
+    rename_file(
+        "out.csv", f"ex{packed_name}-out.csv", dir1=packed_name, dir2=packed_name
+    )
 
     # compare packed<->unpacked outputs
-    full_compare_csv(file1_name=f"ex{packed_name}-out.csv",
-                     file2_name=f"ex{orig_name}-out.csv",
-                     dir1=packed_name, dir2=orig_name)
+    full_compare_csv(
+        file1_name=f"ex{packed_name}-out.csv",
+        file2_name=f"ex{orig_name}-out.csv",
+        dir1=packed_name,
+        dir2=orig_name,
+    )
     print("\nPassed load-packing test!")
 
     run_perf()

--- a/include/erin/all.h
+++ b/include/erin/all.h
@@ -9,6 +9,7 @@
 #include "erin/graph.h"
 #include "erin/load.h"
 #include "erin/logging.h"
+#include "erin/network-utils.h"
 #include "erin/reliability.h"
 #include "erin/result.h"
 #include "erin/scenario.h"

--- a/include/erin/erin.h
+++ b/include/erin/erin.h
@@ -621,7 +621,7 @@ double NextStorageEvent(SimulationState const& ss, size_t storeIdx, double t);
 void UpdateStoresPerElapsedTime(Model const& m, SimulationState& ss, double elapsedTime);
 
 // TODO: change name to `std::string ComponentTypeToString(ComponentType);`
-std::string ToString(ComponentType ct);
+std::string to_string(ComponentType ct);
 
 std::optional<ComponentType> TagToComponentType(std::string const& tag);
 

--- a/include/erin/network-utils.h
+++ b/include/erin/network-utils.h
@@ -12,11 +12,9 @@ namespace erin
 {
 
 std::vector<std::vector<std::string>>
-find_strongly_connected_components(
-  std::vector<std::string> const& nodes,
-  std::vector<std::pair<size_t, size_t>> const& edges,
-  size_t minimum_component_size = 2
-);
+find_strongly_connected_components(std::vector<std::string> const& nodes,
+                                   std::vector<std::pair<size_t, size_t>> const& edges,
+                                   size_t minimum_component_size = 2);
 
 } // namespace erin
 

--- a/include/erin/network-utils.h
+++ b/include/erin/network-utils.h
@@ -1,0 +1,23 @@
+// Copyright (c) 2020 - 2024 Big Ladder Software, LLC.
+// See the LICENSE.txt file for additional terms and conditions.
+#ifndef ERIN_NETWORK_UTILS_H
+#define ERIN_NETWORK_UTILS_H
+
+#include <cstddef>
+#include <vector>
+#include <string>
+#include <utility>
+
+namespace erin
+{
+
+std::vector<std::vector<std::string>>
+find_strongly_connected_components(
+  std::vector<std::string> const& nodes,
+  std::vector<std::pair<size_t, size_t>> const& edges,
+  size_t minimum_component_size = 2
+);
+
+} // namespace erin
+
+#endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,6 +10,7 @@ set(library_sources
     ${PROJECT_SOURCE_DIR}/src/erin-load.cpp
     ${PROJECT_SOURCE_DIR}/src/erin-logging.cpp
     ${PROJECT_SOURCE_DIR}/src/erin-lookup-table.cpp
+    ${PROJECT_SOURCE_DIR}/src/erin-network-utils.cpp
     ${PROJECT_SOURCE_DIR}/src/erin-random.cpp
     ${PROJECT_SOURCE_DIR}/src/erin-reliability.cpp
     ${PROJECT_SOURCE_DIR}/src/erin-scenario.cpp
@@ -32,6 +33,7 @@ set(library_sources
     ${PROJECT_SOURCE_DIR}/include/erin/load.h
     ${PROJECT_SOURCE_DIR}/include/erin/logging.h
     ${PROJECT_SOURCE_DIR}/include/erin/lookup_table.h
+    ${PROJECT_SOURCE_DIR}/include/erin/network-utils.h
     ${PROJECT_SOURCE_DIR}/include/erin/random.h
     ${PROJECT_SOURCE_DIR}/include/erin/reliability.h
     ${PROJECT_SOURCE_DIR}/include/erin/result.h

--- a/src/erin-component.cpp
+++ b/src/erin-component.cpp
@@ -122,7 +122,7 @@ Result parse_single_component(Simulation& s,
     break;
     default:
     {
-        write_error_message(fullTableName, "unhandled component type: " + ToString(ct));
+        write_error_message(fullTableName, "unhandled component type: " + to_string(ct));
         std::exit(1);
     }
     break;
@@ -730,7 +730,7 @@ Result parse_single_component(Simulation& s,
     break;
     default:
     {
-        write_error_message(fullTableName, "unhandled component type: " + ToString(ct));
+        write_error_message(fullTableName, "unhandled component type: " + to_string(ct));
         std::exit(1);
     }
     }

--- a/src/erin-network-utils.cpp
+++ b/src/erin-network-utils.cpp
@@ -21,7 +21,7 @@ void strong_connect(size_t& time_index,
     find_times[node_idx] = static_cast<int>(time_index);
     low_links[node_idx] = static_cast<int>(time_index);
     time_index++;
-    stack.push(node_idx);
+    stack.push(static_cast<int>(node_idx));
     on_stacks[node_idx] = true;
 
     for (std::pair<size_t, size_t> const& e : edges)

--- a/src/erin-network-utils.cpp
+++ b/src/erin-network-utils.cpp
@@ -18,8 +18,8 @@ void strong_connect(size_t& time_index,
                     std::vector<std::string> const& nodes,
                     std::vector<std::pair<size_t, size_t>> const& edges)
 {
-    find_times[node_idx] = time_index;
-    low_links[node_idx] = time_index;
+    find_times[node_idx] = static_cast<int>(time_index);
+    low_links[node_idx] = static_cast<int>(time_index);
     time_index++;
     stack.push(node_idx);
     on_stacks[node_idx] = true;

--- a/src/erin-network-utils.cpp
+++ b/src/erin-network-utils.cpp
@@ -1,0 +1,98 @@
+// Copyright (c) 2020 - 2024 Big Ladder Software, LLC.
+// See the LICENSE.txt file for additional terms and conditions.
+#include <stack>
+#include <algorithm>
+
+#include "erin/network-utils.h"
+
+namespace erin
+{
+
+  void
+  strong_connect(
+    size_t& time_index,
+    size_t node_idx,
+    std::stack<int>& stack,
+    std::vector<int>& find_times,
+    std::vector<int>& low_links,
+    std::vector<bool>& on_stacks,
+    std::vector<std::vector<size_t>>& sccs,
+    std::vector<std::string> const& nodes,
+    std::vector<std::pair<size_t, size_t>> const& edges
+  )
+  {
+    find_times[node_idx] = time_index;
+    low_links[node_idx] = time_index;
+    time_index++;
+    stack.push(node_idx);
+    on_stacks[node_idx] = true;
+
+    for (std::pair<size_t, size_t> const& e : edges)
+    {
+      if (e.first != node_idx)
+      {
+        continue;
+      }
+      size_t neighbor_node_idx = e.second;
+      if (find_times[neighbor_node_idx] == -1)
+      {
+        strong_connect(time_index, neighbor_node_idx, stack, find_times, low_links, on_stacks, sccs, nodes, edges);
+        low_links[node_idx] = std::min(low_links[node_idx], low_links[neighbor_node_idx]);
+      }
+      else if (on_stacks[neighbor_node_idx])
+      {
+        low_links[node_idx] = std::min(low_links[node_idx], find_times[neighbor_node_idx]);
+      }
+    }
+    if (low_links[node_idx] == find_times[node_idx])
+    {
+      std::vector<size_t> scc = {};
+      size_t scc_node_idx;
+      do {
+        scc_node_idx = stack.top();
+        stack.pop();
+        on_stacks[scc_node_idx] = false;
+        scc.push_back(scc_node_idx);
+      } while (scc_node_idx != node_idx);
+      sccs.push_back(std::move(scc));
+    }
+  }
+
+  std::vector<std::vector<std::string>>
+  find_strongly_connected_components(
+    std::vector<std::string> const& nodes,
+    std::vector<std::pair<size_t, size_t>> const& edges,
+    size_t minimum_component_size
+  )
+  {
+    std::vector<std::vector<size_t>> sccs;
+    std::stack<int> stack = {};
+    size_t time_index = 0;
+    std::vector<int> find_times(nodes.size(), -1);
+    std::vector<int> low_links(nodes.size(), -1);
+    std::vector<bool> on_stacks(nodes.size(), false);
+    for (size_t node_idx = 0; node_idx < nodes.size(); ++node_idx)
+    {
+      if (find_times[node_idx] == -1)
+      {
+        strong_connect(time_index, node_idx, stack, find_times, low_links, on_stacks, sccs, nodes, edges);
+      }
+    }
+    std::vector<std::vector<std::string>> result = {};
+    for (std::vector<size_t> const& component : sccs)
+    {
+      if (component.size() < minimum_component_size)
+      {
+        continue;
+      }
+      std::vector<std::string> component_nodes = {};
+      for (size_t node_idx : component)
+      {
+        component_nodes.push_back(nodes[node_idx]);
+      }
+      result.push_back(component_nodes);
+    }
+    return result;
+  }
+
+}

--- a/src/erin-network-utils.cpp
+++ b/src/erin-network-utils.cpp
@@ -8,19 +8,16 @@
 namespace erin
 {
 
-  void
-  strong_connect(
-    size_t& time_index,
-    size_t node_idx,
-    std::stack<int>& stack,
-    std::vector<int>& find_times,
-    std::vector<int>& low_links,
-    std::vector<bool>& on_stacks,
-    std::vector<std::vector<size_t>>& sccs,
-    std::vector<std::string> const& nodes,
-    std::vector<std::pair<size_t, size_t>> const& edges
-  )
-  {
+void strong_connect(size_t& time_index,
+                    size_t node_idx,
+                    std::stack<int>& stack,
+                    std::vector<int>& find_times,
+                    std::vector<int>& low_links,
+                    std::vector<bool>& on_stacks,
+                    std::vector<std::vector<size_t>>& sccs,
+                    std::vector<std::string> const& nodes,
+                    std::vector<std::pair<size_t, size_t>> const& edges)
+{
     find_times[node_idx] = time_index;
     low_links[node_idx] = time_index;
     time_index++;
@@ -29,42 +26,49 @@ namespace erin
 
     for (std::pair<size_t, size_t> const& e : edges)
     {
-      if (e.first != node_idx)
-      {
-        continue;
-      }
-      size_t neighbor_node_idx = e.second;
-      if (find_times[neighbor_node_idx] == -1)
-      {
-        strong_connect(time_index, neighbor_node_idx, stack, find_times, low_links, on_stacks, sccs, nodes, edges);
-        low_links[node_idx] = std::min(low_links[node_idx], low_links[neighbor_node_idx]);
-      }
-      else if (on_stacks[neighbor_node_idx])
-      {
-        low_links[node_idx] = std::min(low_links[node_idx], find_times[neighbor_node_idx]);
-      }
+        if (e.first != node_idx)
+        {
+            continue;
+        }
+        size_t neighbor_node_idx = e.second;
+        if (find_times[neighbor_node_idx] == -1)
+        {
+            strong_connect(time_index,
+                           neighbor_node_idx,
+                           stack,
+                           find_times,
+                           low_links,
+                           on_stacks,
+                           sccs,
+                           nodes,
+                           edges);
+            low_links[node_idx] = std::min(low_links[node_idx], low_links[neighbor_node_idx]);
+        }
+        else if (on_stacks[neighbor_node_idx])
+        {
+            low_links[node_idx] = std::min(low_links[node_idx], find_times[neighbor_node_idx]);
+        }
     }
     if (low_links[node_idx] == find_times[node_idx])
     {
-      std::vector<size_t> scc = {};
-      size_t scc_node_idx;
-      do {
-        scc_node_idx = stack.top();
-        stack.pop();
-        on_stacks[scc_node_idx] = false;
-        scc.push_back(scc_node_idx);
-      } while (scc_node_idx != node_idx);
-      sccs.push_back(std::move(scc));
+        std::vector<size_t> scc = {};
+        size_t scc_node_idx;
+        do
+        {
+            scc_node_idx = stack.top();
+            stack.pop();
+            on_stacks[scc_node_idx] = false;
+            scc.push_back(scc_node_idx);
+        } while (scc_node_idx != node_idx);
+        sccs.push_back(std::move(scc));
     }
-  }
+}
 
-  std::vector<std::vector<std::string>>
-  find_strongly_connected_components(
-    std::vector<std::string> const& nodes,
-    std::vector<std::pair<size_t, size_t>> const& edges,
-    size_t minimum_component_size
-  )
-  {
+std::vector<std::vector<std::string>>
+find_strongly_connected_components(std::vector<std::string> const& nodes,
+                                   std::vector<std::pair<size_t, size_t>> const& edges,
+                                   size_t minimum_component_size)
+{
     std::vector<std::vector<size_t>> sccs;
     std::stack<int> stack = {};
     size_t time_index = 0;
@@ -73,26 +77,27 @@ namespace erin
     std::vector<bool> on_stacks(nodes.size(), false);
     for (size_t node_idx = 0; node_idx < nodes.size(); ++node_idx)
     {
-      if (find_times[node_idx] == -1)
-      {
-        strong_connect(time_index, node_idx, stack, find_times, low_links, on_stacks, sccs, nodes, edges);
-      }
+        if (find_times[node_idx] == -1)
+        {
+            strong_connect(
+                time_index, node_idx, stack, find_times, low_links, on_stacks, sccs, nodes, edges);
+        }
     }
     std::vector<std::vector<std::string>> result = {};
     for (std::vector<size_t> const& component : sccs)
     {
-      if (component.size() < minimum_component_size)
-      {
-        continue;
-      }
-      std::vector<std::string> component_nodes = {};
-      for (size_t node_idx : component)
-      {
-        component_nodes.push_back(nodes[node_idx]);
-      }
-      result.push_back(component_nodes);
+        if (component.size() < minimum_component_size)
+        {
+            continue;
+        }
+        std::vector<std::string> component_nodes = {};
+        for (size_t node_idx : component)
+        {
+            component_nodes.push_back(nodes[node_idx]);
+        }
+        result.push_back(component_nodes);
     }
     return result;
-  }
-
 }
+
+} // namespace erin

--- a/src/erin-simulation.cpp
+++ b/src/erin-simulation.cpp
@@ -150,7 +150,7 @@ void print_components(Simulation const& s)
         assert(compId < m.component.subtype_index.size());
         std::vector<size_t> const& outflowTypes = m.component.outflow_type[compId];
         std::vector<size_t> inflowTypes = m.component.inflow_type[compId];
-        std::cout << compId << ": " << ToString(m.component.component_type[compId]);
+        std::cout << compId << ": " << to_string(m.component.component_type[compId]);
         if (!m.component.tag[compId].empty())
         {
             std::cout << " -- " << m.component.tag[compId] << std::endl;

--- a/src/erin.cpp
+++ b/src/erin.cpp
@@ -167,7 +167,8 @@ std::vector<std::string> check_network(Model const& m)
             assert(inflow_conn_idx < num_conns);
             Connection const& inflow_conn = m.connection[inflow_conn_idx];
             size_t inflow_port = 0;
-            if ((inflow_conn.to != component_type) || (inflow_conn.to_component_id != component_id) ||
+            if ((inflow_conn.to != component_type) ||
+                (inflow_conn.to_component_id != component_id) ||
                 (inflow_conn.to_subtype_index != idx) || (inflow_conn.to_port != inflow_port))
             {
                 add_connection_issue(issues,
@@ -184,8 +185,10 @@ std::vector<std::string> check_network(Model const& m)
             assert(outflow_conn_idx < num_conns);
             Connection const& outflow_conn = m.connection[outflow_conn_idx];
             size_t outflow_port = 0;
-            if ((outflow_conn.from != component_type) || (outflow_conn.from_component_id != component_id) ||
-                (outflow_conn.from_subtype_index != idx) || (outflow_conn.from_port != outflow_port))
+            if ((outflow_conn.from != component_type) ||
+                (outflow_conn.from_component_id != component_id) ||
+                (outflow_conn.from_subtype_index != idx) ||
+                (outflow_conn.from_port != outflow_port))
             {
                 add_connection_issue(issues,
                                      tag,
@@ -220,7 +223,8 @@ std::vector<std::string> check_network(Model const& m)
                 assert(lf_conn_idx < num_conns);
                 Connection const& lf_conn = m.connection[lf_conn_idx];
                 size_t lf_port = 1;
-                if ((lf_conn.from != component_type) || (lf_conn.from_component_id != component_id) ||
+                if ((lf_conn.from != component_type) ||
+                    (lf_conn.from_component_id != component_id) ||
                     (lf_conn.from_subtype_index != idx) || (lf_conn.from_port != lf_port))
                 {
                     add_connection_issue(issues,
@@ -244,7 +248,8 @@ std::vector<std::string> check_network(Model const& m)
             assert(inflow_conn_idx < num_conns);
             Connection const& inflow_conn = m.connection[inflow_conn_idx];
             size_t inflow_port = 0;
-            if ((inflow_conn.to != component_type) || (inflow_conn.to_component_id != component_id) ||
+            if ((inflow_conn.to != component_type) ||
+                (inflow_conn.to_component_id != component_id) ||
                 (inflow_conn.to_subtype_index != idx) || (inflow_conn.to_port != inflow_port))
             {
                 add_connection_issue(issues,
@@ -261,8 +266,10 @@ std::vector<std::string> check_network(Model const& m)
             assert(outflow_conn_idx < num_conns);
             Connection const& outflow_conn = m.connection[outflow_conn_idx];
             size_t outflow_port = 0;
-            if ((outflow_conn.from != component_type) || (outflow_conn.from_component_id != component_id) ||
-                (outflow_conn.from_subtype_index != idx) || (outflow_conn.from_port != outflow_port))
+            if ((outflow_conn.from != component_type) ||
+                (outflow_conn.from_component_id != component_id) ||
+                (outflow_conn.from_subtype_index != idx) ||
+                (outflow_conn.from_port != outflow_port))
             {
                 add_connection_issue(issues,
                                      tag,
@@ -297,7 +304,8 @@ std::vector<std::string> check_network(Model const& m)
                 assert(lf_conn_idx < num_conns);
                 Connection const& lf_conn = m.connection[lf_conn_idx];
                 size_t lf_port = 1;
-                if ((lf_conn.from != component_type) || (lf_conn.from_component_id != component_id) ||
+                if ((lf_conn.from != component_type) ||
+                    (lf_conn.from_component_id != component_id) ||
                     (lf_conn.from_subtype_index != idx) || (lf_conn.from_port != lf_port))
                 {
                     add_connection_issue(issues,
@@ -320,7 +328,8 @@ std::vector<std::string> check_network(Model const& m)
             size_t inflow_conn_idx = comp.inflow_connection_id;
             Connection const& inflow_conn = m.connection[inflow_conn_idx];
             size_t inflow_port = 0;
-            if ((inflow_conn.to != component_type) || (inflow_conn.to_component_id != component_id) ||
+            if ((inflow_conn.to != component_type) ||
+                (inflow_conn.to_component_id != component_id) ||
                 (inflow_conn.to_subtype_index != idx) || (inflow_conn.to_port != inflow_port))
             {
                 add_connection_issue(issues,
@@ -343,8 +352,10 @@ std::vector<std::string> check_network(Model const& m)
             assert(outflow_conn_idx < num_conns);
             Connection const& outflow_conn = m.connection[outflow_conn_idx];
             size_t outflow_port = 0;
-            if ((outflow_conn.from != component_type) || (outflow_conn.from_component_id != component_id) ||
-                (outflow_conn.from_subtype_index != idx) || (outflow_conn.from_port != outflow_port))
+            if ((outflow_conn.from != component_type) ||
+                (outflow_conn.from_component_id != component_id) ||
+                (outflow_conn.from_subtype_index != idx) ||
+                (outflow_conn.from_port != outflow_port))
             {
                 add_connection_issue(issues,
                                      tag,
@@ -371,7 +382,8 @@ std::vector<std::string> check_network(Model const& m)
             assert(inflow_conn_idx < num_conns);
             Connection const& inflow_conn = m.connection[inflow_conn_idx];
             size_t inflow_port = 0;
-            if ((inflow_conn.to != component_type) || (inflow_conn.to_component_id != component_id) ||
+            if ((inflow_conn.to != component_type) ||
+                (inflow_conn.to_component_id != component_id) ||
                 (inflow_conn.to_subtype_index != idx) || (inflow_conn.to_port != inflow_port))
             {
                 add_connection_issue(issues,
@@ -388,8 +400,10 @@ std::vector<std::string> check_network(Model const& m)
             assert(outflow_conn_idx < num_conns);
             Connection const& outflow_conn = m.connection[outflow_conn_idx];
             size_t outflow_port = 0;
-            if ((outflow_conn.from != component_type) || (outflow_conn.from_component_id != component_id) ||
-                (outflow_conn.from_subtype_index != idx) || (outflow_conn.from_port != outflow_port))
+            if ((outflow_conn.from != component_type) ||
+                (outflow_conn.from_component_id != component_id) ||
+                (outflow_conn.from_subtype_index != idx) ||
+                (outflow_conn.from_port != outflow_port))
             {
                 add_connection_issue(issues,
                                      tag,
@@ -445,7 +459,8 @@ std::vector<std::string> check_network(Model const& m)
             assert(inflow_conn_idx < num_conns);
             Connection const& inflow_conn = m.connection[inflow_conn_idx];
             size_t inflow_port = 0;
-            if ((inflow_conn.to != component_type) || (inflow_conn.to_component_id != component_id) ||
+            if ((inflow_conn.to != component_type) ||
+                (inflow_conn.to_component_id != component_id) ||
                 (inflow_conn.to_subtype_index != idx) || (inflow_conn.to_port != inflow_port))
             {
                 add_connection_issue(issues,
@@ -462,8 +477,10 @@ std::vector<std::string> check_network(Model const& m)
             assert(outflow_conn_idx < num_conns);
             Connection const& outflow_conn = m.connection[outflow_conn_idx];
             size_t outflow_port = 0;
-            if ((outflow_conn.from != component_type) || (outflow_conn.from_component_id != component_id) ||
-                (outflow_conn.from_subtype_index != idx) || (outflow_conn.from_port != outflow_port))
+            if ((outflow_conn.from != component_type) ||
+                (outflow_conn.from_component_id != component_id) ||
+                (outflow_conn.from_subtype_index != idx) ||
+                (outflow_conn.from_port != outflow_port))
             {
                 add_connection_issue(issues,
                                      tag,
@@ -519,7 +536,8 @@ std::vector<std::string> check_network(Model const& m)
             {
                 size_t inflow_conn_idx = comp.inflow_connection_ids[in_port];
                 Connection const& inflow_conn = m.connection[inflow_conn_idx];
-                if ((inflow_conn.to != component_type) || (inflow_conn.to_component_id != component_id) ||
+                if ((inflow_conn.to != component_type) ||
+                    (inflow_conn.to_component_id != component_id) ||
                     (inflow_conn.to_subtype_index != idx) || (inflow_conn.to_port != in_port))
                 {
                     add_connection_issue(issues,
@@ -537,8 +555,10 @@ std::vector<std::string> check_network(Model const& m)
             {
                 size_t outflow_conn_idx = comp.outflow_connection_ids[out_port];
                 Connection const& outflow_conn = m.connection[outflow_conn_idx];
-                if ((outflow_conn.from != component_type) || (outflow_conn.from_component_id != component_id) ||
-                    (outflow_conn.from_subtype_index != idx) || (outflow_conn.from_port != out_port))
+                if ((outflow_conn.from != component_type) ||
+                    (outflow_conn.from_component_id != component_id) ||
+                    (outflow_conn.from_subtype_index != idx) ||
+                    (outflow_conn.from_port != out_port))
                 {
                     add_connection_issue(issues,
                                          tag,
@@ -560,7 +580,8 @@ std::vector<std::string> check_network(Model const& m)
             size_t inflow_conn_idx = comp.inflow_connection_id;
             Connection const& inflow_conn = m.connection[inflow_conn_idx];
             size_t inflow_port = 0;
-            if ((inflow_conn.to != component_type) || (inflow_conn.to_component_id != component_id) ||
+            if ((inflow_conn.to != component_type) ||
+                (inflow_conn.to_component_id != component_id) ||
                 (inflow_conn.to_subtype_index != idx) || (inflow_conn.to_port != inflow_port))
             {
                 add_connection_issue(issues,
@@ -576,8 +597,10 @@ std::vector<std::string> check_network(Model const& m)
             size_t outflow_conn_idx = comp.outflow_connection_id;
             Connection const& outflow_conn = m.connection[outflow_conn_idx];
             size_t outflow_port = 0;
-            if ((outflow_conn.from != component_type) || (outflow_conn.from_component_id != component_id) ||
-                (outflow_conn.from_subtype_index != idx) || (outflow_conn.from_port != outflow_port))
+            if ((outflow_conn.from != component_type) ||
+                (outflow_conn.from_component_id != component_id) ||
+                (outflow_conn.from_subtype_index != idx) ||
+                (outflow_conn.from_port != outflow_port))
             {
                 add_connection_issue(issues,
                                      tag,
@@ -634,8 +657,10 @@ std::vector<std::string> check_network(Model const& m)
             size_t outflow_conn_idx = comp.outflow_connection_id;
             Connection const& outflow_conn = m.connection[outflow_conn_idx];
             size_t outflow_port = 0;
-            if ((outflow_conn.from != component_type) || (outflow_conn.from_component_id != component_id) ||
-                (outflow_conn.from_subtype_index != idx) || (outflow_conn.from_port != outflow_port))
+            if ((outflow_conn.from != component_type) ||
+                (outflow_conn.from_component_id != component_id) ||
+                (outflow_conn.from_subtype_index != idx) ||
+                (outflow_conn.from_port != outflow_port))
             {
                 add_connection_issue(issues,
                                      tag,
@@ -656,7 +681,8 @@ std::vector<std::string> check_network(Model const& m)
             size_t inflow_conn_idx = comp.inflow_connection_id;
             Connection const& inflow_conn = m.connection[inflow_conn_idx];
             size_t inflow_port = 0;
-            if ((inflow_conn.to != component_type) || (inflow_conn.to_component_id != component_id) ||
+            if ((inflow_conn.to != component_type) ||
+                (inflow_conn.to_component_id != component_id) ||
                 (inflow_conn.to_subtype_index != idx) || (inflow_conn.to_port != inflow_port))
             {
                 add_connection_issue(issues,
@@ -678,8 +704,10 @@ std::vector<std::string> check_network(Model const& m)
             size_t outflow_conn_idx = comp.outflow_connection_id;
             Connection const& outflow_conn = m.connection[outflow_conn_idx];
             size_t outflow_port = 0;
-            if ((outflow_conn.from != component_type) || (outflow_conn.from_component_id != component_id) ||
-                (outflow_conn.from_subtype_index != idx) || (outflow_conn.from_port != outflow_port))
+            if ((outflow_conn.from != component_type) ||
+                (outflow_conn.from_component_id != component_id) ||
+                (outflow_conn.from_subtype_index != idx) ||
+                (outflow_conn.from_port != outflow_port))
             {
                 add_connection_issue(issues,
                                      tag,
@@ -716,8 +744,10 @@ std::vector<std::string> check_network(Model const& m)
             size_t outflow_conn_idx = comp.outflow_connection_id;
             Connection const& outflow_conn = m.connection[outflow_conn_idx];
             size_t outflow_port = 0;
-            if ((outflow_conn.from != component_type) || (outflow_conn.from_component_id != component_id) ||
-                (outflow_conn.from_subtype_index != idx) || (outflow_conn.from_port != outflow_port))
+            if ((outflow_conn.from != component_type) ||
+                (outflow_conn.from_component_id != component_id) ||
+                (outflow_conn.from_subtype_index != idx) ||
+                (outflow_conn.from_port != outflow_port))
             {
                 add_connection_issue(issues,
                                      tag,
@@ -734,7 +764,8 @@ std::vector<std::string> check_network(Model const& m)
                 size_t inflowConnIdx = comp.inflow_connection_id.value();
                 Connection const& inflowConn = m.connection[inflowConnIdx];
                 size_t inflowPort = 0;
-                if ((inflowConn.to != component_type) || (inflowConn.to_component_id != component_id) ||
+                if ((inflowConn.to != component_type) ||
+                    (inflowConn.to_component_id != component_id) ||
                     (inflowConn.to_subtype_index != idx) || (inflowConn.to_port != inflowPort))
                 {
                     add_connection_issue(issues,

--- a/src/erin.cpp
+++ b/src/erin.cpp
@@ -123,14 +123,13 @@ void add_connection_issue(std::vector<std::string>& issues,
     issues.push_back(oss.str());
 }
 
-std::vector<std::pair<size_t, size_t>>
-connections_to_edges(std::vector<Connection> const& conns)
+std::vector<std::pair<size_t, size_t>> connections_to_edges(std::vector<Connection> const& conns)
 {
     std::vector<std::pair<size_t, size_t>> result(conns.size());
     for (size_t conn_idx = 0; conn_idx < conns.size(); ++conn_idx)
     {
         auto const& c = conns[conn_idx];
-        std::pair<size_t, size_t> edge = { c.from_component_id, c.to_component_id };
+        std::pair<size_t, size_t> edge = {c.from_component_id, c.to_component_id};
         result[conn_idx] = std::move(edge);
     }
     return result;
@@ -986,8 +985,7 @@ std::vector<std::string> check_network(Model const& m)
             }
         }
     }
-    std::vector<std::pair<size_t, size_t>> edges =
-        connections_to_edges(m.connection);
+    std::vector<std::pair<size_t, size_t>> edges = connections_to_edges(m.connection);
     std::vector<std::vector<std::string>> sccs =
         find_strongly_connected_components(m.component.tag, edges);
     if (sccs.size() > 0)

--- a/src/erin.cpp
+++ b/src/erin.cpp
@@ -123,17 +123,17 @@ void add_connection_issue(std::vector<std::string>& issues,
 std::vector<std::string> check_network(Model const& m)
 {
     std::vector<std::string> issues;
-    std::unordered_set<std::string> connectedOutflowPorts;
-    std::unordered_set<std::string> connectedInflowPorts;
-    std::unordered_set<std::string> compTags;
+    std::unordered_set<std::string> connected_outflow_ports;
+    std::unordered_set<std::string> connected_inflow_ports;
+    std::unordered_set<std::string> comp_tags;
     {
         for (auto const& tag : m.component.tag)
         {
-            if (!tag.empty() && compTags.contains(tag))
+            if (!tag.empty() && comp_tags.contains(tag))
             {
                 issues.push_back("multiple components with name '" + tag + "'");
             }
-            compTags.insert(tag);
+            comp_tags.insert(tag);
         }
     }
     assert(m.component.component_type.size() == m.component.inflow_type.size());
@@ -142,95 +142,95 @@ std::vector<std::string> check_network(Model const& m)
     assert(m.component.component_type.size() == m.component.initial_age_s.size());
     assert(m.component.component_type.size() == m.component.report.size());
     assert(m.component.component_type.size() == m.component.tag.size());
-    std::unordered_map<size_t, std::set<size_t>> muxCompIdToInflowConns;
-    std::unordered_map<size_t, std::set<size_t>> muxCompIdToOutflowConns;
-    for (size_t compId = 0; compId < m.component.component_type.size(); ++compId)
+    std::unordered_map<size_t, std::set<size_t>> mux_comp_id_to_inflow_conns;
+    std::unordered_map<size_t, std::set<size_t>> mux_comp_id_to_outflow_conns;
+    for (size_t component_id = 0; component_id < m.component.component_type.size(); ++component_id)
     {
-        assert(compId < m.component.component_type.size());
-        if (m.component.component_type[compId] == ComponentType::mux_type)
+        assert(component_id < m.component.component_type.size());
+        if (m.component.component_type[component_id] == ComponentType::mux_type)
         {
-            muxCompIdToInflowConns[compId] = std::set<size_t> {};
-            muxCompIdToOutflowConns[compId] = std::set<size_t> {};
+            mux_comp_id_to_inflow_conns[component_id] = std::set<size_t> {};
+            mux_comp_id_to_outflow_conns[component_id] = std::set<size_t> {};
         }
-        ComponentType compType = m.component.component_type[compId];
-        size_t idx = m.component.subtype_index[compId];
-        std::string const& tag = m.component.tag[compId];
-        size_t nConns = m.connection.size();
-        ignore(nConns);
-        switch (compType)
+        ComponentType component_type = m.component.component_type[component_id];
+        size_t idx = m.component.subtype_index[component_id];
+        std::string const& tag = m.component.tag[component_id];
+        size_t num_conns = m.connection.size();
+        ignore(num_conns);
+        switch (component_type)
         {
         case ComponentType::constant_efficiency_converter_type:
         {
             assert(idx < m.constant_efficiency_converter.size());
             ConstantEfficiencyConverter const& cec = m.constant_efficiency_converter[idx];
-            size_t inflowConnIdx = cec.inflow_connection_id;
-            assert(inflowConnIdx < nConns);
-            Connection const& inflowConn = m.connection[inflowConnIdx];
-            size_t inflowPort = 0;
-            if ((inflowConn.to != compType) || (inflowConn.to_component_id != compId) ||
-                (inflowConn.to_subtype_index != idx) || (inflowConn.to_port != inflowPort))
+            size_t inflow_conn_idx = cec.inflow_connection_id;
+            assert(inflow_conn_idx < num_conns);
+            Connection const& inflow_conn = m.connection[inflow_conn_idx];
+            size_t inflow_port = 0;
+            if ((inflow_conn.to != component_type) || (inflow_conn.to_component_id != component_id) ||
+                (inflow_conn.to_subtype_index != idx) || (inflow_conn.to_port != inflow_port))
             {
                 add_connection_issue(issues,
                                      tag,
-                                     compId,
-                                     inflowPort,
+                                     component_id,
+                                     inflow_port,
                                      idx,
-                                     compType,
-                                     inflowConn,
-                                     inflowConnIdx,
+                                     component_type,
+                                     inflow_conn,
+                                     inflow_conn_idx,
                                      FlowDirection::inflow);
             }
-            size_t outflowConnIdx = cec.outflow_connection_id;
-            assert(outflowConnIdx < nConns);
-            Connection const& outflowConn = m.connection[outflowConnIdx];
-            size_t outflowPort = 0;
-            if ((outflowConn.from != compType) || (outflowConn.from_component_id != compId) ||
-                (outflowConn.from_subtype_index != idx) || (outflowConn.from_port != outflowPort))
+            size_t outflow_conn_idx = cec.outflow_connection_id;
+            assert(outflow_conn_idx < num_conns);
+            Connection const& outflow_conn = m.connection[outflow_conn_idx];
+            size_t outflow_port = 0;
+            if ((outflow_conn.from != component_type) || (outflow_conn.from_component_id != component_id) ||
+                (outflow_conn.from_subtype_index != idx) || (outflow_conn.from_port != outflow_port))
             {
                 add_connection_issue(issues,
                                      tag,
-                                     compId,
-                                     outflowPort,
+                                     component_id,
+                                     outflow_port,
                                      idx,
-                                     compType,
-                                     outflowConn,
-                                     outflowConnIdx,
+                                     component_type,
+                                     outflow_conn,
+                                     outflow_conn_idx,
                                      FlowDirection::outflow);
             }
-            size_t wasteflowConnIdx = cec.wasteflow_connection_id;
-            assert(wasteflowConnIdx < nConns);
-            Connection const& wfConn = m.connection[wasteflowConnIdx];
-            size_t wfPort = 2;
-            if ((wfConn.from != compType) || (wfConn.from_component_id != compId) ||
-                (wfConn.from_subtype_index != idx) || (wfConn.from_port != wfPort))
+            size_t wasteflow_conn_idx = cec.wasteflow_connection_id;
+            assert(wasteflow_conn_idx < num_conns);
+            Connection const& wf_conn = m.connection[wasteflow_conn_idx];
+            size_t wf_port = 2;
+            if ((wf_conn.from != component_type) || (wf_conn.from_component_id != component_id) ||
+                (wf_conn.from_subtype_index != idx) || (wf_conn.from_port != wf_port))
             {
                 add_connection_issue(issues,
                                      tag,
-                                     compId,
-                                     wfPort,
+                                     component_id,
+                                     wf_port,
                                      idx,
-                                     compType,
-                                     wfConn,
-                                     wasteflowConnIdx,
+                                     component_type,
+                                     wf_conn,
+                                     wasteflow_conn_idx,
                                      FlowDirection::outflow);
             }
             if (cec.lossflow_connection_id.has_value())
             {
-                size_t lfConnIdx = cec.lossflow_connection_id.value();
-                assert(lfConnIdx < nConns);
-                Connection const& lfConn = m.connection[lfConnIdx];
-                size_t lfPort = 1;
-                if ((lfConn.from != compType) || (lfConn.from_component_id != compId) ||
-                    (lfConn.from_subtype_index != idx) || (lfConn.from_port != lfPort))
+                size_t lf_conn_idx = cec.lossflow_connection_id.value();
+                assert(lf_conn_idx < num_conns);
+                Connection const& lf_conn = m.connection[lf_conn_idx];
+                size_t lf_port = 1;
+                if ((lf_conn.from != component_type) || (lf_conn.from_component_id != component_id) ||
+                    (lf_conn.from_subtype_index != idx) || (lf_conn.from_port != lf_port))
                 {
                     add_connection_issue(issues,
                                          tag,
-                                         compId,
-                                         lfPort,
+                                         component_id,
+                                         lf_port,
                                          idx,
-                                         compType,
-                                         lfConn,
-                                         lfConnIdx,
+                                         component_type,
+                                         lf_conn,
+                                         lf_conn_idx,
                                          FlowDirection::outflow);
                 }
             }
@@ -240,74 +240,74 @@ std::vector<std::string> check_network(Model const& m)
         {
             assert(idx < m.variable_efficiency_converter.size());
             VariableEfficiencyConverter const& vec = m.variable_efficiency_converter[idx];
-            size_t inflowConnIdx = vec.inflow_connection_id;
-            assert(inflowConnIdx < nConns);
-            Connection const& inflowConn = m.connection[inflowConnIdx];
-            size_t inflowPort = 0;
-            if ((inflowConn.to != compType) || (inflowConn.to_component_id != compId) ||
-                (inflowConn.to_subtype_index != idx) || (inflowConn.to_port != inflowPort))
+            size_t inflow_conn_idx = vec.inflow_connection_id;
+            assert(inflow_conn_idx < num_conns);
+            Connection const& inflow_conn = m.connection[inflow_conn_idx];
+            size_t inflow_port = 0;
+            if ((inflow_conn.to != component_type) || (inflow_conn.to_component_id != component_id) ||
+                (inflow_conn.to_subtype_index != idx) || (inflow_conn.to_port != inflow_port))
             {
                 add_connection_issue(issues,
                                      tag,
-                                     compId,
-                                     inflowPort,
+                                     component_id,
+                                     inflow_port,
                                      idx,
-                                     compType,
-                                     inflowConn,
-                                     inflowConnIdx,
+                                     component_type,
+                                     inflow_conn,
+                                     inflow_conn_idx,
                                      FlowDirection::inflow);
             }
-            size_t outflowConnIdx = vec.outflow_connection_id;
-            assert(outflowConnIdx < nConns);
-            Connection const& outflowConn = m.connection[outflowConnIdx];
-            size_t outflowPort = 0;
-            if ((outflowConn.from != compType) || (outflowConn.from_component_id != compId) ||
-                (outflowConn.from_subtype_index != idx) || (outflowConn.from_port != outflowPort))
+            size_t outflow_conn_idx = vec.outflow_connection_id;
+            assert(outflow_conn_idx < num_conns);
+            Connection const& outflow_conn = m.connection[outflow_conn_idx];
+            size_t outflow_port = 0;
+            if ((outflow_conn.from != component_type) || (outflow_conn.from_component_id != component_id) ||
+                (outflow_conn.from_subtype_index != idx) || (outflow_conn.from_port != outflow_port))
             {
                 add_connection_issue(issues,
                                      tag,
-                                     compId,
-                                     outflowPort,
+                                     component_id,
+                                     outflow_port,
                                      idx,
-                                     compType,
-                                     outflowConn,
-                                     outflowConnIdx,
+                                     component_type,
+                                     outflow_conn,
+                                     outflow_conn_idx,
                                      FlowDirection::outflow);
             }
-            size_t wasteflowConnIdx = vec.wasteflow_connection_id;
-            assert(wasteflowConnIdx < nConns);
-            Connection const& wfConn = m.connection[wasteflowConnIdx];
-            size_t wfPort = 2;
-            if ((wfConn.from != compType) || (wfConn.from_component_id != compId) ||
-                (wfConn.from_subtype_index != idx) || (wfConn.from_port != wfPort))
+            size_t wasteflow_conn_idx = vec.wasteflow_connection_id;
+            assert(wasteflow_conn_idx < num_conns);
+            Connection const& wf_conn = m.connection[wasteflow_conn_idx];
+            size_t wf_port = 2;
+            if ((wf_conn.from != component_type) || (wf_conn.from_component_id != component_id) ||
+                (wf_conn.from_subtype_index != idx) || (wf_conn.from_port != wf_port))
             {
                 add_connection_issue(issues,
                                      tag,
-                                     compId,
-                                     wfPort,
+                                     component_id,
+                                     wf_port,
                                      idx,
-                                     compType,
-                                     wfConn,
-                                     wasteflowConnIdx,
+                                     component_type,
+                                     wf_conn,
+                                     wasteflow_conn_idx,
                                      FlowDirection::outflow);
             }
             if (vec.lossflow_connection_id.has_value())
             {
-                size_t lfConnIdx = vec.lossflow_connection_id.value();
-                assert(lfConnIdx < nConns);
-                Connection const& lfConn = m.connection[lfConnIdx];
-                size_t lfPort = 1;
-                if ((lfConn.from != compType) || (lfConn.from_component_id != compId) ||
-                    (lfConn.from_subtype_index != idx) || (lfConn.from_port != lfPort))
+                size_t lf_conn_idx = vec.lossflow_connection_id.value();
+                assert(lf_conn_idx < num_conns);
+                Connection const& lf_conn = m.connection[lf_conn_idx];
+                size_t lf_port = 1;
+                if ((lf_conn.from != component_type) || (lf_conn.from_component_id != component_id) ||
+                    (lf_conn.from_subtype_index != idx) || (lf_conn.from_port != lf_port))
                 {
                     add_connection_issue(issues,
                                          tag,
-                                         compId,
-                                         lfPort,
+                                         component_id,
+                                         lf_port,
                                          idx,
-                                         compType,
-                                         lfConn,
-                                         lfConnIdx,
+                                         component_type,
+                                         lf_conn,
+                                         lf_conn_idx,
                                          FlowDirection::outflow);
                 }
             }
@@ -317,20 +317,20 @@ std::vector<std::string> check_network(Model const& m)
         {
             assert(idx < m.constant_load.size());
             ConstantLoad const& comp = m.constant_load[idx];
-            size_t inflowConnIdx = comp.inflow_connection_id;
-            Connection const& inflowConn = m.connection[inflowConnIdx];
-            size_t inflowPort = 0;
-            if ((inflowConn.to != compType) || (inflowConn.to_component_id != compId) ||
-                (inflowConn.to_subtype_index != idx) || (inflowConn.to_port != inflowPort))
+            size_t inflow_conn_idx = comp.inflow_connection_id;
+            Connection const& inflow_conn = m.connection[inflow_conn_idx];
+            size_t inflow_port = 0;
+            if ((inflow_conn.to != component_type) || (inflow_conn.to_component_id != component_id) ||
+                (inflow_conn.to_subtype_index != idx) || (inflow_conn.to_port != inflow_port))
             {
                 add_connection_issue(issues,
                                      tag,
-                                     compId,
-                                     inflowPort,
+                                     component_id,
+                                     inflow_port,
                                      idx,
-                                     compType,
-                                     inflowConn,
-                                     inflowConnIdx,
+                                     component_type,
+                                     inflow_conn,
+                                     inflow_conn_idx,
                                      FlowDirection::inflow);
             }
         }
@@ -339,21 +339,21 @@ std::vector<std::string> check_network(Model const& m)
         {
             assert(idx < m.constant_source.size());
             ConstantSource const& comp = m.constant_source[idx];
-            size_t outflowConnIdx = comp.outflow_connection_id;
-            assert(outflowConnIdx < nConns);
-            Connection const& outflowConn = m.connection[outflowConnIdx];
-            size_t outflowPort = 0;
-            if ((outflowConn.from != compType) || (outflowConn.from_component_id != compId) ||
-                (outflowConn.from_subtype_index != idx) || (outflowConn.from_port != outflowPort))
+            size_t outflow_conn_idx = comp.outflow_connection_id;
+            assert(outflow_conn_idx < num_conns);
+            Connection const& outflow_conn = m.connection[outflow_conn_idx];
+            size_t outflow_port = 0;
+            if ((outflow_conn.from != component_type) || (outflow_conn.from_component_id != component_id) ||
+                (outflow_conn.from_subtype_index != idx) || (outflow_conn.from_port != outflow_port))
             {
                 add_connection_issue(issues,
                                      tag,
-                                     compId,
-                                     outflowPort,
+                                     component_id,
+                                     outflow_port,
                                      idx,
-                                     compType,
-                                     outflowConn,
-                                     outflowConnIdx,
+                                     component_type,
+                                     outflow_conn,
+                                     outflow_conn_idx,
                                      FlowDirection::outflow);
             }
         }
@@ -367,72 +367,72 @@ std::vector<std::string> check_network(Model const& m)
         {
             assert(idx < m.mover.size());
             Mover const& comp = m.mover[idx];
-            size_t inflowConnIdx = comp.inflow_connection_id;
-            assert(inflowConnIdx < nConns);
-            Connection const& inflowConn = m.connection[inflowConnIdx];
-            size_t inflowPort = 0;
-            if ((inflowConn.to != compType) || (inflowConn.to_component_id != compId) ||
-                (inflowConn.to_subtype_index != idx) || (inflowConn.to_port != inflowPort))
+            size_t inflow_conn_idx = comp.inflow_connection_id;
+            assert(inflow_conn_idx < num_conns);
+            Connection const& inflow_conn = m.connection[inflow_conn_idx];
+            size_t inflow_port = 0;
+            if ((inflow_conn.to != component_type) || (inflow_conn.to_component_id != component_id) ||
+                (inflow_conn.to_subtype_index != idx) || (inflow_conn.to_port != inflow_port))
             {
                 add_connection_issue(issues,
                                      tag,
-                                     compId,
-                                     inflowPort,
+                                     component_id,
+                                     inflow_port,
                                      idx,
-                                     compType,
-                                     inflowConn,
-                                     inflowConnIdx,
+                                     component_type,
+                                     inflow_conn,
+                                     inflow_conn_idx,
                                      FlowDirection::inflow);
             }
-            size_t outflowConnIdx = comp.outflow_connection_id;
-            assert(outflowConnIdx < nConns);
-            Connection const& outflowConn = m.connection[outflowConnIdx];
-            size_t outflowPort = 0;
-            if ((outflowConn.from != compType) || (outflowConn.from_component_id != compId) ||
-                (outflowConn.from_subtype_index != idx) || (outflowConn.from_port != outflowPort))
+            size_t outflow_conn_idx = comp.outflow_connection_id;
+            assert(outflow_conn_idx < num_conns);
+            Connection const& outflow_conn = m.connection[outflow_conn_idx];
+            size_t outflow_port = 0;
+            if ((outflow_conn.from != component_type) || (outflow_conn.from_component_id != component_id) ||
+                (outflow_conn.from_subtype_index != idx) || (outflow_conn.from_port != outflow_port))
             {
                 add_connection_issue(issues,
                                      tag,
-                                     compId,
-                                     outflowPort,
+                                     component_id,
+                                     outflow_port,
                                      idx,
-                                     compType,
-                                     outflowConn,
-                                     outflowConnIdx,
+                                     component_type,
+                                     outflow_conn,
+                                     outflow_conn_idx,
                                      FlowDirection::outflow);
             }
-            size_t envConnIdx = comp.in_from_env_connection_id;
-            assert(envConnIdx < nConns);
-            Connection const& envConn = m.connection[envConnIdx];
-            size_t envInflowPort = 1;
-            if ((envConn.to != compType) || (envConn.to_component_id != compId) ||
-                (envConn.to_subtype_index != idx) || (envConn.to_port != envInflowPort))
+            size_t env_conn_idx = comp.in_from_env_connection_id;
+            assert(env_conn_idx < num_conns);
+            Connection const& env_conn = m.connection[env_conn_idx];
+            size_t env_inflow_port = 1;
+            if ((env_conn.to != component_type) || (env_conn.to_component_id != component_id) ||
+                (env_conn.to_subtype_index != idx) || (env_conn.to_port != env_inflow_port))
             {
                 add_connection_issue(issues,
                                      tag,
-                                     compId,
-                                     envInflowPort,
+                                     component_id,
+                                     env_inflow_port,
                                      idx,
-                                     compType,
-                                     envConn,
-                                     envConnIdx,
+                                     component_type,
+                                     env_conn,
+                                     env_conn_idx,
                                      FlowDirection::inflow);
             }
-            size_t wConnIdx = comp.wasteflow_connection_id;
-            assert(wConnIdx < nConns);
-            Connection const& wConn = m.connection[wConnIdx];
-            size_t wasteOutflowPort = 1;
-            if ((wConn.from != compType) || (wConn.from_component_id != compId) ||
-                (wConn.from_subtype_index != idx) || (wConn.from_port != wasteOutflowPort))
+            size_t w_conn_idx = comp.wasteflow_connection_id;
+            assert(w_conn_idx < num_conns);
+            Connection const& w_conn = m.connection[w_conn_idx];
+            size_t waste_outflow_port = 1;
+            if ((w_conn.from != component_type) || (w_conn.from_component_id != component_id) ||
+                (w_conn.from_subtype_index != idx) || (w_conn.from_port != waste_outflow_port))
             {
                 add_connection_issue(issues,
                                      tag,
-                                     compId,
-                                     wasteOutflowPort,
+                                     component_id,
+                                     waste_outflow_port,
                                      idx,
-                                     compType,
-                                     wConn,
-                                     wConnIdx,
+                                     component_type,
+                                     w_conn,
+                                     w_conn_idx,
                                      FlowDirection::outflow);
             }
         }
@@ -441,72 +441,72 @@ std::vector<std::string> check_network(Model const& m)
         {
             assert(idx < m.variable_efficiency_mover.size());
             VariableEfficiencyMover const& comp = m.variable_efficiency_mover[idx];
-            size_t inflowConnIdx = comp.inflow_connection_id;
-            assert(inflowConnIdx < nConns);
-            Connection const& inflowConn = m.connection[inflowConnIdx];
-            size_t inflowPort = 0;
-            if ((inflowConn.to != compType) || (inflowConn.to_component_id != compId) ||
-                (inflowConn.to_subtype_index != idx) || (inflowConn.to_port != inflowPort))
+            size_t inflow_conn_idx = comp.inflow_connection_id;
+            assert(inflow_conn_idx < num_conns);
+            Connection const& inflow_conn = m.connection[inflow_conn_idx];
+            size_t inflow_port = 0;
+            if ((inflow_conn.to != component_type) || (inflow_conn.to_component_id != component_id) ||
+                (inflow_conn.to_subtype_index != idx) || (inflow_conn.to_port != inflow_port))
             {
                 add_connection_issue(issues,
                                      tag,
-                                     compId,
-                                     inflowPort,
+                                     component_id,
+                                     inflow_port,
                                      idx,
-                                     compType,
-                                     inflowConn,
-                                     inflowConnIdx,
+                                     component_type,
+                                     inflow_conn,
+                                     inflow_conn_idx,
                                      FlowDirection::inflow);
             }
-            size_t outflowConnIdx = comp.outflow_connection_id;
-            assert(outflowConnIdx < nConns);
-            Connection const& outflowConn = m.connection[outflowConnIdx];
-            size_t outflowPort = 0;
-            if ((outflowConn.from != compType) || (outflowConn.from_component_id != compId) ||
-                (outflowConn.from_subtype_index != idx) || (outflowConn.from_port != outflowPort))
+            size_t outflow_conn_idx = comp.outflow_connection_id;
+            assert(outflow_conn_idx < num_conns);
+            Connection const& outflow_conn = m.connection[outflow_conn_idx];
+            size_t outflow_port = 0;
+            if ((outflow_conn.from != component_type) || (outflow_conn.from_component_id != component_id) ||
+                (outflow_conn.from_subtype_index != idx) || (outflow_conn.from_port != outflow_port))
             {
                 add_connection_issue(issues,
                                      tag,
-                                     compId,
-                                     outflowPort,
+                                     component_id,
+                                     outflow_port,
                                      idx,
-                                     compType,
-                                     outflowConn,
-                                     outflowConnIdx,
+                                     component_type,
+                                     outflow_conn,
+                                     outflow_conn_idx,
                                      FlowDirection::outflow);
             }
-            size_t envConnIdx = comp.in_from_env_connection_id;
-            assert(envConnIdx < nConns);
-            Connection const& envConn = m.connection[envConnIdx];
-            size_t envInflowPort = 1;
-            if ((envConn.to != compType) || (envConn.to_component_id != compId) ||
-                (envConn.to_subtype_index != idx) || (envConn.to_port != envInflowPort))
+            size_t env_conn_idx = comp.in_from_env_connection_id;
+            assert(env_conn_idx < num_conns);
+            Connection const& env_conn = m.connection[env_conn_idx];
+            size_t env_inflow_port = 1;
+            if ((env_conn.to != component_type) || (env_conn.to_component_id != component_id) ||
+                (env_conn.to_subtype_index != idx) || (env_conn.to_port != env_inflow_port))
             {
                 add_connection_issue(issues,
                                      tag,
-                                     compId,
-                                     envInflowPort,
+                                     component_id,
+                                     env_inflow_port,
                                      idx,
-                                     compType,
-                                     envConn,
-                                     envConnIdx,
+                                     component_type,
+                                     env_conn,
+                                     env_conn_idx,
                                      FlowDirection::inflow);
             }
-            size_t wConnIdx = comp.wasteflow_connection_id;
-            assert(wConnIdx < nConns);
-            Connection const& wConn = m.connection[wConnIdx];
-            size_t wasteOutflowPort = 1;
-            if ((wConn.from != compType) || (wConn.from_component_id != compId) ||
-                (wConn.from_subtype_index != idx) || (wConn.from_port != wasteOutflowPort))
+            size_t w_conn_idx = comp.wasteflow_connection_id;
+            assert(w_conn_idx < num_conns);
+            Connection const& w_conn = m.connection[w_conn_idx];
+            size_t waste_outflow_port = 1;
+            if ((w_conn.from != component_type) || (w_conn.from_component_id != component_id) ||
+                (w_conn.from_subtype_index != idx) || (w_conn.from_port != waste_outflow_port))
             {
                 add_connection_issue(issues,
                                      tag,
-                                     compId,
-                                     wasteOutflowPort,
+                                     component_id,
+                                     waste_outflow_port,
                                      idx,
-                                     compType,
-                                     wConn,
-                                     wConnIdx,
+                                     component_type,
+                                     w_conn,
+                                     w_conn_idx,
                                      FlowDirection::outflow);
             }
         }
@@ -515,39 +515,39 @@ std::vector<std::string> check_network(Model const& m)
         {
             assert(idx < m.mux.size());
             Mux const& comp = m.mux[idx];
-            for (size_t inPort = 0; inPort < comp.number_of_inports; ++inPort)
+            for (size_t in_port = 0; in_port < comp.number_of_inports; ++in_port)
             {
-                size_t inflowConnIdx = comp.inflow_connection_ids[inPort];
-                Connection const& inflowConn = m.connection[inflowConnIdx];
-                if ((inflowConn.to != compType) || (inflowConn.to_component_id != compId) ||
-                    (inflowConn.to_subtype_index != idx) || (inflowConn.to_port != inPort))
+                size_t inflow_conn_idx = comp.inflow_connection_ids[in_port];
+                Connection const& inflow_conn = m.connection[inflow_conn_idx];
+                if ((inflow_conn.to != component_type) || (inflow_conn.to_component_id != component_id) ||
+                    (inflow_conn.to_subtype_index != idx) || (inflow_conn.to_port != in_port))
                 {
                     add_connection_issue(issues,
                                          tag,
-                                         compId,
-                                         inPort,
+                                         component_id,
+                                         in_port,
                                          idx,
-                                         compType,
-                                         inflowConn,
-                                         inflowConnIdx,
+                                         component_type,
+                                         inflow_conn,
+                                         inflow_conn_idx,
                                          FlowDirection::inflow);
                 }
             }
-            for (size_t outPort = 0; outPort < comp.number_of_outports; ++outPort)
+            for (size_t out_port = 0; out_port < comp.number_of_outports; ++out_port)
             {
-                size_t outflowConnIdx = comp.outflow_connection_ids[outPort];
-                Connection const& outflowConn = m.connection[outflowConnIdx];
-                if ((outflowConn.from != compType) || (outflowConn.from_component_id != compId) ||
-                    (outflowConn.from_subtype_index != idx) || (outflowConn.from_port != outPort))
+                size_t outflow_conn_idx = comp.outflow_connection_ids[out_port];
+                Connection const& outflow_conn = m.connection[outflow_conn_idx];
+                if ((outflow_conn.from != component_type) || (outflow_conn.from_component_id != component_id) ||
+                    (outflow_conn.from_subtype_index != idx) || (outflow_conn.from_port != out_port))
                 {
                     add_connection_issue(issues,
                                          tag,
-                                         compId,
-                                         outPort,
+                                         component_id,
+                                         out_port,
                                          idx,
-                                         compType,
-                                         outflowConn,
-                                         outflowConnIdx,
+                                         component_type,
+                                         outflow_conn,
+                                         outflow_conn_idx,
                                          FlowDirection::outflow);
                 }
             }
@@ -557,36 +557,36 @@ std::vector<std::string> check_network(Model const& m)
         {
             assert(idx < m.pass_through.size());
             PassThrough const& comp = m.pass_through[idx];
-            size_t inflowConnIdx = comp.inflow_connection_id;
-            Connection const& inflowConn = m.connection[inflowConnIdx];
-            size_t inflowPort = 0;
-            if ((inflowConn.to != compType) || (inflowConn.to_component_id != compId) ||
-                (inflowConn.to_subtype_index != idx) || (inflowConn.to_port != inflowPort))
+            size_t inflow_conn_idx = comp.inflow_connection_id;
+            Connection const& inflow_conn = m.connection[inflow_conn_idx];
+            size_t inflow_port = 0;
+            if ((inflow_conn.to != component_type) || (inflow_conn.to_component_id != component_id) ||
+                (inflow_conn.to_subtype_index != idx) || (inflow_conn.to_port != inflow_port))
             {
                 add_connection_issue(issues,
                                      tag,
-                                     compId,
-                                     inflowPort,
+                                     component_id,
+                                     inflow_port,
                                      idx,
-                                     compType,
-                                     inflowConn,
-                                     inflowConnIdx,
+                                     component_type,
+                                     inflow_conn,
+                                     inflow_conn_idx,
                                      FlowDirection::inflow);
             }
-            size_t outflowConnIdx = comp.outflow_connection_id;
-            Connection const& outflowConn = m.connection[outflowConnIdx];
-            size_t outflowPort = 0;
-            if ((outflowConn.from != compType) || (outflowConn.from_component_id != compId) ||
-                (outflowConn.from_subtype_index != idx) || (outflowConn.from_port != outflowPort))
+            size_t outflow_conn_idx = comp.outflow_connection_id;
+            Connection const& outflow_conn = m.connection[outflow_conn_idx];
+            size_t outflow_port = 0;
+            if ((outflow_conn.from != component_type) || (outflow_conn.from_component_id != component_id) ||
+                (outflow_conn.from_subtype_index != idx) || (outflow_conn.from_port != outflow_port))
             {
                 add_connection_issue(issues,
                                      tag,
-                                     compId,
-                                     outflowPort,
+                                     component_id,
+                                     outflow_port,
                                      idx,
-                                     compType,
-                                     outflowConn,
-                                     outflowConnIdx,
+                                     component_type,
+                                     outflow_conn,
+                                     outflow_conn_idx,
                                      FlowDirection::outflow);
             }
         }
@@ -595,56 +595,56 @@ std::vector<std::string> check_network(Model const& m)
         {
             assert(idx < m.transfer_switch.size());
             Switch const& comp = m.transfer_switch[idx];
-            size_t primaryInflowConnIdx = comp.inflow_connection_id_primary;
-            Connection const& primaryInflowConn = m.connection[primaryInflowConnIdx];
-            size_t primaryInflowPort = 0;
-            if ((primaryInflowConn.to != compType) ||
-                (primaryInflowConn.to_component_id != compId) ||
-                (primaryInflowConn.to_subtype_index != idx) ||
-                (primaryInflowConn.to_port != primaryInflowPort))
+            size_t primary_inflow_conn_idx = comp.inflow_connection_id_primary;
+            Connection const& primary_inflow_conn = m.connection[primary_inflow_conn_idx];
+            size_t primary_inflow_port = 0;
+            if ((primary_inflow_conn.to != component_type) ||
+                (primary_inflow_conn.to_component_id != component_id) ||
+                (primary_inflow_conn.to_subtype_index != idx) ||
+                (primary_inflow_conn.to_port != primary_inflow_port))
             {
                 add_connection_issue(issues,
                                      tag,
-                                     compId,
-                                     primaryInflowPort,
+                                     component_id,
+                                     primary_inflow_port,
                                      idx,
-                                     compType,
-                                     primaryInflowConn,
-                                     primaryInflowConnIdx,
+                                     component_type,
+                                     primary_inflow_conn,
+                                     primary_inflow_conn_idx,
                                      FlowDirection::inflow);
             }
-            size_t secondaryInflowConnIdx = comp.inflow_connection_id_secondary;
-            Connection const& secondaryInflowConn = m.connection[secondaryInflowConnIdx];
-            size_t secondaryInflowPort = 1;
-            if ((secondaryInflowConn.to != compType) ||
-                (secondaryInflowConn.to_component_id != compId) ||
-                (secondaryInflowConn.to_subtype_index != idx) ||
-                (secondaryInflowConn.to_port != secondaryInflowPort))
+            size_t secondary_inflow_conn_idx = comp.inflow_connection_id_secondary;
+            Connection const& secondary_inflow_conn = m.connection[secondary_inflow_conn_idx];
+            size_t secondary_inflow_port = 1;
+            if ((secondary_inflow_conn.to != component_type) ||
+                (secondary_inflow_conn.to_component_id != component_id) ||
+                (secondary_inflow_conn.to_subtype_index != idx) ||
+                (secondary_inflow_conn.to_port != secondary_inflow_port))
             {
                 add_connection_issue(issues,
                                      tag,
-                                     compId,
-                                     secondaryInflowPort,
+                                     component_id,
+                                     secondary_inflow_port,
                                      idx,
-                                     compType,
-                                     secondaryInflowConn,
-                                     secondaryInflowConnIdx,
+                                     component_type,
+                                     secondary_inflow_conn,
+                                     secondary_inflow_conn_idx,
                                      FlowDirection::inflow);
             }
-            size_t outflowConnIdx = comp.outflow_connection_id;
-            Connection const& outflowConn = m.connection[outflowConnIdx];
-            size_t outflowPort = 0;
-            if ((outflowConn.from != compType) || (outflowConn.from_component_id != compId) ||
-                (outflowConn.from_subtype_index != idx) || (outflowConn.from_port != outflowPort))
+            size_t outflow_conn_idx = comp.outflow_connection_id;
+            Connection const& outflow_conn = m.connection[outflow_conn_idx];
+            size_t outflow_port = 0;
+            if ((outflow_conn.from != component_type) || (outflow_conn.from_component_id != component_id) ||
+                (outflow_conn.from_subtype_index != idx) || (outflow_conn.from_port != outflow_port))
             {
                 add_connection_issue(issues,
                                      tag,
-                                     compId,
-                                     outflowPort,
+                                     component_id,
+                                     outflow_port,
                                      idx,
-                                     compType,
-                                     outflowConn,
-                                     outflowConnIdx,
+                                     component_type,
+                                     outflow_conn,
+                                     outflow_conn_idx,
                                      FlowDirection::outflow);
             }
         }
@@ -653,20 +653,20 @@ std::vector<std::string> check_network(Model const& m)
         {
             assert(idx < m.scheduled_load.size());
             ScheduleBasedLoad const& comp = m.scheduled_load[idx];
-            size_t inflowConnIdx = comp.inflow_connection_id;
-            Connection const& inflowConn = m.connection[inflowConnIdx];
-            size_t inflowPort = 0;
-            if ((inflowConn.to != compType) || (inflowConn.to_component_id != compId) ||
-                (inflowConn.to_subtype_index != idx) || (inflowConn.to_port != inflowPort))
+            size_t inflow_conn_idx = comp.inflow_connection_id;
+            Connection const& inflow_conn = m.connection[inflow_conn_idx];
+            size_t inflow_port = 0;
+            if ((inflow_conn.to != component_type) || (inflow_conn.to_component_id != component_id) ||
+                (inflow_conn.to_subtype_index != idx) || (inflow_conn.to_port != inflow_port))
             {
                 add_connection_issue(issues,
                                      tag,
-                                     compId,
-                                     inflowPort,
+                                     component_id,
+                                     inflow_port,
                                      idx,
-                                     compType,
-                                     inflowConn,
-                                     inflowConnIdx,
+                                     component_type,
+                                     inflow_conn,
+                                     inflow_conn_idx,
                                      FlowDirection::inflow);
             }
         }
@@ -675,36 +675,36 @@ std::vector<std::string> check_network(Model const& m)
         {
             assert(idx < m.scheduled_source.size());
             ScheduleBasedSource const& comp = m.scheduled_source[idx];
-            size_t outflowConnIdx = comp.outflow_connection_id;
-            Connection const& outflowConn = m.connection[outflowConnIdx];
-            size_t outflowPort = 0;
-            if ((outflowConn.from != compType) || (outflowConn.from_component_id != compId) ||
-                (outflowConn.from_subtype_index != idx) || (outflowConn.from_port != outflowPort))
+            size_t outflow_conn_idx = comp.outflow_connection_id;
+            Connection const& outflow_conn = m.connection[outflow_conn_idx];
+            size_t outflow_port = 0;
+            if ((outflow_conn.from != component_type) || (outflow_conn.from_component_id != component_id) ||
+                (outflow_conn.from_subtype_index != idx) || (outflow_conn.from_port != outflow_port))
             {
                 add_connection_issue(issues,
                                      tag,
-                                     compId,
-                                     outflowPort,
+                                     component_id,
+                                     outflow_port,
                                      idx,
-                                     compType,
-                                     outflowConn,
-                                     outflowConnIdx,
+                                     component_type,
+                                     outflow_conn,
+                                     outflow_conn_idx,
                                      FlowDirection::outflow);
             }
-            size_t wfConnIdx = comp.wasteflow_connection_id;
-            Connection const& wfConn = m.connection[wfConnIdx];
-            size_t wfPort = 1;
-            if ((wfConn.from != compType) || (wfConn.from_component_id != compId) ||
-                (wfConn.from_subtype_index != idx) || (wfConn.from_port != wfPort))
+            size_t wf_conn_idx = comp.wasteflow_connection_id;
+            Connection const& wf_conn = m.connection[wf_conn_idx];
+            size_t wf_port = 1;
+            if ((wf_conn.from != component_type) || (wf_conn.from_component_id != component_id) ||
+                (wf_conn.from_subtype_index != idx) || (wf_conn.from_port != wf_port))
             {
                 add_connection_issue(issues,
                                      tag,
-                                     compId,
-                                     wfPort,
+                                     component_id,
+                                     wf_port,
                                      idx,
-                                     compType,
-                                     wfConn,
-                                     wfConnIdx,
+                                     component_type,
+                                     wf_conn,
+                                     wf_conn_idx,
                                      FlowDirection::outflow);
             }
         }
@@ -713,20 +713,20 @@ std::vector<std::string> check_network(Model const& m)
         {
             assert(idx < m.store.size());
             Store const& comp = m.store[idx];
-            size_t outflowConnIdx = comp.outflow_connection_id;
-            Connection const& outflowConn = m.connection[outflowConnIdx];
-            size_t outflowPort = 0;
-            if ((outflowConn.from != compType) || (outflowConn.from_component_id != compId) ||
-                (outflowConn.from_subtype_index != idx) || (outflowConn.from_port != outflowPort))
+            size_t outflow_conn_idx = comp.outflow_connection_id;
+            Connection const& outflow_conn = m.connection[outflow_conn_idx];
+            size_t outflow_port = 0;
+            if ((outflow_conn.from != component_type) || (outflow_conn.from_component_id != component_id) ||
+                (outflow_conn.from_subtype_index != idx) || (outflow_conn.from_port != outflow_port))
             {
                 add_connection_issue(issues,
                                      tag,
-                                     compId,
-                                     outflowPort,
+                                     component_id,
+                                     outflow_port,
                                      idx,
-                                     compType,
-                                     outflowConn,
-                                     outflowConnIdx,
+                                     component_type,
+                                     outflow_conn,
+                                     outflow_conn_idx,
                                      FlowDirection::outflow);
             }
             if (comp.inflow_connection_id.has_value())
@@ -734,15 +734,15 @@ std::vector<std::string> check_network(Model const& m)
                 size_t inflowConnIdx = comp.inflow_connection_id.value();
                 Connection const& inflowConn = m.connection[inflowConnIdx];
                 size_t inflowPort = 0;
-                if ((inflowConn.to != compType) || (inflowConn.to_component_id != compId) ||
+                if ((inflowConn.to != component_type) || (inflowConn.to_component_id != component_id) ||
                     (inflowConn.to_subtype_index != idx) || (inflowConn.to_port != inflowPort))
                 {
                     add_connection_issue(issues,
                                          tag,
-                                         compId,
+                                         component_id,
                                          inflowPort,
                                          idx,
-                                         compType,
+                                         component_type,
                                          inflowConn,
                                          inflowConnIdx,
                                          FlowDirection::inflow);
@@ -753,15 +753,15 @@ std::vector<std::string> check_network(Model const& m)
                 size_t wfConnIdx = comp.wasteflow_connection_id.value();
                 Connection const& wfConn = m.connection[wfConnIdx];
                 size_t wfPort = 1;
-                if ((wfConn.from != compType) || (wfConn.from_component_id != compId) ||
+                if ((wfConn.from != component_type) || (wfConn.from_component_id != component_id) ||
                     (wfConn.from_subtype_index != idx) || (wfConn.from_port != wfPort))
                 {
                     add_connection_issue(issues,
                                          tag,
-                                         compId,
+                                         component_id,
                                          wfPort,
                                          idx,
-                                         compType,
+                                         component_type,
                                          wfConn,
                                          wfConnIdx,
                                          FlowDirection::outflow);
@@ -776,7 +776,7 @@ std::vector<std::string> check_network(Model const& m)
         break;
         default:
         {
-            std::cout << "unhandled component type: " + ToString(compType) << std::endl;
+            std::cout << "unhandled component type: " + ToString(component_type) << std::endl;
             std::exit(1);
         }
         break;
@@ -822,7 +822,7 @@ std::vector<std::string> check_network(Model const& m)
                     << fromMux.outflow_connection_ids.size() << "\n";
                 issues.push_back(oss.str());
             }
-            if (muxCompIdToOutflowConns[conn.from_component_id].contains(connIdx))
+            if (mux_comp_id_to_outflow_conns[conn.from_component_id].contains(connIdx))
             {
                 std::ostringstream oss;
                 oss << "mux has multiple instances of the same outflow "
@@ -830,7 +830,7 @@ std::vector<std::string> check_network(Model const& m)
                 oss << "connIdx: " << connIdx << "\n";
                 issues.push_back(oss.str());
             }
-            muxCompIdToOutflowConns[conn.from_component_id].insert(connIdx);
+            mux_comp_id_to_outflow_conns[conn.from_component_id].insert(connIdx);
         }
         if (toType == ComponentType::mux_type)
         {
@@ -866,7 +866,7 @@ std::vector<std::string> check_network(Model const& m)
                     << toMux.inflow_connection_ids.size() << "\n";
                 issues.push_back(oss.str());
             }
-            if (muxCompIdToInflowConns[conn.to_component_id].contains(connIdx))
+            if (mux_comp_id_to_inflow_conns[conn.to_component_id].contains(connIdx))
             {
                 std::ostringstream oss;
                 oss << "mux has multiple instances of the same inflow "
@@ -874,7 +874,7 @@ std::vector<std::string> check_network(Model const& m)
                 oss << "connIdx: " << connIdx << "\n";
                 issues.push_back(oss.str());
             }
-            muxCompIdToInflowConns[conn.to_component_id].insert(connIdx);
+            mux_comp_id_to_inflow_conns[conn.to_component_id].insert(connIdx);
         }
         std::string outflowCompPort;
         {
@@ -882,7 +882,7 @@ std::vector<std::string> check_network(Model const& m)
             oss << conn.from_component_id << ":" << conn.from_port;
             outflowCompPort = oss.str();
         };
-        if (connectedOutflowPorts.contains(outflowCompPort))
+        if (connected_outflow_ports.contains(outflowCompPort))
         {
             std::ostringstream oss;
             oss << "Port multiply connected: "
@@ -894,14 +894,14 @@ std::vector<std::string> check_network(Model const& m)
                 << "\n";
             issues.push_back(oss.str());
         }
-        connectedOutflowPorts.insert(outflowCompPort);
+        connected_outflow_ports.insert(outflowCompPort);
         std::string inflowCompPort;
         {
             std::ostringstream oss;
             oss << conn.to_component_id << ":" << conn.to_port;
             inflowCompPort = oss.str();
         };
-        if (connectedInflowPorts.contains(inflowCompPort))
+        if (connected_inflow_ports.contains(inflowCompPort))
         {
             std::ostringstream oss;
             oss << "Port multiply connected: "
@@ -912,27 +912,27 @@ std::vector<std::string> check_network(Model const& m)
                 << "- type: " << ToString(m.component.component_type[conn.to_component_id]) << "\n";
             issues.push_back(oss.str());
         }
-        connectedInflowPorts.insert(inflowCompPort);
+        connected_inflow_ports.insert(inflowCompPort);
     }
     for (size_t compId = 0; compId < m.component.component_type.size(); ++compId)
     {
         if (m.component.component_type[compId] == ComponentType::mux_type)
         {
             Mux const& mux = m.mux[m.component.subtype_index[compId]];
-            if (mux.number_of_inports != muxCompIdToInflowConns[compId].size())
+            if (mux.number_of_inports != mux_comp_id_to_inflow_conns[compId].size())
             {
                 std::ostringstream oss;
                 oss << "mux specifies " << mux.number_of_inports
                     << " inports but the number of connections are "
-                    << muxCompIdToInflowConns[compId].size() << "\n";
+                    << mux_comp_id_to_inflow_conns[compId].size() << "\n";
                 issues.push_back(oss.str());
             }
-            if (mux.number_of_outports != muxCompIdToOutflowConns[compId].size())
+            if (mux.number_of_outports != mux_comp_id_to_outflow_conns[compId].size())
             {
                 std::ostringstream oss;
                 oss << "mux specifies " << mux.number_of_outports
                     << " outports but the number of connections are "
-                    << muxCompIdToOutflowConns[compId].size() << "\n";
+                    << mux_comp_id_to_outflow_conns[compId].size() << "\n";
                 issues.push_back(oss.str());
             }
         }

--- a/src/erin.cpp
+++ b/src/erin.cpp
@@ -784,7 +784,8 @@ std::vector<std::string> check_network(Model const& m)
                 size_t wf_conn_idx = comp.wasteflow_connection_id.value();
                 Connection const& wf_conn = m.connection[wf_conn_idx];
                 size_t wf_port = 1;
-                if ((wf_conn.from != component_type) || (wf_conn.from_component_id != component_id) ||
+                if ((wf_conn.from != component_type) ||
+                    (wf_conn.from_component_id != component_id) ||
                     (wf_conn.from_subtype_index != idx) || (wf_conn.from_port != wf_port))
                 {
                     add_connection_issue(issues,
@@ -940,7 +941,8 @@ std::vector<std::string> check_network(Model const& m)
                 << "- compId: " << conn.to_component_id << "\n"
                 << "- outflowPort: " << conn.to_port << "\n"
                 << "- tag: " << m.component.tag[conn.to_component_id] << "\n"
-                << "- type: " << to_string(m.component.component_type[conn.to_component_id]) << "\n";
+                << "- type: " << to_string(m.component.component_type[conn.to_component_id])
+                << "\n";
             issues.push_back(oss.str());
         }
         connected_inflow_ports.insert(inflow_comp_port);
@@ -4348,7 +4350,8 @@ Connection Model_AddConnection(Model& m,
     break;
     default:
     {
-        write_error_message("Model_AddConnection", "unhandled component type: " + to_string(toType));
+        write_error_message("Model_AddConnection",
+                            "unhandled component type: " + to_string(toType));
         std::exit(1);
     }
     break;

--- a/src/erin.cpp
+++ b/src/erin.cpp
@@ -95,13 +95,13 @@ void add_connection_issue(std::vector<std::string>& issues,
     oss << "- ACCORDING TO THE COMPONENT:\n";
     oss << "  - component id:            " << compId << "\n";
     oss << "  - component " << direction << " port:  " << compPort << "\n";
-    oss << "  - component type:          " << ToString(compType) << "\n";
+    oss << "  - component type:          " << to_string(compType) << "\n";
     oss << "  - component tag:           " << componentTag << "\n";
     oss << "  - component subtype index: " << compSubtypeIdx << "\n";
     oss << "- ACCORDING TO THE " << direction << " CONNECTION:\n";
     oss << "  - connection id:  " << connIdx << "\n";
     oss << "  - component type: "
-        << ToString(flowDirection == FlowDirection::outflow ? conn.from : conn.to) << "\n";
+        << to_string(flowDirection == FlowDirection::outflow ? conn.from : conn.to) << "\n";
     oss << "  - component id:   "
         << (flowDirection == FlowDirection::outflow ? conn.from_component_id : conn.to_component_id)
         << "\n";
@@ -761,40 +761,40 @@ std::vector<std::string> check_network(Model const& m)
             }
             if (comp.inflow_connection_id.has_value())
             {
-                size_t inflowConnIdx = comp.inflow_connection_id.value();
-                Connection const& inflowConn = m.connection[inflowConnIdx];
-                size_t inflowPort = 0;
-                if ((inflowConn.to != component_type) ||
-                    (inflowConn.to_component_id != component_id) ||
-                    (inflowConn.to_subtype_index != idx) || (inflowConn.to_port != inflowPort))
+                size_t inflow_conn_idx = comp.inflow_connection_id.value();
+                Connection const& inflow_conn = m.connection[inflow_conn_idx];
+                size_t inflow_port = 0;
+                if ((inflow_conn.to != component_type) ||
+                    (inflow_conn.to_component_id != component_id) ||
+                    (inflow_conn.to_subtype_index != idx) || (inflow_conn.to_port != inflow_port))
                 {
                     add_connection_issue(issues,
                                          tag,
                                          component_id,
-                                         inflowPort,
+                                         inflow_port,
                                          idx,
                                          component_type,
-                                         inflowConn,
-                                         inflowConnIdx,
+                                         inflow_conn,
+                                         inflow_conn_idx,
                                          FlowDirection::inflow);
                 }
             }
             if (comp.wasteflow_connection_id.has_value())
             {
-                size_t wfConnIdx = comp.wasteflow_connection_id.value();
-                Connection const& wfConn = m.connection[wfConnIdx];
-                size_t wfPort = 1;
-                if ((wfConn.from != component_type) || (wfConn.from_component_id != component_id) ||
-                    (wfConn.from_subtype_index != idx) || (wfConn.from_port != wfPort))
+                size_t wf_conn_idx = comp.wasteflow_connection_id.value();
+                Connection const& wf_conn = m.connection[wf_conn_idx];
+                size_t wf_port = 1;
+                if ((wf_conn.from != component_type) || (wf_conn.from_component_id != component_id) ||
+                    (wf_conn.from_subtype_index != idx) || (wf_conn.from_port != wf_port))
                 {
                     add_connection_issue(issues,
                                          tag,
                                          component_id,
-                                         wfPort,
+                                         wf_port,
                                          idx,
                                          component_type,
-                                         wfConn,
-                                         wfConnIdx,
+                                         wf_conn,
+                                         wf_conn_idx,
                                          FlowDirection::outflow);
                 }
             }
@@ -807,163 +807,163 @@ std::vector<std::string> check_network(Model const& m)
         break;
         default:
         {
-            std::cout << "unhandled component type: " + ToString(component_type) << std::endl;
+            std::cout << "unhandled component type: " + to_string(component_type) << std::endl;
             std::exit(1);
         }
         break;
         }
     }
-    for (size_t connIdx = 0; connIdx < m.connection.size(); ++connIdx)
+    for (size_t conn_idx = 0; conn_idx < m.connection.size(); ++conn_idx)
     {
-        Connection const& conn = m.connection[connIdx];
+        Connection const& conn = m.connection[conn_idx];
         // asser that component port links back to connection
-        ComponentType fromType = conn.from;
-        ComponentType toType = conn.to;
-        if (fromType == ComponentType::mux_type)
+        ComponentType from_type = conn.from;
+        ComponentType to_type = conn.to;
+        if (from_type == ComponentType::mux_type)
         {
-            auto const& fromMux = m.mux[conn.from_subtype_index];
-            if (conn.from_port >= fromMux.outflow_connection_ids.size())
+            auto const& from_mux = m.mux[conn.from_subtype_index];
+            if (conn.from_port >= from_mux.outflow_connection_ids.size())
             {
                 std::ostringstream oss;
                 oss << "mux outflow connection inconsistent\n";
                 oss << "conn.FromId: " << conn.from_component_id << "\n";
                 oss << "conn.FromPort: " << conn.from_port << "\n";
-                oss << "mux num outflow connections: " << fromMux.number_of_outports << "\n";
+                oss << "mux num outflow connections: " << from_mux.number_of_outports << "\n";
                 oss << "mux num outflow connections from count: "
-                    << fromMux.outflow_connection_ids.size() << "\n";
+                    << from_mux.outflow_connection_ids.size() << "\n";
                 issues.push_back(oss.str());
             }
-            else if (fromMux.outflow_connection_ids[conn.from_port] != connIdx)
+            else if (from_mux.outflow_connection_ids[conn.from_port] != conn_idx)
             {
                 std::ostringstream oss;
                 oss << "mux outflow connection inconsistent\n";
-                oss << "connId: " << connIdx << "\n";
+                oss << "connId: " << conn_idx << "\n";
                 oss << "conn.FromId: " << conn.from_component_id << "\n";
                 oss << "conn.FromPort: " << conn.from_port << "\n";
                 oss << "fromMux.OutflowConns[conn.FromPort]: "
-                    << fromMux.outflow_connection_ids[conn.from_port] << "\n";
+                    << from_mux.outflow_connection_ids[conn.from_port] << "\n";
                 issues.push_back(oss.str());
             }
-            if (fromMux.number_of_outports != fromMux.outflow_connection_ids.size())
+            if (from_mux.number_of_outports != from_mux.outflow_connection_ids.size())
             {
                 std::ostringstream oss;
                 oss << "mux num outflows inconsistent\n";
-                oss << "mux num outflow connections: " << fromMux.number_of_outports << "\n";
+                oss << "mux num outflow connections: " << from_mux.number_of_outports << "\n";
                 oss << "mux num outflow connections from count: "
-                    << fromMux.outflow_connection_ids.size() << "\n";
+                    << from_mux.outflow_connection_ids.size() << "\n";
                 issues.push_back(oss.str());
             }
-            if (mux_comp_id_to_outflow_conns[conn.from_component_id].contains(connIdx))
+            if (mux_comp_id_to_outflow_conns[conn.from_component_id].contains(conn_idx))
             {
                 std::ostringstream oss;
                 oss << "mux has multiple instances of the same outflow "
                        "connection\n";
-                oss << "connIdx: " << connIdx << "\n";
+                oss << "connIdx: " << conn_idx << "\n";
                 issues.push_back(oss.str());
             }
-            mux_comp_id_to_outflow_conns[conn.from_component_id].insert(connIdx);
+            mux_comp_id_to_outflow_conns[conn.from_component_id].insert(conn_idx);
         }
-        if (toType == ComponentType::mux_type)
+        if (to_type == ComponentType::mux_type)
         {
-            auto const& toMux = m.mux[conn.to_subtype_index];
-            if (conn.to_port >= toMux.inflow_connection_ids.size())
+            auto const& to_mux = m.mux[conn.to_subtype_index];
+            if (conn.to_port >= to_mux.inflow_connection_ids.size())
             {
                 std::ostringstream oss;
                 oss << "mux inflow connection inconsistent\n";
                 oss << "conn.ToId: " << conn.to_component_id << "\n";
                 oss << "conn.ToPort: " << conn.to_port << "\n";
-                oss << "mux num inflow connections: " << toMux.number_of_inports << "\n";
+                oss << "mux num inflow connections: " << to_mux.number_of_inports << "\n";
                 oss << "mux num inflow connections from count: "
-                    << toMux.inflow_connection_ids.size() << "\n";
+                    << to_mux.inflow_connection_ids.size() << "\n";
                 issues.push_back(oss.str());
             }
-            else if (toMux.inflow_connection_ids[conn.to_port] != connIdx)
+            else if (to_mux.inflow_connection_ids[conn.to_port] != conn_idx)
             {
                 std::ostringstream oss;
                 oss << "mux inflow connection inconsistent\n";
-                oss << "connId: " << connIdx << "\n";
+                oss << "connId: " << conn_idx << "\n";
                 oss << "conn.ToId: " << conn.to_component_id << "\n";
                 oss << "conn.FromPort: " << conn.to_port << "\n";
                 oss << "toMux.InflowConns[conn.FromPort]: "
-                    << toMux.outflow_connection_ids[conn.to_port] << "\n";
+                    << to_mux.outflow_connection_ids[conn.to_port] << "\n";
                 issues.push_back(oss.str());
             }
-            if (toMux.number_of_inports != toMux.inflow_connection_ids.size())
+            if (to_mux.number_of_inports != to_mux.inflow_connection_ids.size())
             {
                 std::ostringstream oss;
                 oss << "mux num inflows inconsistent\n";
-                oss << "mux num inflow connections: " << toMux.number_of_inports << "\n";
+                oss << "mux num inflow connections: " << to_mux.number_of_inports << "\n";
                 oss << "mux num inflow connections from count: "
-                    << toMux.inflow_connection_ids.size() << "\n";
+                    << to_mux.inflow_connection_ids.size() << "\n";
                 issues.push_back(oss.str());
             }
-            if (mux_comp_id_to_inflow_conns[conn.to_component_id].contains(connIdx))
+            if (mux_comp_id_to_inflow_conns[conn.to_component_id].contains(conn_idx))
             {
                 std::ostringstream oss;
                 oss << "mux has multiple instances of the same inflow "
                        "connection\n";
-                oss << "connIdx: " << connIdx << "\n";
+                oss << "connIdx: " << conn_idx << "\n";
                 issues.push_back(oss.str());
             }
-            mux_comp_id_to_inflow_conns[conn.to_component_id].insert(connIdx);
+            mux_comp_id_to_inflow_conns[conn.to_component_id].insert(conn_idx);
         }
-        std::string outflowCompPort;
+        std::string outflow_comp_port;
         {
             std::ostringstream oss;
             oss << conn.from_component_id << ":" << conn.from_port;
-            outflowCompPort = oss.str();
+            outflow_comp_port = oss.str();
         };
-        if (connected_outflow_ports.contains(outflowCompPort))
+        if (connected_outflow_ports.contains(outflow_comp_port))
         {
             std::ostringstream oss;
             oss << "Port multiply connected: "
-                << "- outflowCompPort: " << outflowCompPort << "\n"
+                << "- outflowCompPort: " << outflow_comp_port << "\n"
                 << "- compId: " << conn.from_component_id << "\n"
                 << "- outflowPort: " << conn.from_port << "\n"
                 << "- tag: " << m.component.tag[conn.from_component_id] << "\n"
-                << "- type: " << ToString(m.component.component_type[conn.from_component_id])
+                << "- type: " << to_string(m.component.component_type[conn.from_component_id])
                 << "\n";
             issues.push_back(oss.str());
         }
-        connected_outflow_ports.insert(outflowCompPort);
-        std::string inflowCompPort;
+        connected_outflow_ports.insert(outflow_comp_port);
+        std::string inflow_comp_port;
         {
             std::ostringstream oss;
             oss << conn.to_component_id << ":" << conn.to_port;
-            inflowCompPort = oss.str();
+            inflow_comp_port = oss.str();
         };
-        if (connected_inflow_ports.contains(inflowCompPort))
+        if (connected_inflow_ports.contains(inflow_comp_port))
         {
             std::ostringstream oss;
             oss << "Port multiply connected: "
-                << "- inflowCompPort: " << inflowCompPort << "\n"
+                << "- inflowCompPort: " << inflow_comp_port << "\n"
                 << "- compId: " << conn.to_component_id << "\n"
                 << "- outflowPort: " << conn.to_port << "\n"
                 << "- tag: " << m.component.tag[conn.to_component_id] << "\n"
-                << "- type: " << ToString(m.component.component_type[conn.to_component_id]) << "\n";
+                << "- type: " << to_string(m.component.component_type[conn.to_component_id]) << "\n";
             issues.push_back(oss.str());
         }
-        connected_inflow_ports.insert(inflowCompPort);
+        connected_inflow_ports.insert(inflow_comp_port);
     }
-    for (size_t compId = 0; compId < m.component.component_type.size(); ++compId)
+    for (size_t comp_id = 0; comp_id < m.component.component_type.size(); ++comp_id)
     {
-        if (m.component.component_type[compId] == ComponentType::mux_type)
+        if (m.component.component_type[comp_id] == ComponentType::mux_type)
         {
-            Mux const& mux = m.mux[m.component.subtype_index[compId]];
-            if (mux.number_of_inports != mux_comp_id_to_inflow_conns[compId].size())
+            Mux const& mux = m.mux[m.component.subtype_index[comp_id]];
+            if (mux.number_of_inports != mux_comp_id_to_inflow_conns[comp_id].size())
             {
                 std::ostringstream oss;
                 oss << "mux specifies " << mux.number_of_inports
                     << " inports but the number of connections are "
-                    << mux_comp_id_to_inflow_conns[compId].size() << "\n";
+                    << mux_comp_id_to_inflow_conns[comp_id].size() << "\n";
                 issues.push_back(oss.str());
             }
-            if (mux.number_of_outports != mux_comp_id_to_outflow_conns[compId].size())
+            if (mux.number_of_outports != mux_comp_id_to_outflow_conns[comp_id].size())
             {
                 std::ostringstream oss;
                 oss << "mux specifies " << mux.number_of_outports
                     << " outports but the number of connections are "
-                    << mux_comp_id_to_outflow_conns[compId].size() << "\n";
+                    << mux_comp_id_to_outflow_conns[comp_id].size() << "\n";
                 issues.push_back(oss.str());
             }
         }
@@ -1933,7 +1933,7 @@ void RunConnectionsBackward(Model& model, SimulationState& ss)
             default:
             {
                 std::cout << "Unhandled component type on backward pass: "
-                          << ToString(model.connection[connIdx].from) << std::endl;
+                          << to_string(model.connection[connIdx].from) << std::endl;
             }
             }
         }
@@ -2231,7 +2231,7 @@ void RunConnectionsForward(Model& model, SimulationState& ss)
             default:
             {
                 std::cerr << "unhandled component type on forward pass: "
-                          << ToString(model.connection[connIdx].to) << std::endl;
+                          << to_string(model.connection[connIdx].to) << std::endl;
                 std::exit(1);
             }
             }
@@ -2534,8 +2534,7 @@ void UpdateScheduleBasedSourceNextEvent(Model const& m, SimulationState& ss, dou
     }
 }
 
-// TODO: rename to ComponentTypeToString(.)
-std::string ToString(ComponentType compType)
+std::string to_string(ComponentType compType)
 {
     std::string result = "?";
     switch (compType)
@@ -2773,7 +2772,7 @@ FlowSummary SummarizeFlows(Model const& m, SimulationState const& ss, double t)
         {
             write_error_message("SummarizeFlows(.)",
                                 "Unhandled From type for connection - from pass: " +
-                                    ToString(m.connection[flowIdx].from));
+                                    to_string(m.connection[flowIdx].from));
         }
         break;
         }
@@ -2814,7 +2813,7 @@ FlowSummary SummarizeFlows(Model const& m, SimulationState const& ss, double t)
         {
             write_error_message("SummarizeFlows(.)",
                                 "Unhandled From type for connection - to pass: " +
-                                    ToString(m.connection[flowIdx].to));
+                                    to_string(m.connection[flowIdx].to));
         }
         break;
         }
@@ -2882,15 +2881,15 @@ void PrintModelState(Model& m, SimulationState& ss)
 {
     for (size_t storeIdx = 0; storeIdx < m.store.size(); ++storeIdx)
     {
-        std::cout << ToString(ComponentType::store_type) << "[" << storeIdx
+        std::cout << to_string(ComponentType::store_type) << "[" << storeIdx
                   << "].InitialStorage (J): " << m.store[storeIdx].initial_storage_J << std::endl;
-        std::cout << ToString(ComponentType::store_type) << "[" << storeIdx
+        std::cout << to_string(ComponentType::store_type) << "[" << storeIdx
                   << "].StorageAmount (J) : " << ss.storage_amounts_J[storeIdx] << std::endl;
-        std::cout << ToString(ComponentType::store_type) << "[" << storeIdx
+        std::cout << to_string(ComponentType::store_type) << "[" << storeIdx
                   << "].Capacity (J)      : " << m.store[storeIdx].capacity_J << std::endl;
         double soc =
             (double)ss.storage_amounts_J[storeIdx] * 100.0 / (double)m.store[storeIdx].capacity_J;
-        std::cout << ToString(ComponentType::store_type) << "[" << storeIdx
+        std::cout << to_string(ComponentType::store_type) << "[" << storeIdx
                   << "].SOC               : " << soc << " %" << std::endl;
     }
 }
@@ -4013,7 +4012,7 @@ Connection Model_AddConnection(Model& m,
                           << "attempt to doubly connect "
                           << "compId=" << fromId << " outport=" << fromPort
                           << " tag=" << m.component.tag[fromId]
-                          << " type=" << ToString(m.component.component_type[fromId]) << std::endl;
+                          << " type=" << to_string(m.component.component_type[fromId]) << std::endl;
             }
             if (conn.to_component_id == toId && conn.to_port == toPort)
             {
@@ -4022,7 +4021,7 @@ Connection Model_AddConnection(Model& m,
                           << "attempt to doubly connect "
                           << "compId=" << toId << " inport=" << toPort
                           << " tag=" << m.component.tag[toId]
-                          << " type=" << ToString(m.component.component_type[toId]) << std::endl;
+                          << " type=" << to_string(m.component.component_type[toId]) << std::endl;
             }
         }
         if (issueFound)
@@ -4216,7 +4215,7 @@ Connection Model_AddConnection(Model& m,
     default:
     {
         write_error_message("Model_AddConnection",
-                            "unhandled component type: " + ToString(fromType));
+                            "unhandled component type: " + to_string(fromType));
         std::exit(1);
     }
     }
@@ -4241,7 +4240,7 @@ Connection Model_AddConnection(Model& m,
         {
             write_error_message("Model_AddConnection",
                                 "unhandled inport: " + std::to_string(toPort) + " for " +
-                                    ToString(toType));
+                                    to_string(toType));
             std::exit(1);
         }
         break;
@@ -4349,7 +4348,7 @@ Connection Model_AddConnection(Model& m,
     break;
     default:
     {
-        write_error_message("Model_AddConnection", "unhandled component type: " + ToString(toType));
+        write_error_message("Model_AddConnection", "unhandled component type: " + to_string(toType));
         std::exit(1);
     }
     break;
@@ -4902,7 +4901,7 @@ Result ParseNetwork(FlowDict const& fd, Model& m, toml::table const& table)
         {
             std::cout << "[network] "
                       << "port is unaddressable for "
-                      << ToString(m.component.component_type[fromCompId]) << ": trying to address "
+                      << to_string(m.component.component_type[fromCompId]) << ": trying to address "
                       << fromTap.port << " but only " << m.component.outflow_type[fromCompId].size()
                       << " ports available" << std::endl;
             return Result::failure;
@@ -4929,7 +4928,7 @@ Result ParseNetwork(FlowDict const& fd, Model& m, toml::table const& table)
                 return Result::failure;
             }
             std::cout << "[network] port is unaddressable for "
-                      << ToString(m.component.component_type[toCompId]) << ": trying to address "
+                      << to_string(m.component.component_type[toCompId]) << ": trying to address "
                       << toTap.port << " but only " << m.component.inflow_type[toCompId].size()
                       << " ports available" << std::endl;
             return Result::failure;
@@ -5014,9 +5013,9 @@ std::string ConnectionToString(ComponentDict const& cd, Connection const& c, boo
     }
     std::ostringstream oss {};
     oss << fromTag << (compact ? "" : ("[" + std::to_string(c.from_component_id) + "]")) << ":OUT("
-        << c.from_port << ")" << (compact ? "" : (": " + ToString(c.from))) << " => " << toTag
+        << c.from_port << ")" << (compact ? "" : (": " + to_string(c.from))) << " => " << toTag
         << (compact ? "" : ("[" + std::to_string(c.to_component_id) + "]")) << ":IN(" << c.to_port
-        << ")" << (compact ? "" : (": " + ToString(c.to)));
+        << ")" << (compact ? "" : (": " + to_string(c.to)));
     return oss.str();
 }
 
@@ -5089,14 +5088,14 @@ std::string NodeConnectionToString(Model const& model,
 
     if (c.from_component_id.index() == 0)
     {
-        oss << (compact ? "" : (": " + ToString(c.from)));
+        oss << (compact ? "" : (": " + to_string(c.from)));
     }
 
     oss << " => " << toTag << (compact ? "" : ("[" + toString + "]")) << ":IN(" << c.to_port << ")";
 
     if (c.to_component_id.index() == 0)
     {
-        oss << (compact ? "" : (": " + ToString(c.to)));
+        oss << (compact ? "" : (": " + to_string(c.to)));
     }
 
     return oss.str();

--- a/src/erin.cpp
+++ b/src/erin.cpp
@@ -1,11 +1,5 @@
 // Copyright (c) 2020 - 2024 Big Ladder Software, LLC.
 // See the LICENSE.txt file for additional terms and conditions.
-#include "erin/erin.h"
-#include "erin/logging.h"
-#include "erin/lookup_table.h"
-#include "erin/time_and_amount.h"
-#include "erin/units.h"
-#include "erin/utils.h"
 #include <cmath>
 #include <cstdlib>
 #include <sstream>
@@ -14,7 +8,16 @@
 #include <string>
 #include <unordered_set>
 #include <utility>
+
 #include <fmt/core.h>
+
+#include "erin/erin.h"
+#include "erin/logging.h"
+#include "erin/lookup_table.h"
+#include "erin/time_and_amount.h"
+#include "erin/units.h"
+#include "erin/utils.h"
+#include "erin/network-utils.h"
 
 namespace erin
 {
@@ -118,6 +121,19 @@ void add_connection_issue(std::vector<std::string>& issues,
             << "' is declared but not hooked up to the network.";
     }
     issues.push_back(oss.str());
+}
+
+std::vector<std::pair<size_t, size_t>>
+connections_to_edges(std::vector<Connection> const& conns)
+{
+    std::vector<std::pair<size_t, size_t>> result(conns.size());
+    for (size_t conn_idx = 0; conn_idx < conns.size(); ++conn_idx)
+    {
+        auto const& c = conns[conn_idx];
+        std::pair<size_t, size_t> edge = { c.from_component_id, c.to_component_id };
+        result[conn_idx] = std::move(edge);
+    }
+    return result;
 }
 
 std::vector<std::string> check_network(Model const& m)
@@ -969,6 +985,25 @@ std::vector<std::string> check_network(Model const& m)
                 issues.push_back(oss.str());
             }
         }
+    }
+    std::vector<std::pair<size_t, size_t>> edges =
+        connections_to_edges(m.connection);
+    std::vector<std::vector<std::string>> sccs =
+        find_strongly_connected_components(m.component.tag, edges);
+    if (sccs.size() > 0)
+    {
+        std::ostringstream oss;
+        oss << "ERROR: network is not a directed acyclical graph" << std::endl;
+        oss << "... the following components have cyclical relationships:" << std::endl;
+        for (size_t comp_idx = 0; comp_idx < sccs.size(); ++comp_idx)
+        {
+            oss << "... * STRONGLY CONNECTED COMPONENT " << (comp_idx + 1) << std::endl;
+            for (auto const& node : sccs[comp_idx])
+            {
+                oss << "...  - " << node << std::endl;
+            }
+        }
+        issues.push_back(oss.str());
     }
     return issues;
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,6 +8,7 @@ set(test_sources
   erin_simulation_tests.cpp
   erin_switch_tests.cpp
   erin_tests.cpp
+  network-utils-tests.cpp
 )
 
 add_executable(${PROJECT_NAME}_tests ${test_sources})

--- a/test/network-utils-tests.cpp
+++ b/test/network-utils-tests.cpp
@@ -1,0 +1,70 @@
+// Copyright (c) 2020 - 2024 Big Ladder Software, LLC.
+// See the LICENSE.txt file for additional terms and conditions.
+#include <cstddef>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "erin/network-utils.h"
+
+TEST(NetworkUtils, test_no_strongly_connected_components_for_DAG)
+{
+  std::vector<std::string> nodes = {
+    "A",
+    "B",
+    "C",
+  };
+  std::vector<std::pair<size_t, size_t>> edges = {
+    {0, 1},
+    {1, 2},
+  };
+  std::vector<std::vector<std::string>> sccs =
+    erin::find_strongly_connected_components(nodes, edges);
+  EXPECT_EQ(sccs.size(), 0);
+}
+
+TEST(NetworkUtils, test_find_1_strongly_connected_component_set)
+{
+  std::vector<std::string> nodes = {
+    "A",
+    "B",
+    "C",
+  };
+  std::vector<std::pair<size_t, size_t>> edges = {
+    {0, 1},
+    {1, 2},
+    {2, 0},
+  };
+  std::vector<std::vector<std::string>> sccs =
+    erin::find_strongly_connected_components(nodes, edges);
+  EXPECT_EQ(sccs.size(), 1);
+  EXPECT_EQ(sccs[0].size(), 3);
+  bool found_A = false;
+  bool found_B = false;
+  bool found_C = false;
+  for (std::string const& node : sccs[0])
+  {
+    if (node == "A")
+    {
+      found_A = true;
+    }
+    else if (node == "B")
+    {
+      found_B = true;
+    }
+    else if (node == "C")
+    {
+      found_C = true;
+    }
+    else
+    {
+      FAIL() << "Didn't find 'A', 'B', or 'C'";
+    }
+  }
+  EXPECT_TRUE(found_A);
+  EXPECT_TRUE(found_B);
+  EXPECT_TRUE(found_C);
+}
+

--- a/test/network-utils-tests.cpp
+++ b/test/network-utils-tests.cpp
@@ -11,60 +11,59 @@
 
 TEST(NetworkUtils, test_no_strongly_connected_components_for_DAG)
 {
-  std::vector<std::string> nodes = {
-    "A",
-    "B",
-    "C",
-  };
-  std::vector<std::pair<size_t, size_t>> edges = {
-    {0, 1},
-    {1, 2},
-  };
-  std::vector<std::vector<std::string>> sccs =
-    erin::find_strongly_connected_components(nodes, edges);
-  EXPECT_EQ(sccs.size(), 0);
+    std::vector<std::string> nodes = {
+        "A",
+        "B",
+        "C",
+    };
+    std::vector<std::pair<size_t, size_t>> edges = {
+        {0, 1},
+        {1, 2},
+    };
+    std::vector<std::vector<std::string>> sccs =
+        erin::find_strongly_connected_components(nodes, edges);
+    EXPECT_EQ(sccs.size(), 0);
 }
 
 TEST(NetworkUtils, test_find_1_strongly_connected_component_set)
 {
-  std::vector<std::string> nodes = {
-    "A",
-    "B",
-    "C",
-  };
-  std::vector<std::pair<size_t, size_t>> edges = {
-    {0, 1},
-    {1, 2},
-    {2, 0},
-  };
-  std::vector<std::vector<std::string>> sccs =
-    erin::find_strongly_connected_components(nodes, edges);
-  EXPECT_EQ(sccs.size(), 1);
-  EXPECT_EQ(sccs[0].size(), 3);
-  bool found_A = false;
-  bool found_B = false;
-  bool found_C = false;
-  for (std::string const& node : sccs[0])
-  {
-    if (node == "A")
+    std::vector<std::string> nodes = {
+        "A",
+        "B",
+        "C",
+    };
+    std::vector<std::pair<size_t, size_t>> edges = {
+        {0, 1},
+        {1, 2},
+        {2, 0},
+    };
+    std::vector<std::vector<std::string>> sccs =
+        erin::find_strongly_connected_components(nodes, edges);
+    EXPECT_EQ(sccs.size(), 1);
+    EXPECT_EQ(sccs[0].size(), 3);
+    bool found_A = false;
+    bool found_B = false;
+    bool found_C = false;
+    for (std::string const& node : sccs[0])
     {
-      found_A = true;
+        if (node == "A")
+        {
+            found_A = true;
+        }
+        else if (node == "B")
+        {
+            found_B = true;
+        }
+        else if (node == "C")
+        {
+            found_C = true;
+        }
+        else
+        {
+            FAIL() << "Didn't find 'A', 'B', or 'C'";
+        }
     }
-    else if (node == "B")
-    {
-      found_B = true;
-    }
-    else if (node == "C")
-    {
-      found_C = true;
-    }
-    else
-    {
-      FAIL() << "Didn't find 'A', 'B', or 'C'";
-    }
-  }
-  EXPECT_TRUE(found_A);
-  EXPECT_TRUE(found_B);
-  EXPECT_TRUE(found_C);
+    EXPECT_TRUE(found_A);
+    EXPECT_TRUE(found_B);
+    EXPECT_TRUE(found_C);
 }
-


### PR DESCRIPTION
This PR enables the check functionality to also detect if there are cycles in the network. Networks in ERIN must be directed acyclical graphs (DAG). In this PR, we also discovered that exit codes were not being bubbled up to main's exit correctly. This PR fixes that as well.

Fixes #36 