### PR TITLE
Fix bug where ERIN will segfault if a load profile is empty

### DIFF
--- a/src/erin.cpp
+++ b/src/erin.cpp
@@ -1775,9 +1775,13 @@ void RunScheduleBasedSourceBackward(Model& model,
     assert(outConnIdx == sbs.outflow_connection_id);
     auto wasteConn = model.scheduled_source[sbsIdx].wasteflow_connection_id;
     auto schIdx = ss.schedule_based_source_index[sbsIdx];
-    auto available = sbs.time_and_availables[schIdx].amount_W > sbs.max_outflow_W
-                         ? sbs.max_outflow_W
-                         : sbs.time_and_availables[schIdx].amount_W;
+    flow_t available = 0;
+    if (sbs.time_and_availables.size() > schIdx)
+    {
+        available = sbs.time_and_availables[schIdx].amount_W > sbs.max_outflow_W
+                        ? sbs.max_outflow_W
+                        : sbs.time_and_availables[schIdx].amount_W;
+    }
     auto spillage = available > ss.flows[outConnIdx].requested_W
                         ? available - ss.flows[outConnIdx].requested_W
                         : 0;

--- a/templates/template-engine/Program.cs
+++ b/templates/template-engine/Program.cs
@@ -29,7 +29,15 @@ if (ECHO_ARGS)
 	Console.WriteLine($"verbosity         : {verbose}");
 }
 
-Utils.Run(templateDirectory, inputFile, outputFile, verbose);
+try
+{
+	Utils.Run(templateDirectory, inputFile, outputFile, verbose);
+}
+catch (Exception ex)
+{
+	Console.WriteLine($"Exception on template expansion:\n{ex}");
+	return 1;
+}
 if (verbose)
 {
 	Console.WriteLine("Done!");

--- a/templates/template-engine/Utils.cs
+++ b/templates/template-engine/Utils.cs
@@ -449,9 +449,9 @@ namespace TemplateEngine
 				TomlTable singleParam = (TomlTable)paramKvp.Value;
 				string paramTypeAsStr = Get<string>(singleParam, "type");
 				object? defaultValue = null;
-				if (paramTable.ContainsKey("default"))
+				if (singleParam.ContainsKey("default"))
 				{
-					defaultValue = paramTable["default"];
+					defaultValue = singleParam["default"];
 				}
 				ParamType paramType = StringToParamType(paramTypeAsStr);
 				if (paramType == ParamType.Unhandled)

--- a/templates/template-engine/Utils.cs
+++ b/templates/template-engine/Utils.cs
@@ -459,6 +459,14 @@ namespace TemplateEngine
 					throw new Exception(
 						$"[ERROR] Unhandled parameter type for '{paramName}' ({paramTypeAsStr})");
 				}
+				TemplateParameter tp = new()
+				{
+					Name = paramName,
+					Type = paramType,
+					IsOptional = isOptional,
+					Validate = x => true,
+					DefaultValue = defaultValue,
+				};
 				switch (paramType)
 				{
 					case ParamType.Enumeration:
@@ -468,12 +476,7 @@ namespace TemplateEngine
 						{
 							throw new Exception($"[ERROR] Template {templateName} does not contain required 'enum_options' for parameter {paramName}");
 						}
-						TemplateParameter tp = new()
-						{
-							Name = paramName,
-							Type = paramType,
-							IsOptional = isOptional,
-							Validate = x => {
+						tp.Validate = x => {
 								try
 								{
 									string value = (string)x;
@@ -481,20 +484,12 @@ namespace TemplateEngine
 								}
 								catch {}
 								return false;
-							},
-							DefaultValue = defaultValue,
-						};
-						parameters.Add(paramName, tp);
+							};
 					}
 					break;
 					case ParamType.Fraction:
 					{
-						TemplateParameter tp = new()
-						{
-							Name = paramName,
-							Type = paramType,
-							IsOptional = isOptional,
-							Validate = x => {
+						tp.Validate = x => {
 								try
 								{
 									double value = (double)x;
@@ -502,20 +497,12 @@ namespace TemplateEngine
 								}
 								catch {}
 								return false;
-							},
-							DefaultValue = defaultValue,
-						};
-						parameters.Add(paramName, tp);
+							};
 					}
 					break;
 					case ParamType.Integer:
 					{
-						TemplateParameter tp = new()
-						{
-							Name = paramName,
-							Type = paramType,
-							IsOptional = isOptional,
-							Validate = x => {
+						tp.Validate = x => {
 								try
 								{
 									long value = (long)x;
@@ -523,20 +510,12 @@ namespace TemplateEngine
 								}
 								catch {}
 								return false;
-							},
-							DefaultValue = defaultValue,
-						};
-						parameters.Add(paramName, tp);
+							};
 					}
 					break;
 					case ParamType.Number:
 					{
-						TemplateParameter tp = new()
-						{
-							Name = paramName,
-							Type = paramType,
-							IsOptional = isOptional,
-							Validate = x => {
+						tp.Validate = x => {
 								try
 								{
 									double value = (double)x;
@@ -544,20 +523,12 @@ namespace TemplateEngine
 								}
 								catch {}
 								return false;
-							},
-							DefaultValue = defaultValue,
-						};
-						parameters.Add(paramName, tp);
+							};
 					}
 					break;
 					case ParamType.String:
 					{
-						TemplateParameter tp = new()
-						{
-							Name = paramName,
-							Type = paramType,
-							IsOptional = isOptional,
-							Validate = x => {
+						tp.Validate = x => {
 								try
 								{
 									string value = (string)x;
@@ -565,20 +536,12 @@ namespace TemplateEngine
 								}
 								catch {}
 								return false;
-							},
-							DefaultValue = defaultValue,
-						};
-						parameters.Add(paramName, tp);
+							};
 					}
 					break;
 					case ParamType.TableFromStringToString:
 					{
-						TemplateParameter tp = new()
-						{
-							Name = paramName,
-							Type = paramType,
-							IsOptional = isOptional,
-							Validate = x =>
+						tp.Validate = x =>
 							{
 								try
 								{
@@ -591,20 +554,12 @@ namespace TemplateEngine
 								}
 								catch {}
 								return false;
-							},
-							DefaultValue = defaultValue,
-						};
-						parameters.Add(paramName, tp);
+							};
 					}
 					break;
 					case ParamType.ArrayOfTwoTupleOfNumber:
 					{
-						TemplateParameter tp = new()
-						{
-							Name = paramName,
-							Type = paramType,
-							IsOptional = isOptional,
-							Validate = x =>
+						tp.Validate = x =>
 							{
 								try
 								{
@@ -633,10 +588,7 @@ namespace TemplateEngine
 								}
 								catch {}
 								return false;
-							},
-							DefaultValue = defaultValue,
-						};
-						parameters.Add(paramName, tp);
+							};
 					}
 					break;
 					default:
@@ -645,6 +597,7 @@ namespace TemplateEngine
 							$"[ERROR] Unhandled param type: {paramType}");
 					}
 				}
+				parameters.Add(paramName, tp);
 			}
 		}
 
@@ -815,7 +768,7 @@ namespace TemplateEngine
 							defaultValue = fieldValue["default"];
 						}
 						else if (parameters.TryGetValue(
-							fieldName, out TemplateParameter? tp))
+							paramName, out TemplateParameter? tp))
 						{
 							defaultValue = tp.DefaultValue;
 						}

--- a/templates/templates/h2_fuel_cell_and_boiler.toml
+++ b/templates/templates/h2_fuel_cell_and_boiler.toml
@@ -1,0 +1,174 @@
+type = "template"
+name = "h2_fuel_cell_and_boiler"
+equipment_type_name = "H2 (PEM) Electrolyzer and Fuel Cell"
+category = "Power Generation"
+description = "Hydrogen system with electrolyzer, H2 storage, fuel cell and natural gas / h2 boiler"
+mean_time_between_failures_in_hours = 100.0
+mean_time_to_repair_in_hours = 8.0
+first_cost_in_usd_per_size = 10.0
+annual_maintenance_cost_in_usd_per_size = 10.0
+num_inflows = 2
+num_outflows = 2
+connections = [
+ ["<0>", "electrical_substation:IN(0)", "electricity"],
+ ["electrical_substation:OUT(1)", "pem_electrolyzer:IN(0)", "electricity"],
+ ["pem_fuel_cell:OUT(0)", "electrical_bus:IN(0)", "electricity"],
+ ["electrical_substation:OUT(0)", "electrical_bus:IN(1)", "electricity"],
+ ["electrical_bus:OUT(0)", "<0>", "electricity"],
+ ["pem_electrolyzer:OUT(0)", "h2_storage:IN(0)", "hydrogen"],
+ ["h2_storage:OUT(0)", "h2_storage_splitter:IN(0)", "hydrogen"],
+ ["h2_storage_splitter:OUT(0)", "pem_fuel_cell:IN(0)", "hydrogen"],
+ ["h2_storage_splitter:OUT(1)", "blend_input_h2:IN(0)", "hydrogen"],
+ ["blend_input_h2:OUT(0)", "h2_ng_mixer:IN(0)", "h2_ng_blend"],
+ ["blend_input_ng:OUT(0)", "h2_ng_mixer:IN(1)", "h2_ng_blend"],
+ ["h2_ng_mixer:OUT(0)", "h2_ng_boiler:IN(0)", "h2_ng_blend"],
+ ["h2_ng_boiler:OUT(0)", "<1>", "hot_water"],
+ ["<1>", "blend_input_ng:IN(0)", "natural_gas"],
+]
+
+[parameters.required]
+
+[parameters.optional]
+electrolyzer_efficiency.type = "[[number number]*]"
+electrolyzer_efficiency.ui = '{"yMax": 100, "yMin": 0, "yUnit": "%", "xLabel": "Load Fraction", "yLabel": "Efficiency", "display": "input"}'
+electrolyzer_efficiency.default = [[0.0, 0.22], [0.8, 0.3], [1.0, 0.28]]
+electrolyzer_max_outflow.type = "number"
+electrolyzer_max_outflow.constraints = [">0"]
+electrolyzer_max_outflow.default = 200.0
+electrolyzer_max_outflow.ui = '{"unit": "electrolyzer_rate_unit", "label": "Max Electrolyzer Output", "display": "input", "erinUnit": "kW"}'
+electrolyzer_rate_unit.type = "enum"
+electrolyzer_rate_unit.enum_options = ["kg H2/h", "kg H2/min", "W", "kW", "MW"]
+electrolyzer_rate_unit.default = "kg H2/h"
+electrolyzer_rate_unit.ui = '{"display": "unit"}'
+h2_storage_capacity.type = "number"
+h2_storage_capacity.constraints = [">0"]
+h2_storage_capacity.default = 100.0
+h2_storage_capacity.ui = '{"unit": "h2_storage_capacity_unit", "label": "Max Hydrogen Storage Capacity", "display": "input", "erinUnit": "kJ"}'
+h2_storage_capacity_unit.type = "enum"
+h2_storage_capacity_unit.enum_options = ["kg H2", "J", "kJ", "MJ"]
+h2_storage_capacity_unit.default = "kg H2"
+h2_storage_capacity_unit.ui = '{"display": "unit"}'
+h2_storage_max_charge.type = "number"
+h2_storage_max_charge.constraints = [">0"]
+h2_storage_max_charge.default = 200.0
+h2_storage_max_charge.ui = '{"unit": "h2_storage_rate_unit", "label": "Max Hydrogen Storage Rate", "display": "input", "erinUnit": "kW"}'
+h2_storage_rate_unit.type = "enum"
+h2_storage_rate_unit.enum_options = ["kg H2/h", "W", "kW", "MW"]
+h2_storage_rate_unit.default = "kg H2/h"
+h2_storage_rate_unit.ui = '{"display": "unit"}'
+h2_storage_max_discharge.type = "number"
+h2_storage_max_discharge.constraints = [">0"]
+h2_storage_max_discharge.default = 200.0
+h2_storage_max_discharge.ui = '{"unit": "h2_storage_rate_unit", "label": "Max Hydrogen Discharge Rate", "display": "input", "erinUnit": "kW"}'
+h2_storage_init_soc.type = "frac"
+h2_storage_init_soc.default = 1.0
+h2_storage_init_soc.ui = '{"unit": "h2_storage_capacity_unit", "label": "Initial Hydrogen Capacity", "display": "input", "erinUnit": "kJ"}'
+fuel_cell_max_outflow.type = "number"
+fuel_cell_max_outflow.constraints = [">0"]
+fuel_cell_max_outflow.default = 750.0
+fuel_cell_max_outflow.ui = '{"unit": "fuel_cell_rate_unit", "label": "Max Fuel Cell Output Power", "display": "input", "erinUnit": "kW"}'
+fuel_cell_rate_unit.type = "enum"
+fuel_cell_rate_unit.enum_options = ["W", "kW", "MW"]
+fuel_cell_rate_unit.default = "kW"
+fuel_cell_rate_unit.ui = '{"display": "unit"}'
+fuel_cell_efficiency.type = "[[number number]*]"
+fuel_cell_efficiency.default = [[0.0, 0.6], [1.0, 0.6]]
+fuel_cell_efficiency.ui = '{"yMax": 100, "yMin": 0, "yUnit": "%", "xLabel": "Load Fraction", "yLabel": "Efficiency", "display": "input"}'
+boiler_max_outflow.type = "number"
+boiler_max_outflow.constraints = [">0"]
+boiler_max_outflow.default = 750.0
+boiler_max_outflow.ui = '{"unit": "boiler_max_outflow_unit", "label": "Max Boiler Output Power", "display": "input", "erinUnit": "kW"}'
+boiler_max_outflow_unit.type = "enum"
+boiler_max_outflow_unit.enum_options = ["kW", "W", "MW"]
+boiler_max_outflow_unit.default = "kW"
+boiler_max_outflow_unit.ui = '{"display": "unit"}'
+boiler_efficiency.type = "[[number number]*]"
+boiler_efficiency.default = [[0.0, 0.94], [1.0, 0.94]]
+boiler_efficiency.ui = '{"yMax": 100, "yMin": 0, "yUnit": "%", "xLabel": "Load Fraction", "yLabel": "Efficiency", "display": "input"}'
+
+[[components]]
+id = "electrical_substation"
+type = "mux"
+flow = "electricity"
+num_inflows = 1
+num_outflows = 2
+
+[[components]]
+id = "pem_electrolyzer"
+type = "variable_efficiency_converter"
+efficiency_by_fraction_out.param = "electrolyzer_efficiency"
+inflow = "electricity"
+lossflow = "waste_heat"
+outflow = "hydrogen"
+max_outflow.param = "electrolyzer_max_outflow"
+rate_unit = "kW"
+
+[[components]]
+id = "h2_storage"
+type = "store"
+flow = "hydrogen"
+max_charge.param = "h2_storage_max_charge"
+capacity.param = "h2_storage_capacity"
+capacity_unit = "kJ"
+max_discharge.param = "h2_storage_max_discharge"
+max_outflow.param = "h2_storage_max_discharge"
+charge_at_soc = 0.8
+roundtrip_efficiency = 1.0
+init_soc.param = "h2_storage_init_soc"
+
+[[components]]
+id = "pem_fuel_cell"
+type = "variable_efficiency_converter"
+inflow = "hydrogen"
+outflow = "electricity"
+lossflow = "waste_heat"
+max_outflow.param = "fuel_cell_max_outflow"
+rate_unit = "kW"
+efficiency_by_fraction_out.param = "fuel_cell_efficiency"
+
+[[components]]
+id = "electrical_bus"
+type = "mux"
+num_inflows = 2
+num_outflows = 1
+flow = "electricity"
+
+[[components]]
+id = "h2_ng_boiler"
+type = "variable_efficiency_converter"
+inflow = "h2_ng_blend"
+outflow = "hot_water"
+lossflow = "waste_heat"
+max_outflow.param = "boiler_max_outflow"
+rate_unit = "kW"
+efficiency_by_fraction_out.param = "boiler_efficiency"
+
+[[components]]
+id = "h2_storage_splitter"
+type = "mux"
+flow = "hydrogen"
+num_inflows = 1
+num_outflows = 2
+
+[[components]]
+id = "h2_ng_mixer"
+type = "mux"
+flow = "h2_ng_blend"
+num_inflows = 2
+num_outflows = 1
+
+[[components]]
+id = "blend_input_ng"
+type = "converter"
+inflow = "natural_gas"
+outflow = "h2_ng_blend"
+lossflow = "waste_heat"
+constant_efficiency = 1.0
+
+[[components]]
+id = "blend_input_h2"
+type = "converter"
+inflow = "hydrogen"
+outflow = "h2_ng_blend"
+lossflow = "waste_heat"
+constant_efficiency = 1.0

--- a/templates/templates/pv_wind_and_battery.toml
+++ b/templates/templates/pv_wind_and_battery.toml
@@ -1,0 +1,106 @@
+type = "template"
+name = "pv_wind_and_battery"
+category = "Solar Energy"
+equipment_type_name = "PV Array, Wind Turbines, and Battery"
+description = "A PV array and Wind Turbines with battery storage"
+mean_time_between_failures_in_hours = 87600.0
+mean_time_to_repair_in_hours = 48.0
+first_cost_in_usd_per_size = 10.0
+annual_maintenance_cost_in_usd_per_size = 45.0
+num_inflows = 1
+num_outflows = 1
+connections = [
+  ["pv_array:OUT(0)", "main_electric_bus:IN(0)", "electricity"],
+  ["wind_turbines:OUT(0)", "main_electric_bus:IN(1)", "electricity"],
+  ["<0>", "main_electric_bus:IN(2)", "electricity"],
+  ["main_electric_bus:OUT(0)", "splitter:IN(0)", "electricity"],
+  ["splitter:OUT(0)", "battery:IN(0)", "electricity"],
+  ["splitter:OUT(1)", "electric_bus:IN(0)", "electricity"],
+  ["battery:OUT(0)", "electric_bus:IN(1)", "electricity"],
+  ["electric_bus:OUT(0)", "<0>", "electricity"],
+]
+
+[parameters.required]
+pv_supply_by_scenario.type = "(table string string)"
+pv_supply_by_scenario.ui = '{"display": "input-by-scenario", "label": "PV Supply by Scenario"}'
+wind_supply_by_scenario.type = "(table string string)"
+wind_supply_by_scenario.ui = '{"display": "input-by-scenario", "label": "Wind Supply by Scenario"}'
+
+[parameters.optional]
+battery_capacity.type = "number"
+battery_capacity.constraints = [">0"]
+battery_capacity.default = 500.0
+battery_capacity.ui = '{"unit": "battery_capacity_unit", "label": "Battery Max Capacity", "erinUnit": "kWh", "display": "input"}'
+battery_capacity_unit.type = "enum"
+battery_capacity_unit.enum_options = ["kWh", "J", "kJ", "MJ"]
+battery_capacity_unit.default = "kWh"
+battery_capacity_unit.ui = '{"display": "unit"}'
+battery_max_charge.type = "number"
+battery_max_charge.constraints = [">0"]
+battery_max_charge.default = 100.0
+battery_max_charge.ui = '{"unit": "battery_rate_unit", "label": "Battery Max Charge Rate", "erinUnit": "kW", "display": "input"}'
+battery_max_discharge.type = "number"
+battery_max_discharge.constraints = [">0"]
+battery_max_discharge.default = 100.0
+battery_max_discharge.ui = '{"unit": "battery_rate_unit", "label": "Battery Max Discharge Rate", "erinUnit": "kW", "display": "input"}'
+battery_rate_unit.type = "enum"
+battery_rate_unit.enum_options = ["W", "kW", "MW"]
+battery_rate_unit.default = "kW"
+battery_rate_unit.ui = '{"display": "unit"}'
+battery_soc_to_start_charging.type = "frac"
+battery_soc_to_start_charging.constraints = ["<1"]
+battery_soc_to_start_charging.default = 0.8
+battery_soc_to_start_charging.ui = '{"label": "SOC to Initiate Charging", "display": "input"}'
+battery_roundtrip_efficiency.type = "frac"
+battery_roundtrip_efficiency.default = 0.9
+battery_roundtrip_efficiency.ui = '{"label": "Roundtrip Efficiency", "display": "input"}'
+battery_init_soc.type = "frac"
+battery_init_soc.default = 1.0
+battery_init_soc.ui = '{"label": "Initial SOC", "display": "input"}'
+
+[[components]]
+id = "pv_array"
+type = "uncontrolled_source"
+outflow = "electricity"
+supply_by_scenario.param = "pv_supply_by_scenario"
+
+[[components]]
+id = "wind_turbines"
+type = "uncontrolled_source"
+outflow = "electricity"
+supply_by_scenario.param = "wind_supply_by_scenario"
+
+[[components]]
+id = "main_electric_bus"
+type = "mux"
+flow = "electricity"
+num_inflows = 3
+num_outflows = 1
+
+[[components]]
+id = "splitter"
+type = "mux"
+flow = "electricity"
+num_inflows = 1
+num_outflows = 2
+
+[[components]]
+id = "battery"
+type = "store"
+flow = "electricity"
+max_charge = 100
+capacity.param = "battery_capacity"
+capacity_unit = "kWh"
+max_discharge.param = "battery_max_discharge"
+max_outflow.param = "battery_max_discharge"
+charge_at_soc.param = "battery_soc_to_start_charging"
+roundtrip_efficiency.param = "battery_roundtrip_efficiency"
+init_soc.param = "battery_init_soc"
+
+[[components]]
+id = "electric_bus"
+type = "mux"
+num_inflows = 2
+num_outflows = 1
+flow = "electricity"
+


### PR DESCRIPTION
## Description

ERIN was causing a seg fault when fed an empty load profile via packed loads for an uncontrolled source. This specifically fixes the issue for that component. More such issues may exist. A more comprehensive check should be made as having an empty load profile should at least result in a warning...